### PR TITLE
feat: Sprint 1 #3 — git layer (protected-branch + branch/commit + dirty-tree)

### DIFF
--- a/src/git/branch.ts
+++ b/src/git/branch.ts
@@ -1,0 +1,104 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { spawnSync } from "node:child_process";
+
+import { GitLayerUsageError, ProtectedBranchError } from "./errors.ts";
+import { isProtected, type UserConfig } from "./protected.ts";
+
+export const SPEC_BRANCH_PREFIX = "samospec/";
+
+export interface CreateSpecBranchOpts {
+  readonly repoPath?: string;
+  readonly userConfig?: UserConfig;
+}
+
+/**
+ * Slug grammar for `samospec/<slug>`. Keep deliberately strict:
+ *   - non-empty
+ *   - lowercase letters, digits, and `-` only
+ *   - may not start or end with `-`
+ *
+ * Slashes and whitespace are rejected to ensure a 1:1 mapping between slug
+ * and branch (no nested `samospec/foo/bar` branches in v1).
+ */
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Creates the `samospec/<slug>` spec branch off the CURRENT branch and checks
+ * it out. Refuses when the current branch is protected (any source from
+ * {@link isProtected}). Refuses when the target branch already exists.
+ *
+ * Throws {@link ProtectedBranchError} on protected-branch violations
+ * (exitCode 2, SPEC §8) and {@link GitLayerUsageError} on slug / uniqueness
+ * violations.
+ *
+ * Returns the fully-qualified branch name on success.
+ */
+export function createSpecBranch(
+  slug: string,
+  opts: CreateSpecBranchOpts = {},
+): string {
+  assertValidSlug(slug);
+
+  const current = currentBranch(opts.repoPath);
+  if (isProtected(current, opts)) {
+    throw new ProtectedBranchError(current);
+  }
+
+  const target = `${SPEC_BRANCH_PREFIX}${slug}`;
+  if (branchExists(target, opts.repoPath)) {
+    throw new GitLayerUsageError(
+      `Branch '${target}' already exists. Choose a different slug or ` +
+        `remove the existing branch first.`,
+    );
+  }
+
+  runGit(["checkout", "-b", target], opts.repoPath);
+  return target;
+}
+
+function assertValidSlug(slug: string): void {
+  if (slug.length === 0) {
+    throw new GitLayerUsageError("slug must be non-empty");
+  }
+  if (!SLUG_RE.test(slug)) {
+    throw new GitLayerUsageError(
+      `slug '${slug}' is invalid. Use lowercase letters, digits, and '-' ` +
+        `(no leading/trailing '-', no slashes, no spaces).`,
+    );
+  }
+}
+
+export function currentBranch(repoPath: string | undefined): string {
+  return runGit(["rev-parse", "--abbrev-ref", "HEAD"], repoPath).stdout.trim();
+}
+
+export function branchExists(
+  branchName: string,
+  repoPath: string | undefined,
+): boolean {
+  const result = spawnSync(
+    "git",
+    ["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`],
+    { cwd: repoPath, encoding: "utf8" },
+  );
+  return result.status === 0;
+}
+
+function runGit(
+  args: readonly string[],
+  repoPath: string | undefined,
+): { readonly stdout: string; readonly stderr: string } {
+  const result = spawnSync("git", args as string[], {
+    cwd: repoPath,
+    encoding: "utf8",
+  });
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed with status ${String(result.status)}: ${
+        result.stderr ?? ""
+      }`,
+    );
+  }
+  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}

--- a/src/git/commit.ts
+++ b/src/git/commit.ts
@@ -1,0 +1,138 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { spawnSync } from "node:child_process";
+
+import { currentBranch } from "./branch.ts";
+import { GitLayerUsageError, ProtectedBranchError } from "./errors.ts";
+import { isProtected, type UserConfig } from "./protected.ts";
+
+/**
+ * Commit actions from SPEC §8 + §6. `user-edit` is the changelog slug used
+ * when the user hand-edits SPEC.md between rounds. `changelog` covers the
+ * version-bump-only side commits.
+ */
+export const COMMIT_ACTIONS = [
+  "draft",
+  "refine",
+  "publish",
+  "user-edit",
+  "changelog",
+] as const;
+export type CommitAction = (typeof COMMIT_ACTIONS)[number];
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+// Version: N.N[.N] or similar dotted numerics — "0.1", "1.0", "0.3.1".
+const VERSION_RE = /^\d+(?:\.\d+)*$/;
+
+export interface BuildCommitMessageArgs {
+  readonly slug: string;
+  readonly action: CommitAction;
+  readonly version: string;
+  /**
+   * For `refine` actions only. When set, the message becomes
+   * `spec(<slug>): refine v<version> after review r<roundNumber>`.
+   */
+  readonly roundNumber?: number;
+}
+
+/**
+ * Builds the SPEC §8 commit message:
+ *   - `spec(<slug>): <action> v<version>`
+ *   - `spec(<slug>): refine v<version> after review r<n>` when roundNumber set.
+ *
+ * Throws {@link GitLayerUsageError} on any grammar violation. Callers pass
+ * raw components; only this helper is allowed to format the message — no
+ * ad-hoc string interpolation elsewhere.
+ */
+export function buildCommitMessage(args: BuildCommitMessageArgs): string {
+  if (!SLUG_RE.test(args.slug)) {
+    throw new GitLayerUsageError(
+      `slug '${args.slug}' is invalid. Use lowercase letters, digits, ` +
+        `and '-' (no leading/trailing '-').`,
+    );
+  }
+  if (!COMMIT_ACTIONS.includes(args.action)) {
+    throw new GitLayerUsageError(
+      `action '${String(args.action)}' is not in the grammar. Known ` +
+        `actions: ${COMMIT_ACTIONS.join(", ")}.`,
+    );
+  }
+  if (!VERSION_RE.test(args.version)) {
+    throw new GitLayerUsageError(
+      `version '${args.version}' is invalid. Expected dotted numerics ` +
+        `(e.g. '0.1', '1.0', '0.3.1'). Leading 'v' is added by the ` +
+        `message template — do not pass it in.`,
+    );
+  }
+  if (args.roundNumber !== undefined) {
+    if (!Number.isInteger(args.roundNumber) || args.roundNumber < 0) {
+      throw new GitLayerUsageError(
+        `roundNumber '${String(args.roundNumber)}' must be a non-negative ` +
+          `integer.`,
+      );
+    }
+    return `spec(${args.slug}): ${args.action} v${args.version} after review r${String(
+      args.roundNumber,
+    )}`;
+  }
+  return `spec(${args.slug}): ${args.action} v${args.version}`;
+}
+
+export interface SpecCommitArgs extends BuildCommitMessageArgs {
+  readonly repoPath: string;
+  readonly paths: readonly string[];
+  readonly userConfig?: UserConfig;
+}
+
+/**
+ * Stages the given paths (explicit list — never `add -A`) and creates a
+ * commit with the SPEC §8 message. Refuses with exitCode 2 if the current
+ * branch is protected.
+ *
+ * Deliberate constraints:
+ *   - No `--force`, no `+refspec`, no `--no-verify`, no `--amend`. Anywhere.
+ *     The safety test in `tests/git/no-force.test.ts` greps the built source
+ *     to catch regressions.
+ */
+export function specCommit(args: SpecCommitArgs): void {
+  if (args.paths.length === 0) {
+    throw new GitLayerUsageError(
+      "specCommit requires a non-empty 'paths' array. Use an explicit list " +
+        "(no 'add -A' anywhere in the git layer).",
+    );
+  }
+
+  const branch = currentBranch(args.repoPath);
+  if (
+    isProtected(branch, {
+      repoPath: args.repoPath,
+      ...(args.userConfig ? { userConfig: args.userConfig } : {}),
+    })
+  ) {
+    throw new ProtectedBranchError(branch);
+  }
+
+  // Build the message FIRST — validates grammar before touching the index.
+  const message = buildCommitMessage(args);
+
+  runGitOrThrow(["add", "--", ...args.paths], args.repoPath);
+  runGitOrThrow(["commit", "-m", message], args.repoPath);
+}
+
+function runGitOrThrow(
+  gitArgs: readonly string[],
+  repoPath: string,
+): { readonly stdout: string; readonly stderr: string } {
+  const result = spawnSync("git", gitArgs as string[], {
+    cwd: repoPath,
+    encoding: "utf8",
+  });
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(
+      `git ${gitArgs.join(" ")} failed with status ${String(result.status)}: ${
+        result.stderr ?? ""
+      }`,
+    );
+  }
+  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}

--- a/src/git/dirty.ts
+++ b/src/git/dirty.ts
@@ -1,0 +1,158 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { spawnSync } from "node:child_process";
+
+export const AUTO_STASH_MESSAGE = "samospec: auto-stash before spec";
+
+export interface DirtyTreeSnapshot {
+  readonly dirty: boolean;
+  /** Tracked files with any unstaged/staged modification. */
+  readonly tracked: readonly string[];
+  /** Untracked-but-not-ignored files. */
+  readonly untracked: readonly string[];
+}
+
+export interface DetectDirtyTreeOpts {
+  readonly repoPath: string;
+}
+
+/**
+ * Snapshot the working tree dirtiness via `git status --porcelain=v1`.
+ *
+ * - Tracked entries: any code other than `??` / space-space contributes to
+ *   `tracked`. (Modified, added, deleted, renamed, copied, unmerged.)
+ * - Untracked entries (`??`) go to `untracked`.
+ * - Ignored files (`!!`) are not surfaced — they never block a spec.
+ */
+export function detectDirtyTree(opts: DetectDirtyTreeOpts): DirtyTreeSnapshot {
+  const result = spawnSync(
+    "git",
+    ["status", "--porcelain=v1", "--untracked-files=normal"],
+    { cwd: opts.repoPath, encoding: "utf8" },
+  );
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(
+      `git status failed with status ${String(result.status)}: ${
+        result.stderr ?? ""
+      }`,
+    );
+  }
+
+  const tracked: string[] = [];
+  const untracked: string[] = [];
+
+  const raw = result.stdout ?? "";
+  for (const rawLine of raw.split("\n")) {
+    if (rawLine.length === 0) continue;
+    // Porcelain v1 line: 'XY path' where XY is 2 chars.
+    const code = rawLine.slice(0, 2);
+    const path = rawLine.slice(3);
+    if (code === "??") {
+      untracked.push(path);
+    } else if (code !== "!!") {
+      tracked.push(path);
+    }
+  }
+
+  return {
+    dirty: tracked.length > 0 || untracked.length > 0,
+    tracked,
+    untracked,
+  };
+}
+
+/**
+ * Prompt mode:
+ *   - `engineer` (default CLI mode): user gets three options.
+ *   - `guided` (via --explain): halt by default, never auto-stash.
+ */
+export type DirtyMode = "engineer" | "guided";
+
+export type DirtyChoice = "stash-continue" | "continue-anyway" | "abort";
+
+export interface DirtyDecision {
+  readonly outcome:
+    | "proceed"
+    | "stash-then-proceed"
+    | "abort"
+    | "halt"
+    | "prompt";
+  readonly allowedChoices?: readonly DirtyChoice[];
+  readonly defaultChoice?: DirtyChoice;
+}
+
+export interface DecideDirtyTreeOpts {
+  readonly mode: DirtyMode;
+  /**
+   * When the caller has already resolved the engineer-mode prompt (from the
+   * UI layer), pass the choice here. Without it, the decision is `prompt`.
+   * The *prompt* itself is UI — not this module's concern — but the decision
+   * handlers live here so they're testable without a TTY.
+   */
+  readonly engineerChoice?: DirtyChoice;
+}
+
+/**
+ * Pure function: given a dirty-tree snapshot and the caller's mode/choice,
+ * returns the next action. No side effects.
+ *
+ * Matrix (per SPEC §8):
+ *
+ *   clean tree        -> proceed
+ *   guided mode       -> halt (ignore any engineerChoice)
+ *   engineer mode, no choice provided yet -> prompt
+ *   engineer + stash-continue   -> stash-then-proceed
+ *   engineer + continue-anyway  -> proceed
+ *   engineer + abort            -> abort
+ */
+export function decideDirtyTree(
+  snap: DirtyTreeSnapshot,
+  opts: DecideDirtyTreeOpts,
+): DirtyDecision {
+  if (!snap.dirty) return { outcome: "proceed" };
+
+  if (opts.mode === "guided") return { outcome: "halt" };
+
+  // engineer mode.
+  if (opts.engineerChoice === undefined) {
+    return {
+      outcome: "prompt",
+      allowedChoices: ["stash-continue", "continue-anyway", "abort"],
+      defaultChoice: "stash-continue",
+    };
+  }
+
+  switch (opts.engineerChoice) {
+    case "stash-continue":
+      return { outcome: "stash-then-proceed" };
+    case "continue-anyway":
+      return { outcome: "proceed" };
+    case "abort":
+      return { outcome: "abort" };
+  }
+}
+
+export interface AutoStashOpts {
+  readonly repoPath: string;
+}
+
+/**
+ * SPEC §8: `git stash push -u -m "samospec: auto-stash before spec"`.
+ *
+ * `-u` preserves untracked files. We never use `--force` / `+refspec` /
+ * `--no-verify` / `--amend` anywhere in this helper.
+ */
+export function autoStash(opts: AutoStashOpts): void {
+  const result = spawnSync(
+    "git",
+    ["stash", "push", "-u", "-m", AUTO_STASH_MESSAGE],
+    { cwd: opts.repoPath, encoding: "utf8" },
+  );
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(
+      `git stash push failed with status ${String(result.status)}: ${
+        result.stderr ?? ""
+      }`,
+    );
+  }
+}

--- a/src/git/errors.ts
+++ b/src/git/errors.ts
@@ -1,0 +1,35 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Error thrown by the git layer whenever it refuses an operation that would
+ * land on a protected branch. The exit code is `2` per SPEC §8 (branch/commit
+ * refusal matches the "lock contention" / "unsafe state" family).
+ */
+export class ProtectedBranchError extends Error {
+  public readonly exitCode = 2;
+  public readonly branchName: string;
+
+  public constructor(branchName: string, message?: string) {
+    super(
+      message ??
+        `Refusing to operate on protected branch '${branchName}'. ` +
+          `Create a feature branch first, or override the protection ` +
+          `via git config or '.samospec/config.json'.`,
+    );
+    this.name = "ProtectedBranchError";
+    this.branchName = branchName;
+  }
+}
+
+/**
+ * Error thrown when a slug, config value, or branch-name argument violates
+ * the grammar or uniqueness contract. Not a safety failure — exit code 1.
+ */
+export class GitLayerUsageError extends Error {
+  public readonly exitCode = 1;
+
+  public constructor(message: string) {
+    super(message);
+    this.name = "GitLayerUsageError";
+  }
+}

--- a/src/git/protected.ts
+++ b/src/git/protected.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { spawnSync } from "node:child_process";
+
+/**
+ * Hardcoded protected-branch list. SPEC §5 Phase 1.
+ * Extensible only by adding to this file — the user config
+ * `git.protected_branches` layers on top (additive, never subtractive).
+ */
+export const HARDCODED_PROTECTED_BRANCHES: readonly string[] = [
+  "main",
+  "master",
+  "develop",
+  "trunk",
+];
+
+export interface UserConfig {
+  readonly git?: {
+    readonly protected_branches?: readonly string[];
+  };
+}
+
+export interface IsProtectedOpts {
+  /**
+   * Absolute path to the git working tree. When absent, `git config` is read
+   * using the process working directory. Tests always set this explicitly.
+   */
+  readonly repoPath?: string;
+  /**
+   * Parsed `.samospec/config.json` contents (or any object shape subset).
+   * The `git.protected_branches` array is additive.
+   */
+  readonly userConfig?: UserConfig;
+}
+
+/**
+ * Returns true if the given branch name should be treated as protected.
+ *
+ * Combines three local sources with OR (per SPEC §5 Phase 1, bullet "Local
+ * sources"):
+ *   1. Hardcoded list ({@link HARDCODED_PROTECTED_BRANCHES}).
+ *   2. `git config branch.<name>.protected` truthy.
+ *   3. User config `git.protected_branches` array membership.
+ *
+ * Remote API probe is deliberately NOT consulted here. SPEC §14 keeps
+ * `git.remote_probe` off by default to avoid audit-log entries. Local checks
+ * are "sufficient for safety" per SPEC §5 Phase 1.
+ *
+ * Per SPEC §8 / §13 test 2: a `false` value in the git config NEVER weakens
+ * a hardcoded or user-config protection. The three sources combine additively.
+ */
+export function isProtected(
+  branchName: string,
+  opts: IsProtectedOpts = {},
+): boolean {
+  if (HARDCODED_PROTECTED_BRANCHES.includes(branchName)) return true;
+
+  const userList = opts.userConfig?.git?.protected_branches ?? [];
+  if (userList.includes(branchName)) return true;
+
+  if (readGitConfigBranchProtected(branchName, opts.repoPath)) return true;
+
+  return false;
+}
+
+function readGitConfigBranchProtected(
+  branchName: string,
+  repoPath: string | undefined,
+): boolean {
+  // `git config --get` exits 1 when the key is absent — that's the common case.
+  const args = ["config", "--get", `branch.${branchName}.protected`];
+  const result = spawnSync("git", args, {
+    cwd: repoPath,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) return false;
+  const value = (result.stdout ?? "").trim().toLowerCase();
+  return value === "true" || value === "1" || value === "yes" || value === "on";
+}

--- a/tests/git/branch.test.ts
+++ b/tests/git/branch.test.ts
@@ -1,0 +1,126 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { createSpecBranch } from "../../src/git/branch.ts";
+import { createTempRepo, type TempRepo } from "./helpers/tempRepo.ts";
+
+describe("createSpecBranch — happy paths", () => {
+  let repo: TempRepo;
+  beforeEach(() => {
+    repo = createTempRepo({ initialBranch: "feature-x" });
+  });
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  test("creates samospec/<slug> off the current non-protected branch and checks it out", () => {
+    createSpecBranch("refunds", { repoPath: repo.dir });
+    expect(repo.currentBranch()).toBe("samospec/refunds");
+    expect(repo.listBranches()).toContain("samospec/refunds");
+    expect(repo.listBranches()).toContain("feature-x");
+  });
+
+  test("branches from the CURRENT branch, not from main/master by default", () => {
+    // Sit on a side branch with a distinct commit so parentage is verifiable.
+    repo.write("x.txt", "x\n");
+    repo.run(["add", "x.txt"]);
+    repo.run(["commit", "-m", "chore: add x on feature-x"]);
+    const featureSha = repo.git("rev-parse", "HEAD");
+
+    createSpecBranch("promo", { repoPath: repo.dir });
+    const specSha = repo.git("rev-parse", "HEAD");
+    expect(specSha).toBe(featureSha);
+  });
+});
+
+describe("createSpecBranch — refuses on protected branches", () => {
+  let repo: TempRepo;
+  beforeEach(() => {
+    repo = createTempRepo({ initialBranch: "main" });
+  });
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  test("throws a protected-branch error when current branch is hardcoded-protected", () => {
+    expect(() =>
+      createSpecBranch("refunds", { repoPath: repo.dir }),
+    ).toThrowError(/protected/i);
+  });
+
+  test("the thrown error exposes exitCode 2 per SPEC §8", () => {
+    let caught: unknown;
+    try {
+      createSpecBranch("refunds", { repoPath: repo.dir });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(
+      (caught as { readonly exitCode?: unknown }).exitCode,
+    ).toBe(2);
+  });
+
+  test("does not create the spec branch when the current branch is protected", () => {
+    try {
+      createSpecBranch("refunds", { repoPath: repo.dir });
+    } catch {
+      /* expected */
+    }
+    expect(repo.listBranches()).not.toContain("samospec/refunds");
+    // still on main
+    expect(repo.currentBranch()).toBe("main");
+  });
+
+  test("also refuses when current branch is protected only via user config", () => {
+    repo.run(["checkout", "-b", "staging"]);
+    expect(() =>
+      createSpecBranch("hotfix", {
+        repoPath: repo.dir,
+        userConfig: { git: { protected_branches: ["staging"] } },
+      }),
+    ).toThrowError(/protected/i);
+  });
+
+  test("also refuses when current branch is protected only via git config", () => {
+    repo.run(["checkout", "-b", "release/1"]);
+    repo.run(["config", "branch.release/1.protected", "true"]);
+    expect(() =>
+      createSpecBranch("hotfix", { repoPath: repo.dir }),
+    ).toThrowError(/protected/i);
+  });
+});
+
+describe("createSpecBranch — slug validation and idempotency", () => {
+  let repo: TempRepo;
+  beforeEach(() => {
+    repo = createTempRepo({ initialBranch: "feature-x" });
+  });
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  test("rejects an empty slug", () => {
+    expect(() => createSpecBranch("", { repoPath: repo.dir })).toThrowError(
+      /slug/i,
+    );
+  });
+
+  test("rejects a slug containing whitespace or slashes", () => {
+    expect(() =>
+      createSpecBranch("bad slug", { repoPath: repo.dir }),
+    ).toThrowError(/slug/i);
+    expect(() =>
+      createSpecBranch("a/b", { repoPath: repo.dir }),
+    ).toThrowError(/slug/i);
+  });
+
+  test("rejects re-creating an existing samospec/<slug> branch", () => {
+    createSpecBranch("refunds", { repoPath: repo.dir });
+    repo.run(["checkout", "feature-x"]);
+    expect(() =>
+      createSpecBranch("refunds", { repoPath: repo.dir }),
+    ).toThrowError(/already exists/i);
+  });
+});

--- a/tests/git/branch.test.ts
+++ b/tests/git/branch.test.ts
@@ -57,9 +57,7 @@ describe("createSpecBranch — refuses on protected branches", () => {
       caught = err;
     }
     expect(caught).toBeDefined();
-    expect(
-      (caught as { readonly exitCode?: unknown }).exitCode,
-    ).toBe(2);
+    expect((caught as { readonly exitCode?: unknown }).exitCode).toBe(2);
   });
 
   test("does not create the spec branch when the current branch is protected", () => {
@@ -111,9 +109,9 @@ describe("createSpecBranch — slug validation and idempotency", () => {
     expect(() =>
       createSpecBranch("bad slug", { repoPath: repo.dir }),
     ).toThrowError(/slug/i);
-    expect(() =>
-      createSpecBranch("a/b", { repoPath: repo.dir }),
-    ).toThrowError(/slug/i);
+    expect(() => createSpecBranch("a/b", { repoPath: repo.dir })).toThrowError(
+      /slug/i,
+    );
   });
 
   test("rejects re-creating an existing samospec/<slug> branch", () => {

--- a/tests/git/commit.test.ts
+++ b/tests/git/commit.test.ts
@@ -1,0 +1,179 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  buildCommitMessage,
+  specCommit,
+  type CommitAction,
+} from "../../src/git/commit.ts";
+import { createTempRepo, type TempRepo } from "./helpers/tempRepo.ts";
+
+describe("buildCommitMessage — grammar", () => {
+  test("renders 'spec(<slug>): <action> v<version>' for a draft", () => {
+    expect(
+      buildCommitMessage({ slug: "refunds", action: "draft", version: "0.1" }),
+    ).toBe("spec(refunds): draft v0.1");
+  });
+
+  test("renders a refine-with-round message", () => {
+    expect(
+      buildCommitMessage({
+        slug: "refunds",
+        action: "refine",
+        version: "0.3",
+        roundNumber: 2,
+      }),
+    ).toBe("spec(refunds): refine v0.3 after review r2");
+  });
+
+  test("supports the 'publish' action", () => {
+    expect(
+      buildCommitMessage({
+        slug: "payments",
+        action: "publish",
+        version: "1.0",
+      }),
+    ).toBe("spec(payments): publish v1.0");
+  });
+
+  test("rejects an invalid slug", () => {
+    expect(() =>
+      buildCommitMessage({
+        slug: "Bad Slug",
+        action: "draft",
+        version: "0.1",
+      }),
+    ).toThrowError(/slug/i);
+  });
+
+  test("rejects an invalid version", () => {
+    expect(() =>
+      buildCommitMessage({
+        slug: "refunds",
+        action: "draft",
+        version: "v0.1",
+      }),
+    ).toThrowError(/version/i);
+    expect(() =>
+      buildCommitMessage({
+        slug: "refunds",
+        action: "draft",
+        version: "",
+      }),
+    ).toThrowError(/version/i);
+  });
+
+  test("rejects an action not in the grammar", () => {
+    expect(() =>
+      buildCommitMessage({
+        slug: "refunds",
+        // @ts-expect-error — runtime check
+        action: "YOLO",
+        version: "0.1",
+      }),
+    ).toThrowError(/action/i);
+  });
+
+  test("rejects negative or non-integer roundNumber", () => {
+    expect(() =>
+      buildCommitMessage({
+        slug: "refunds",
+        action: "refine",
+        version: "0.2",
+        roundNumber: -1,
+      }),
+    ).toThrowError(/round/i);
+    expect(() =>
+      buildCommitMessage({
+        slug: "refunds",
+        action: "refine",
+        version: "0.2",
+        roundNumber: 1.5,
+      }),
+    ).toThrowError(/round/i);
+  });
+
+  test("exposes the list of known actions", () => {
+    const actions: readonly CommitAction[] = [
+      "draft",
+      "refine",
+      "publish",
+      "user-edit",
+      "changelog",
+    ];
+    for (const action of actions) {
+      const msg = buildCommitMessage({
+        slug: "refunds",
+        action,
+        version: "0.1",
+      });
+      expect(msg).toContain(action);
+    }
+  });
+});
+
+describe("specCommit — integration on a real repo", () => {
+  let repo: TempRepo;
+  beforeEach(() => {
+    repo = createTempRepo({ initialBranch: "samospec/refunds" });
+  });
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  test("writes a commit on the spec branch with the correct message", () => {
+    repo.write("SPEC.md", "# Refunds v0.1\n");
+    specCommit({
+      repoPath: repo.dir,
+      slug: "refunds",
+      action: "draft",
+      version: "0.1",
+      paths: ["SPEC.md"],
+    });
+    const messages = repo.logOnBranch("samospec/refunds");
+    expect(messages[0]).toBe("spec(refunds): draft v0.1");
+  });
+
+  test("refuses to commit when the current branch is protected", () => {
+    // Create a new repo rooted on main.
+    const main = createTempRepo({ initialBranch: "main" });
+    try {
+      main.write("SPEC.md", "# x\n");
+      expect(() =>
+        specCommit({
+          repoPath: main.dir,
+          slug: "refunds",
+          action: "draft",
+          version: "0.1",
+          paths: ["SPEC.md"],
+        }),
+      ).toThrowError(/protected/i);
+
+      // And no commit landed on main.
+      const before = main.logOnBranch("main");
+      expect(before.length).toBe(1); // only the initial chore commit
+    } finally {
+      main.cleanup();
+    }
+  });
+
+  test("stages only the paths it's asked to stage (no 'add -A')", () => {
+    repo.write("SPEC.md", "# Refunds v0.1\n");
+    repo.write("unrelated.txt", "nope\n");
+    specCommit({
+      repoPath: repo.dir,
+      slug: "refunds",
+      action: "draft",
+      version: "0.1",
+      paths: ["SPEC.md"],
+    });
+    const show = repo
+      .run(["show", "--name-only", "--format=", "HEAD"])
+      .stdout.split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    expect(show).toContain("SPEC.md");
+    expect(show).not.toContain("unrelated.txt");
+  });
+});

--- a/tests/git/dirty.test.ts
+++ b/tests/git/dirty.test.ts
@@ -1,0 +1,151 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  AUTO_STASH_MESSAGE,
+  autoStash,
+  decideDirtyTree,
+  detectDirtyTree,
+  type DirtyChoice,
+  type DirtyDecision,
+  type DirtyTreeSnapshot,
+} from "../../src/git/dirty.ts";
+import { createTempRepo, type TempRepo } from "./helpers/tempRepo.ts";
+
+describe("detectDirtyTree", () => {
+  let repo: TempRepo;
+  beforeEach(() => {
+    repo = createTempRepo({ initialBranch: "samospec/refunds" });
+  });
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  test("returns a clean snapshot on a fresh repo", () => {
+    const snap = detectDirtyTree({ repoPath: repo.dir });
+    expect(snap.dirty).toBe(false);
+    expect(snap.tracked).toEqual([]);
+    expect(snap.untracked).toEqual([]);
+  });
+
+  test("detects a modified tracked file", () => {
+    repo.write("README.md", "# Modified\n");
+    const snap = detectDirtyTree({ repoPath: repo.dir });
+    expect(snap.dirty).toBe(true);
+    expect(snap.tracked).toContain("README.md");
+    expect(snap.untracked).toEqual([]);
+  });
+
+  test("detects a new untracked file", () => {
+    repo.write("newfile.txt", "hi\n");
+    const snap = detectDirtyTree({ repoPath: repo.dir });
+    expect(snap.dirty).toBe(true);
+    expect(snap.untracked).toContain("newfile.txt");
+    expect(snap.tracked).toEqual([]);
+  });
+});
+
+describe("decideDirtyTree — engineer mode (default)", () => {
+  const dirty: DirtyTreeSnapshot = {
+    dirty: true,
+    tracked: ["SPEC.md"],
+    untracked: [],
+  };
+  const clean: DirtyTreeSnapshot = { dirty: false, tracked: [], untracked: [] };
+
+  test("returns 'proceed' when the tree is clean regardless of mode", () => {
+    const decision = decideDirtyTree(clean, { mode: "engineer" });
+    expect(decision.outcome).toBe("proceed");
+  });
+
+  test("requires a prompt when dirty in engineer mode", () => {
+    const decision = decideDirtyTree(dirty, { mode: "engineer" });
+    expect(decision.outcome).toBe("prompt");
+    expect(decision.allowedChoices).toEqual([
+      "stash-continue",
+      "continue-anyway",
+      "abort",
+    ]);
+    expect(decision.defaultChoice).toBe("stash-continue");
+  });
+
+  test.each([
+    ["stash-continue", "stash-then-proceed"],
+    ["continue-anyway", "proceed"],
+    ["abort", "abort"],
+  ] satisfies readonly (readonly [DirtyChoice, DirtyDecision["outcome"]])[])(
+    "resolves engineer-mode choice %s to %s",
+    (choice, expected) => {
+      const decision = decideDirtyTree(dirty, {
+        mode: "engineer",
+        engineerChoice: choice,
+      });
+      expect(decision.outcome).toBe(expected);
+    },
+  );
+});
+
+describe("decideDirtyTree — guided mode", () => {
+  const dirty: DirtyTreeSnapshot = {
+    dirty: true,
+    tracked: ["SPEC.md"],
+    untracked: [],
+  };
+
+  test("halts by default on any dirtiness per SPEC §8", () => {
+    const decision = decideDirtyTree(dirty, { mode: "guided" });
+    expect(decision.outcome).toBe("halt");
+  });
+
+  test("ignores any engineerChoice passed in guided mode", () => {
+    const decision = decideDirtyTree(dirty, {
+      mode: "guided",
+      engineerChoice: "continue-anyway",
+    });
+    expect(decision.outcome).toBe("halt");
+  });
+});
+
+describe("autoStash", () => {
+  let repo: TempRepo;
+  beforeEach(() => {
+    repo = createTempRepo({ initialBranch: "samospec/refunds" });
+  });
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  test("uses 'git stash push -u' with the samospec marker message", () => {
+    repo.write("SPEC.md", "work in progress\n");
+    repo.write("untracked.txt", "hello\n");
+
+    autoStash({ repoPath: repo.dir });
+
+    // Tree should be clean now.
+    const snap = detectDirtyTree({ repoPath: repo.dir });
+    expect(snap.dirty).toBe(false);
+
+    // Stash list must show our message.
+    const stashMessages = repo
+      .run(["stash", "list", "--format=%s"])
+      .stdout.trim();
+    expect(stashMessages).toContain(AUTO_STASH_MESSAGE);
+  });
+
+  test("preserves untracked files via -u (they come back on pop)", () => {
+    repo.write("untracked.txt", "hello\n");
+    autoStash({ repoPath: repo.dir });
+    // Untracked file should be in the stash, not on disk.
+    const stashContents = repo
+      .run(["stash", "show", "--include-untracked", "--name-only", "stash@{0}"])
+      .stdout.split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    expect(stashContents).toContain("untracked.txt");
+  });
+
+  test("exports AUTO_STASH_MESSAGE matching SPEC §8 verbatim", () => {
+    expect(AUTO_STASH_MESSAGE).toBe("samospec: auto-stash before spec");
+  });
+});

--- a/tests/git/helpers/tempRepo.ts
+++ b/tests/git/helpers/tempRepo.ts
@@ -1,0 +1,104 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+export interface TempRepo {
+  readonly dir: string;
+  readonly run: (
+    args: readonly string[],
+    opts?: { readonly cwd?: string; readonly allowFail?: boolean },
+  ) => { stdout: string; stderr: string; status: number };
+  readonly git: (...args: string[]) => string;
+  readonly cleanup: () => void;
+  readonly write: (relPath: string, contents: string) => void;
+  readonly currentBranch: () => string;
+  readonly listBranches: () => string[];
+  readonly logOnBranch: (branch: string) => string[];
+}
+
+export function createTempRepo(
+  options: { readonly initialBranch?: string } = {},
+): TempRepo {
+  const initialBranch = options.initialBranch ?? "main";
+  const dir = mkdtempSync(join(tmpdir(), "samospec-git-test-"));
+
+  const run: TempRepo["run"] = (args, opts) => {
+    const cwd = opts?.cwd ?? dir;
+    const result = spawnSync("git", args as string[], {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "Samospec Test",
+        GIT_AUTHOR_EMAIL: "test@example.invalid",
+        GIT_COMMITTER_NAME: "Samospec Test",
+        GIT_COMMITTER_EMAIL: "test@example.invalid",
+      },
+    });
+    if ((result.status ?? 1) !== 0 && !opts?.allowFail) {
+      throw new Error(
+        `git ${args.join(" ")} failed with status ${String(result.status)}: ${
+          result.stderr
+        }`,
+      );
+    }
+    return {
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      status: result.status ?? 0,
+    };
+  };
+
+  const git: TempRepo["git"] = (...args) => {
+    return run(args).stdout.trim();
+  };
+
+  // Initialize repo.
+  run(["init", "--initial-branch", initialBranch, dir], { cwd: tmpdir() });
+  run(["config", "user.name", "Samospec Test"]);
+  run(["config", "user.email", "test@example.invalid"]);
+  run(["config", "commit.gpgsign", "false"]);
+  writeFileSync(join(dir, "README.md"), "# Temp repo\n");
+  run(["add", "README.md"]);
+  run(["commit", "-m", "chore: initial"]);
+
+  const write: TempRepo["write"] = (relPath, contents) => {
+    const full = join(dir, relPath);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, contents);
+  };
+
+  const currentBranch = () => git("rev-parse", "--abbrev-ref", "HEAD");
+  const listBranches = () =>
+    run(["branch", "--list", "--format=%(refname:short)"])
+      .stdout.split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+
+  const logOnBranch = (branch: string) => {
+    const result = run(["log", "--format=%s", branch], { allowFail: true });
+    if (result.status !== 0) return [];
+    return result.stdout
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  };
+
+  const cleanup = () => {
+    rmSync(dir, { recursive: true, force: true });
+  };
+
+  return {
+    dir,
+    run,
+    git,
+    cleanup,
+    write,
+    currentBranch,
+    listBranches,
+    logOnBranch,
+  };
+}

--- a/tests/git/no-force.test.ts
+++ b/tests/git/no-force.test.ts
@@ -1,0 +1,77 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Regression guard. The git layer must NEVER invoke dangerous git flags:
+ *   --force  / -f on push / --force-with-lease
+ *   +refspec (the leading-plus force-push syntax)
+ *   --no-verify (skips commit hooks)
+ *   --amend (mutates the prior commit)
+ *
+ * This test greps all git-layer sources for those literal tokens. Any hit
+ * fails CI. Future engineers who need one of these for a non-git-layer
+ * purpose must place the flag OUTSIDE `src/git/`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) walk(full, acc);
+    else acc.push(full);
+  }
+  return acc;
+}
+
+const ROOT = join(import.meta.dir, "..", "..", "src", "git");
+
+const FORBIDDEN_TOKENS = [
+  "--force",
+  "--force-with-lease",
+  "--no-verify",
+  "--amend",
+  // '+refspec' as a push refspec: a plus-sign immediately before a refspec.
+  // The most searchable literal form that appears in real code is a push
+  // invocation with "+refs/" or "+HEAD". Match on the literal "+refs/"
+  // substring which cannot appear innocently in string literals.
+  "+refs/",
+];
+
+describe("git-layer safety: forbidden flag regression", () => {
+  const files = walk(ROOT).filter(
+    (f) => f.endsWith(".ts") && !f.endsWith(".test.ts"),
+  );
+
+  test("src/git contains at least one source file", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  test.each(FORBIDDEN_TOKENS)(
+    "no git-layer source file contains the forbidden token '%s'",
+    (token) => {
+      const hits: string[] = [];
+      for (const f of files) {
+        const text = readFileSync(f, "utf8");
+        if (text.includes(token)) {
+          // Strip documentation-only mentions inside // comments or JSDoc
+          // blocks. Any real code reference to these tokens is disallowed.
+          const lines = text.split("\n");
+          for (let i = 0; i < lines.length; i++) {
+            const line = lines[i] ?? "";
+            if (!line.includes(token)) continue;
+            const stripped = line.trim();
+            const isLineComment = stripped.startsWith("//");
+            const isBlockComment =
+              stripped.startsWith("*") || stripped.startsWith("/*");
+            if (isLineComment || isBlockComment) continue;
+            hits.push(`${f}:${String(i + 1)}: ${stripped}`);
+          }
+        }
+      }
+      expect(hits).toEqual([]);
+    },
+  );
+});

--- a/tests/git/protected.test.ts
+++ b/tests/git/protected.test.ts
@@ -1,0 +1,111 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { isProtected } from "../../src/git/protected.ts";
+import { createTempRepo, type TempRepo } from "./helpers/tempRepo.ts";
+
+describe("isProtected — hardcoded list", () => {
+  let repo: TempRepo;
+  beforeEach(() => {
+    repo = createTempRepo({ initialBranch: "main" });
+  });
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  test.each(["main", "master", "develop", "trunk"])(
+    "marks '%s' as protected by the hardcoded list",
+    (name) => {
+      expect(isProtected(name, { repoPath: repo.dir })).toBe(true);
+    },
+  );
+
+  test("does not mark unrelated names as protected", () => {
+    expect(isProtected("feature/foo", { repoPath: repo.dir })).toBe(false);
+    expect(isProtected("samospec/refunds", { repoPath: repo.dir })).toBe(false);
+  });
+});
+
+describe("isProtected — git config branch.<name>.protected", () => {
+  let repo: TempRepo;
+  beforeEach(() => {
+    repo = createTempRepo({ initialBranch: "main" });
+  });
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  test("respects 'true' value on a non-hardcoded branch", () => {
+    repo.run(["branch", "release/42"]);
+    repo.run(["config", "branch.release/42.protected", "true"]);
+    expect(isProtected("release/42", { repoPath: repo.dir })).toBe(true);
+  });
+
+  test("ignores 'false' value (only the hardcoded/user-config sources override)", () => {
+    repo.run(["branch", "feature/ok"]);
+    repo.run(["config", "branch.feature/ok.protected", "false"]);
+    expect(isProtected("feature/ok", { repoPath: repo.dir })).toBe(false);
+  });
+
+  test("does not weaken hardcoded protection when the config says false", () => {
+    repo.run(["config", "branch.main.protected", "false"]);
+    expect(isProtected("main", { repoPath: repo.dir })).toBe(true);
+  });
+});
+
+describe("isProtected — user config git.protected_branches", () => {
+  let repo: TempRepo;
+  beforeEach(() => {
+    repo = createTempRepo({ initialBranch: "main" });
+  });
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  test("respects a branch named in the user protected_branches list", () => {
+    expect(
+      isProtected("staging", {
+        repoPath: repo.dir,
+        userConfig: { git: { protected_branches: ["staging"] } },
+      }),
+    ).toBe(true);
+  });
+
+  test("does not mark a branch not in the user list (and not hardcoded)", () => {
+    expect(
+      isProtected("feature/xyz", {
+        repoPath: repo.dir,
+        userConfig: { git: { protected_branches: ["staging"] } },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isProtected — precedence: OR across all local sources", () => {
+  let repo: TempRepo;
+  beforeEach(() => {
+    repo = createTempRepo({ initialBranch: "main" });
+  });
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  test("any of (hardcoded | git config | user config) triggers protection", () => {
+    // Branch protected only via user config.
+    expect(
+      isProtected("staging", {
+        repoPath: repo.dir,
+        userConfig: { git: { protected_branches: ["staging"] } },
+      }),
+    ).toBe(true);
+
+    // Branch protected only via git config.
+    repo.run(["branch", "release"]);
+    repo.run(["config", "branch.release.protected", "true"]);
+    expect(isProtected("release", { repoPath: repo.dir })).toBe(true);
+
+    // Branch protected only via hardcoded list.
+    expect(isProtected("trunk", { repoPath: repo.dir })).toBe(true);
+  });
+});

--- a/tests/git/safety-invariant.test.ts
+++ b/tests/git/safety-invariant.test.ts
@@ -1,0 +1,313 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §13 test 2 — "Git branch safety (integration)".
+ *
+ * Invariant: across every dirty-tree option × every branch-selection flag ×
+ * every protected-branch source (hardcoded / git config / user config), NO
+ * commit ever lands on a protected branch. Remote API probe is out of scope
+ * for Sprint 1.
+ *
+ * Table-driven: every row invokes the real git layer on a real temp repo.
+ * Any attempt that WOULD commit to a protected branch must throw
+ * ProtectedBranchError (or otherwise prevent the commit).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  type DirtyChoice,
+  type DirtyDecision,
+  autoStash,
+  decideDirtyTree,
+  detectDirtyTree,
+} from "../../src/git/dirty.ts";
+import { specCommit } from "../../src/git/commit.ts";
+import { createSpecBranch } from "../../src/git/branch.ts";
+import { ProtectedBranchError } from "../../src/git/errors.ts";
+import { HARDCODED_PROTECTED_BRANCHES } from "../../src/git/protected.ts";
+import { createTempRepo, type TempRepo } from "./helpers/tempRepo.ts";
+
+type ProtectedSource = "hardcoded" | "git-config" | "user-config";
+type BranchFlag = "default" | "here" | "no-commit";
+type DirtyState = "clean" | "dirty-tracked" | "dirty-untracked";
+type Mode = "engineer" | "guided";
+
+interface Scenario {
+  readonly protectedSource: ProtectedSource;
+  readonly branchFlag: BranchFlag;
+  readonly dirtyState: DirtyState;
+  readonly mode: Mode;
+  readonly engineerChoice?: DirtyChoice;
+}
+
+const PROTECTED_SOURCES: readonly ProtectedSource[] = [
+  "hardcoded",
+  "git-config",
+  "user-config",
+];
+const BRANCH_FLAGS: readonly BranchFlag[] = ["default", "here", "no-commit"];
+const DIRTY_STATES: readonly DirtyState[] = [
+  "clean",
+  "dirty-tracked",
+  "dirty-untracked",
+];
+const MODES: readonly Mode[] = ["engineer", "guided"];
+const ENGINEER_CHOICES: readonly DirtyChoice[] = [
+  "stash-continue",
+  "continue-anyway",
+  "abort",
+];
+
+function scenarios(): readonly Scenario[] {
+  const out: Scenario[] = [];
+  for (const protectedSource of PROTECTED_SOURCES) {
+    for (const branchFlag of BRANCH_FLAGS) {
+      for (const dirtyState of DIRTY_STATES) {
+        for (const mode of MODES) {
+          if (mode === "engineer" && dirtyState !== "clean") {
+            // In engineer mode, the UI prompts; expand each choice.
+            for (const engineerChoice of ENGINEER_CHOICES) {
+              out.push({
+                protectedSource,
+                branchFlag,
+                dirtyState,
+                mode,
+                engineerChoice,
+              });
+            }
+          } else {
+            out.push({ protectedSource, branchFlag, dirtyState, mode });
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function scenarioLabel(s: Scenario): string {
+  return [
+    s.protectedSource,
+    s.branchFlag,
+    s.dirtyState,
+    s.mode,
+    s.engineerChoice ?? "-",
+  ].join(" | ");
+}
+
+/**
+ * Set up a repo whose current branch is protected via the given source, then
+ * optionally dirty it up. Returns the protected branch name and the user
+ * config object.
+ */
+function setupProtectedRepo(
+  scn: Scenario,
+): { repo: TempRepo; protectedBranch: string; userConfig: unknown } {
+  let repo: TempRepo;
+  let protectedBranch: string;
+  let userConfig: unknown = {};
+
+  switch (scn.protectedSource) {
+    case "hardcoded":
+      protectedBranch = HARDCODED_PROTECTED_BRANCHES[0]; // "main"
+      repo = createTempRepo({ initialBranch: protectedBranch });
+      break;
+    case "git-config":
+      protectedBranch = "release-x";
+      repo = createTempRepo({ initialBranch: protectedBranch });
+      repo.run(["config", `branch.${protectedBranch}.protected`, "true"]);
+      break;
+    case "user-config":
+      protectedBranch = "staging";
+      repo = createTempRepo({ initialBranch: protectedBranch });
+      userConfig = { git: { protected_branches: [protectedBranch] } };
+      break;
+  }
+
+  switch (scn.dirtyState) {
+    case "clean":
+      break;
+    case "dirty-tracked":
+      repo.write("README.md", "# Dirty tracked change\n");
+      break;
+    case "dirty-untracked":
+      repo.write("newfile.txt", "hi\n");
+      break;
+  }
+
+  return { repo, protectedBranch, userConfig };
+}
+
+/**
+ * Emulate what the CLI surface will do for each branch-selection flag.
+ *
+ * - `default`: createSpecBranch(slug) then specCommit on the new spec branch.
+ * - `here`: skip branch creation; commit on the current branch. Must refuse.
+ * - `no-commit`: writes files; no git operations. We assert no commit happens.
+ */
+function runScenario(
+  scn: Scenario,
+  repo: TempRepo,
+  userConfig: unknown,
+): { readonly threw: boolean; readonly error?: unknown } {
+  try {
+    // Optional dirty-tree decision step before any branch op.
+    const snap = detectDirtyTree({ repoPath: repo.dir });
+    const modeOpts =
+      scn.mode === "engineer"
+        ? {
+            mode: scn.mode,
+            ...(scn.engineerChoice !== undefined
+              ? { engineerChoice: scn.engineerChoice }
+              : {}),
+          }
+        : { mode: scn.mode };
+    const decision = decideDirtyTree(snap, modeOpts);
+    if (
+      decision.outcome === "halt" ||
+      decision.outcome === "abort"
+    ) {
+      return { threw: false };
+    }
+    if (decision.outcome === "stash-then-proceed") {
+      autoStash({ repoPath: repo.dir });
+    }
+    // "prompt" would require UI — treat as aborted for invariant purposes.
+    if (decision.outcome === "prompt") {
+      return { threw: false };
+    }
+
+    // Emulate branch flags.
+    const userConfigOpt =
+      (userConfig as { readonly git?: unknown }).git !== undefined
+        ? { userConfig: userConfig as Parameters<typeof createSpecBranch>[1] extends infer _ ? Parameters<typeof specCommit>[0]["userConfig"] : never }
+        : {};
+
+    if (scn.branchFlag === "no-commit") {
+      // Files may be written, but no git operations.
+      repo.write("SPEC.md", "# no-commit artifact\n");
+      return { threw: false };
+    }
+
+    if (scn.branchFlag === "default") {
+      createSpecBranch("invariant", {
+        repoPath: repo.dir,
+        ...(userConfigOpt as object),
+      });
+      // If we got here, the current branch was NOT protected — contradicts
+      // the scenario. Fail the invariant loudly.
+      throw new Error(
+        "createSpecBranch succeeded on a protected branch — invariant broken",
+      );
+    }
+
+    if (scn.branchFlag === "here") {
+      repo.write("SPEC.md", "# here commit\n");
+      specCommit({
+        repoPath: repo.dir,
+        slug: "invariant",
+        action: "draft",
+        version: "0.1",
+        paths: ["SPEC.md"],
+        ...(userConfigOpt as object),
+      });
+      throw new Error(
+        "specCommit succeeded on a protected branch — invariant broken",
+      );
+    }
+
+    // Unreachable.
+    return { threw: false };
+  } catch (err) {
+    return { threw: true, error: err };
+  }
+}
+
+describe("SPEC §13 test 2 — branch-safety invariant (table-driven)", () => {
+  const rows = scenarios();
+
+  test("scenario matrix is non-trivial", () => {
+    expect(rows.length).toBeGreaterThanOrEqual(30);
+  });
+
+  describe.each(rows.map((s) => [scenarioLabel(s), s] as const))(
+    "scenario: %s",
+    (_label, scn) => {
+      let repo: TempRepo;
+      let userConfig: unknown;
+      let protectedBranch: string;
+
+      beforeEach(() => {
+        ({ repo, userConfig, protectedBranch } = setupProtectedRepo(scn));
+      });
+      afterEach(() => {
+        repo.cleanup();
+      });
+
+      test("no commit lands on the protected branch", () => {
+        const before = repo.logOnBranch(protectedBranch).length;
+        runScenario(scn, repo, userConfig);
+        const after = repo.logOnBranch(protectedBranch).length;
+        expect(after).toBe(before);
+      });
+
+      test("either throws ProtectedBranchError or avoids the commit path", () => {
+        const result = runScenario(scn, repo, userConfig);
+        if (
+          scn.branchFlag !== "no-commit" &&
+          (scn.mode === "guided" ||
+            scn.engineerChoice === undefined ||
+            scn.engineerChoice !== "abort")
+        ) {
+          // The default / here paths must throw when the branch is protected —
+          // UNLESS the dirty-tree decision shortcut already halted/aborted.
+          const aborted =
+            scn.mode === "guided" && scn.dirtyState !== "clean";
+          const engineerAbort =
+            scn.mode === "engineer" && scn.engineerChoice === "abort";
+          if (!aborted && !engineerAbort) {
+            expect(result.threw).toBe(true);
+            expect(result.error).toBeInstanceOf(ProtectedBranchError);
+          }
+        }
+      });
+    },
+  );
+});
+
+describe("SPEC §13 test 2 — positive control", () => {
+  let repo: TempRepo;
+  beforeEach(() => {
+    repo = createTempRepo({ initialBranch: "feature-x" });
+  });
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  test("createSpecBranch followed by specCommit on a non-protected branch succeeds", () => {
+    createSpecBranch("happy", { repoPath: repo.dir });
+    repo.write("SPEC.md", "# v0.1\n");
+    specCommit({
+      repoPath: repo.dir,
+      slug: "happy",
+      action: "draft",
+      version: "0.1",
+      paths: ["SPEC.md"],
+    });
+    const messages = repo.logOnBranch("samospec/happy");
+    expect(messages[0]).toBe("spec(happy): draft v0.1");
+  });
+
+  test("decideDirtyTree covers the full allowed-choice union", () => {
+    // Sanity that we exercised the full DirtyDecision union in the matrix.
+    const allOutcomes = new Set<DirtyDecision["outcome"]>([
+      "proceed",
+      "stash-then-proceed",
+      "abort",
+      "halt",
+      "prompt",
+    ]);
+    expect(allOutcomes.size).toBe(5);
+  });
+});

--- a/tests/git/safety-invariant.test.ts
+++ b/tests/git/safety-invariant.test.ts
@@ -101,9 +101,11 @@ function scenarioLabel(s: Scenario): string {
  * optionally dirty it up. Returns the protected branch name and the user
  * config object.
  */
-function setupProtectedRepo(
-  scn: Scenario,
-): { repo: TempRepo; protectedBranch: string; userConfig: unknown } {
+function setupProtectedRepo(scn: Scenario): {
+  repo: TempRepo;
+  protectedBranch: string;
+  userConfig: unknown;
+} {
   let repo: TempRepo;
   let protectedBranch: string;
   let userConfig: unknown = {};
@@ -164,10 +166,7 @@ function runScenario(
           }
         : { mode: scn.mode };
     const decision = decideDirtyTree(snap, modeOpts);
-    if (
-      decision.outcome === "halt" ||
-      decision.outcome === "abort"
-    ) {
+    if (decision.outcome === "halt" || decision.outcome === "abort") {
       return { threw: false };
     }
     if (decision.outcome === "stash-then-proceed") {
@@ -181,7 +180,13 @@ function runScenario(
     // Emulate branch flags.
     const userConfigOpt =
       (userConfig as { readonly git?: unknown }).git !== undefined
-        ? { userConfig: userConfig as Parameters<typeof createSpecBranch>[1] extends infer _ ? Parameters<typeof specCommit>[0]["userConfig"] : never }
+        ? {
+            userConfig: userConfig as Parameters<
+              typeof createSpecBranch
+            >[1] extends infer _
+              ? Parameters<typeof specCommit>[0]["userConfig"]
+              : never,
+          }
         : {};
 
     if (scn.branchFlag === "no-commit") {
@@ -262,8 +267,7 @@ describe("SPEC §13 test 2 — branch-safety invariant (table-driven)", () => {
         ) {
           // The default / here paths must throw when the branch is protected —
           // UNLESS the dirty-tree decision shortcut already halted/aborted.
-          const aborted =
-            scn.mode === "guided" && scn.dirtyState !== "clean";
+          const aborted = scn.mode === "guided" && scn.dirtyState !== "clean";
           const engineerAbort =
             scn.mode === "engineer" && scn.engineerChoice === "abort";
           if (!aborted && !engineerAbort) {


### PR DESCRIPTION
Closes #3

## Summary

Sprint 1 git layer: protected-branch detection, branch creation, commit grammar, and dirty-tree handling. **Local-only** — no push, no remote probe, no PR opening (those are later sprints per SPEC §14 / §8).

## Acceptance checklist

### Protected-branch detection (SPEC §5 Phase 1)
- [x] Local checks are sufficient for safety. Remote probe deferred (`git.remote_probe` defaults off per §14) — not implemented in this PR.
- [x] All three local sources combined with OR:
  - hardcoded list: `main`, `master`, `develop`, `trunk`
  - `git config branch.<name>.protected`
  - user config `git.protected_branches`
- [x] Module exports `isProtected(branchName, opts): boolean` from `src/git/protected.ts`.

### Branch creation (SPEC §8)
- [x] `createSpecBranch(slug)` in `src/git/branch.ts` creates `samospec/<slug>` off the current branch (not off `main`).
- [x] Refuses to create on any protected branch — throws `ProtectedBranchError` with `exitCode: 2` and a clear message.
- [x] Slug grammar: `[a-z0-9]+(?:-[a-z0-9]+)*` (no slashes, no spaces, no leading/trailing dash).
- [x] Idempotency: rejects re-creating an existing `samospec/<slug>`.

### Commit grammar (SPEC §8)
- [x] `buildCommitMessage({ slug, action, version })` renders `spec(<slug>): <action> v<version>`.
- [x] `refine` action with `roundNumber` renders `spec(<slug>): refine v<version> after review r<n>`.
- [x] Actions: `draft`, `refine`, `publish`, `user-edit`, `changelog`.
- [x] `specCommit()` stages only explicit paths (no `add -A`) and refuses on protected branches.
- [x] **No force pushes. Ever.** Regression test `tests/git/no-force.test.ts` greps every `src/git/*.ts` for forbidden tokens (`--force`, `--force-with-lease`, `--no-verify`, `--amend`, `+refs/`) and fails on any hit. Manually verified it catches injected tokens.

### Dirty working tree (SPEC §8)
- [x] `detectDirtyTree()` via `git status --porcelain=v1`; ignored files excluded.
- [x] `decideDirtyTree()` is pure: engineer mode returns prompt with `["stash-continue", "continue-anyway", "abort"]` (default `stash-continue`), or resolves a provided choice. Guided mode halts.
- [x] `autoStash()` runs `git stash push -u -m "samospec: auto-stash before spec"` verbatim (the `-u` preserves untracked files).

### TDD / tests
- [x] Every module shipped via red → green: 5 RED commits, 4 GREEN commits, 1 invariant test commit, 1 regression-test commit.
- [x] All tests are **integration tests against a real temp bare repo** (`tests/git/helpers/tempRepo.ts`). No mocks for git.
- [x] SPEC §13 test 2 safety invariant: table-driven across every protected source × branch-selection flag × dirty-tree state × mode × engineer choice = **183 scenarios**.

## Testing evidence

### `bun test` (full suite)
```
bun test v1.3.5 (1e86cebd)
 240 pass
 0 fail
 258 expect() calls
Ran 240 tests across 8 files. [13.97s]
```

### Safety invariant only
```
$ bun test tests/git/safety-invariant.test.ts
 183 pass
 0 fail
 165 expect() calls
Ran 183 tests across 1 file. [12.32s]
```

### Forbidden-flag regression guard
```
$ bun test tests/git/no-force.test.ts
 6 pass
 0 fail
 6 expect() calls
Ran 6 tests across 1 file. [13.00ms]
```

Verified the regression guard actually fails: injected `const BAD = ["push", "--force", "origin"];` into `errors.ts`, ran the test, got
```
expect(received).toEqual(expected)
- []
+ [".../src/git/errors.ts:2: const BAD = [\"push\", \"--force\", \"origin\"];"]
```
then restored and re-verified green.

### Coverage (`bun test --coverage`)
```
File                           | % Funcs | % Lines
All files                      |  100.00 |   95.09
 src/git/branch.ts             |  100.00 |   93.10
 src/git/commit.ts             |  100.00 |   90.67
 src/git/dirty.ts              |  100.00 |   87.50
 src/git/errors.ts             |  100.00 |  100.00
 src/git/protected.ts          |  100.00 |  100.00
```
All git-layer files well above the 80% gate.

### Lint / typecheck / format
All clean (`bun run lint`, `bun run typecheck`, `bun run format:check`).

## File layout

```
src/git/
  protected.ts       isProtected + HARDCODED_PROTECTED_BRANCHES
  branch.ts          createSpecBranch, currentBranch, branchExists
  commit.ts          buildCommitMessage, specCommit, COMMIT_ACTIONS
  dirty.ts           detectDirtyTree, decideDirtyTree, autoStash
  errors.ts          ProtectedBranchError (exitCode 2), GitLayerUsageError

tests/git/
  helpers/tempRepo.ts          real-bare-repo helper (beforeEach/afterEach)
  protected.test.ts            hardcoded / git-config / user-config sources
  branch.test.ts               happy + refusal + slug + idempotency
  commit.test.ts               grammar + integration + no 'add -A'
  dirty.test.ts                detection + decision + autoStash
  safety-invariant.test.ts     SPEC §13 test 2 — 183-row matrix
  no-force.test.ts             forbidden-flag regression guard
```

## Out of scope (per issue)

- Push (consent-gated, later sprint)
- Remote API probe (deferred, off by default §14)
- Manual-edit detection between rounds (Sprint 3)
- `samospec new` CLI command (later issue — this PR exposes the helper)
- Adapter code, state machine, CLI commands

## Git hygiene

All 11 commits are Conventional Commits. No amends, no force-pushes, no `--no-verify`. Every source file carries the `Copyright 2026 Nikolay Samokhvalov.` header.