### PR TITLE
feat: Sprint 1 #2 — phase machine + round state + lockfile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,14 @@
   "workspaces": {
     "": {
       "name": "samospec",
+      "dependencies": {
+        "zod": "^4.3.6",
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.2.0",
         "eslint": "^10.2.1",
+        "fast-check": "^4.7.0",
         "prettier": "^3.8.3",
         "typescript": "^5.6.0",
         "typescript-eslint": "^8.58.2",
@@ -107,6 +111,8 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "fast-check": ["fast-check@4.7.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
@@ -171,6 +177,8 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
+
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
@@ -196,6 +204,8 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/package.json
+++ b/package.json
@@ -38,8 +38,12 @@
     "@eslint/js": "^10.0.1",
     "@types/bun": "^1.2.0",
     "eslint": "^10.2.1",
+    "fast-check": "^4.7.0",
     "prettier": "^3.8.3",
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.58.2"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
   }
 }

--- a/src/state/lock.ts
+++ b/src/state/lock.ts
@@ -1,0 +1,214 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import path from "node:path";
+
+import { lockSchema, type Lock } from "./types.ts";
+
+// SPEC §8 — stale detection has two reasons.
+export type LockStaleReason = "pid_dead" | "age_exceeded";
+
+// Buffer added on top of `max_wall_clock_minutes` before a lock is
+// declared stale purely by age (SPEC §8).
+export const STALE_AGE_BUFFER_MINUTES = 30;
+
+export class LockContendedError extends Error {
+  public readonly holderPid: number;
+  public readonly lockPath: string;
+  constructor(lockPath: string, holderPid: number) {
+    super(
+      `another samospec process (pid ${holderPid}) holds the repo lock at ${lockPath}`,
+    );
+    this.name = "LockContendedError";
+    this.holderPid = holderPid;
+    this.lockPath = lockPath;
+  }
+}
+
+export interface LockHandle {
+  readonly lockPath: string;
+  readonly pid: number;
+  readonly slug: string;
+}
+
+export interface AcquireLockArgs {
+  readonly lockPath: string;
+  readonly slug: string;
+  readonly now: number;
+  readonly maxWallClockMinutes: number;
+  // Optional injection seam: defaults to process.pid.
+  readonly pid?: number;
+  // Optional injection seam: defaults to a POSIX `kill(pid, 0)` probe.
+  readonly isPidAlive?: (pid: number) => boolean;
+}
+
+export interface StaleLockInfo {
+  readonly lock: Lock;
+  readonly now: number;
+  readonly maxWallClockMinutes: number;
+  readonly isPidAlive?: (pid: number) => boolean;
+}
+
+/**
+ * Default POSIX-style PID liveness probe. `process.kill(pid, 0)` does
+ * not actually send a signal but raises ESRCH if the PID is no longer
+ * running. Per SPEC §8, false negatives (dead PID misreported as alive)
+ * are absorbed by the age_exceeded cross-check.
+ */
+export function defaultIsPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return false;
+    // EPERM = pid exists but we are not allowed to signal it — still alive.
+    if (code === "EPERM") return true;
+    return false;
+  }
+}
+
+/**
+ * Determine whether an existing lock should be considered stale per
+ * SPEC §8. Returns the reason, or null when the lock is still live.
+ */
+export function isLockStale(info: StaleLockInfo): LockStaleReason | null {
+  const probe = info.isPidAlive ?? defaultIsPidAlive;
+  if (!probe(info.lock.pid)) {
+    return "pid_dead";
+  }
+  const startedAtMs = Date.parse(info.lock.started_at);
+  if (!Number.isFinite(startedAtMs)) {
+    // Unparseable timestamp is conservatively treated as age-exceeded so
+    // we do not block forever on a garbage lock (SPEC §8 stale removal).
+    return "age_exceeded";
+  }
+  const ageMs = info.now - startedAtMs;
+  const maxAgeMs =
+    (info.maxWallClockMinutes + STALE_AGE_BUFFER_MINUTES) * 60_000;
+  if (ageMs > maxAgeMs) return "age_exceeded";
+  return null;
+}
+
+/**
+ * Read a .lock file. Returns null if absent or malformed — malformed is
+ * treated as "no valid owner" so acquireLock can overwrite it safely.
+ */
+export function readLock(file: string): Lock | null {
+  if (!existsSync(file)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const result = lockSchema.safeParse(parsed);
+  if (!result.success) return null;
+  return result.data;
+}
+
+/**
+ * Acquire the repo-level lock. Raises LockContendedError if a live,
+ * non-stale holder is present (exit 2 per SPEC §8). Stale or malformed
+ * lock files are auto-removed and overwritten with ours.
+ */
+export function acquireLock(args: AcquireLockArgs): LockHandle {
+  const pid = args.pid ?? process.pid;
+  const probe = args.isPidAlive ?? defaultIsPidAlive;
+
+  const existing = readLock(args.lockPath);
+  if (existing !== null && existing.pid !== pid) {
+    const staleReason = isLockStale({
+      lock: existing,
+      now: args.now,
+      maxWallClockMinutes: args.maxWallClockMinutes,
+      isPidAlive: probe,
+    });
+    if (staleReason === null) {
+      throw new LockContendedError(args.lockPath, existing.pid);
+    }
+    // Stale — remove, log, fall through to acquire.
+    try {
+      unlinkSync(args.lockPath);
+    } catch {
+      /* best-effort */
+    }
+  } else if (existing === null && existsSync(args.lockPath)) {
+    // Malformed lock file on disk; overwrite-as-stale.
+    try {
+      unlinkSync(args.lockPath);
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  const lock: Lock = {
+    pid,
+    started_at: new Date(args.now).toISOString(),
+    slug: args.slug,
+  };
+
+  writeLockFile(args.lockPath, lock);
+
+  return { lockPath: args.lockPath, pid, slug: args.slug };
+}
+
+/**
+ * Release a lock acquired by this process. Safe to call twice or on a
+ * file that has already been removed (idempotent cleanup).
+ */
+export function releaseLock(handle: LockHandle): void {
+  try {
+    const current = readLock(handle.lockPath);
+    if (current === null || current.pid === handle.pid) {
+      if (existsSync(handle.lockPath)) {
+        unlinkSync(handle.lockPath);
+      }
+    }
+  } catch {
+    // Best-effort; exit-time cleanup must never throw.
+  }
+}
+
+function writeLockFile(file: string, lock: Lock): void {
+  const validated = lockSchema.parse(lock);
+  const dir = path.dirname(file);
+  mkdirSync(dir, { recursive: true });
+  const tmp = path.join(dir, `.${path.basename(file)}.tmp.${process.pid}`);
+  const payload = `${JSON.stringify(validated, null, 2)}\n`;
+
+  const fd = openSync(tmp, "w", 0o644);
+  try {
+    writeSync(fd, payload, 0, "utf8");
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+
+  try {
+    renameSync(tmp, file);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+}

--- a/src/state/lock.ts
+++ b/src/state/lock.ts
@@ -186,6 +186,72 @@ export function releaseLock(handle: LockHandle): void {
   }
 }
 
+/**
+ * Signals we release the lock on. SIGKILL is intentionally omitted —
+ * it cannot be intercepted; the stale-lock path handles that case.
+ */
+export const RELEASE_SIGNALS = ["SIGINT", "SIGTERM"] as const;
+export type ReleaseSignal = (typeof RELEASE_SIGNALS)[number];
+
+type SignalRegister = (sig: ReleaseSignal, cb: () => void) => void;
+type ExitRegister = (cb: () => void) => void;
+
+export interface ReleaseHookEmitter {
+  readonly onSignal: SignalRegister;
+  readonly onExit: ExitRegister;
+  readonly offSignal?: SignalRegister;
+  readonly offExit?: ExitRegister;
+}
+
+const defaultEmitter: ReleaseHookEmitter = {
+  onSignal: (sig, cb) => {
+    process.on(sig, cb);
+  },
+  onExit: (cb) => {
+    process.on("exit", cb);
+  },
+  offSignal: (sig, cb) => {
+    process.off(sig, cb);
+  },
+  offExit: (cb) => {
+    process.off("exit", cb);
+  },
+};
+
+/**
+ * Install SIGINT / SIGTERM / exit listeners that release `handle`. The
+ * returned detach function removes them — call it in tests and on any
+ * replace-handle path so listeners do not accumulate.
+ *
+ * Per SPEC §8 the lock must be released on "normal + SIGINT + SIGTERM"
+ * exits. SIGKILL and power loss are absorbed by the stale-lock rule.
+ */
+export function installReleaseHooks(
+  handle: LockHandle,
+  emitter: ReleaseHookEmitter = defaultEmitter,
+): () => void {
+  const onExit = (): void => {
+    releaseLock(handle);
+  };
+  const signalHandlers: Partial<Record<ReleaseSignal, () => void>> = {};
+  for (const sig of RELEASE_SIGNALS) {
+    const h = (): void => {
+      releaseLock(handle);
+    };
+    signalHandlers[sig] = h;
+    emitter.onSignal(sig, h);
+  }
+  emitter.onExit(onExit);
+
+  return (): void => {
+    for (const sig of RELEASE_SIGNALS) {
+      const h = signalHandlers[sig];
+      if (h !== undefined) emitter.offSignal?.(sig, h);
+    }
+    emitter.offExit?.(onExit);
+  };
+}
+
 function writeLockFile(file: string, lock: Lock): void {
   const validated = lockSchema.parse(lock);
   const dir = path.dirname(file);

--- a/src/state/phase.ts
+++ b/src/state/phase.ts
@@ -1,0 +1,66 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { PHASES, type Phase, type State } from "./types.ts";
+
+/**
+ * Canonical phase order per SPEC §5. Exported as a readonly array so
+ * callers can iterate deterministically — `PHASES` (the type alias) is
+ * used for schema validation, `PHASE_ORDER` is the operational vector.
+ */
+export const PHASE_ORDER: readonly Phase[] = PHASES;
+
+const PHASE_INDEX: ReadonlyMap<Phase, number> = new Map(
+  PHASE_ORDER.map((p, i) => [p, i]),
+);
+
+/**
+ * Raised when advancePhase is called with an illegal transition.
+ * Caller (CLI) translates to exit 1 with the included message.
+ */
+export class PhaseTransitionError extends Error {
+  public readonly from: Phase;
+  public readonly to: Phase;
+  constructor(from: Phase, to: Phase) {
+    super(`illegal phase transition: ${from} -> ${to}`);
+    this.name = "PhaseTransitionError";
+    this.from = from;
+    this.to = to;
+  }
+}
+
+/**
+ * Returns true if `to` is the same phase or the next phase after `from`.
+ * Backward or skipping transitions always return false (SPEC §5: phase
+ * never goes backwards; §13 test 1 invariant).
+ */
+export function isLegalPhaseTransition(from: Phase, to: Phase): boolean {
+  if (from === to) return true;
+  const fi = PHASE_INDEX.get(from);
+  const ti = PHASE_INDEX.get(to);
+  if (fi === undefined || ti === undefined) return false;
+  return ti === fi + 1;
+}
+
+export interface AdvancePhaseOpts {
+  readonly now: string;
+}
+
+/**
+ * Produce a new State with `phase` advanced to `to` and `updated_at`
+ * bumped to `opts.now`. Throws PhaseTransitionError on illegal moves;
+ * the schema validation happens at the write-state boundary.
+ */
+export function advancePhase(
+  state: State,
+  to: Phase,
+  opts: AdvancePhaseOpts,
+): State {
+  if (!isLegalPhaseTransition(state.phase, to)) {
+    throw new PhaseTransitionError(state.phase, to);
+  }
+  return {
+    ...state,
+    phase: to,
+    updated_at: opts.now,
+  };
+}

--- a/src/state/round.ts
+++ b/src/state/round.ts
@@ -1,0 +1,194 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import path from "node:path";
+
+import {
+  roundSchema,
+  type Round,
+  type RoundState,
+  type State,
+} from "./types.ts";
+
+/**
+ * SPEC §7 round state transition table. Each key is a state; the value
+ * is the set of permitted next states. `lead_terminal` has no outgoing
+ * transitions — it is absorbing. `running -> running` is permitted to
+ * model a retry-in-place when every seat has been kicked forward but
+ * another retryable failure needs to be re-run inside the same state.
+ *
+ * Write ordering (per round, per critique) is documented in SPEC §7:
+ *   critique file write -> fsync -> round.json seat update -> fsync.
+ */
+export const ROUND_TRANSITIONS: Record<RoundState, readonly RoundState[]> = {
+  planned: ["running"],
+  running: ["reviews_collected", "lead_terminal", "running"],
+  reviews_collected: ["lead_revised", "lead_terminal"],
+  lead_revised: ["committed", "lead_terminal"],
+  committed: ["planned"],
+  lead_terminal: [],
+};
+
+export class RoundTransitionError extends Error {
+  public readonly from: RoundState;
+  public readonly to: RoundState;
+  constructor(from: RoundState, to: RoundState) {
+    super(`illegal round-state transition: ${from} -> ${to}`);
+    this.name = "RoundTransitionError";
+    this.from = from;
+    this.to = to;
+  }
+}
+
+export function isLegalRoundTransition(
+  from: RoundState,
+  to: RoundState,
+): boolean {
+  return ROUND_TRANSITIONS[from].includes(to);
+}
+
+export interface RoundTransitionOpts {
+  readonly now: string;
+}
+
+/**
+ * Apply a round-state transition to `state`, updating round_state,
+ * round_index (on committed -> planned), and updated_at. Throws
+ * RoundTransitionError on illegal moves; schema validation happens at
+ * the writeState boundary.
+ */
+export function applyRoundTransition(
+  state: State,
+  to: RoundState,
+  opts: RoundTransitionOpts,
+): State {
+  if (!isLegalRoundTransition(state.round_state, to)) {
+    throw new RoundTransitionError(state.round_state, to);
+  }
+  const bumpsRound = state.round_state === "committed" && to === "planned";
+  return {
+    ...state,
+    round_state: to,
+    round_index: bumpsRound ? state.round_index + 1 : state.round_index,
+    updated_at: opts.now,
+  };
+}
+
+export interface NewRoundArgs {
+  readonly round: number;
+  readonly now: string;
+}
+
+/**
+ * Build an initial `round.json` record for a new review round.
+ * Status starts at `planned`; both reviewer seats are `pending`.
+ */
+export function newRound(args: NewRoundArgs): Round {
+  return roundSchema.parse({
+    round: args.round,
+    status: "planned",
+    seats: { reviewer_a: "pending", reviewer_b: "pending" },
+    started_at: args.now,
+  });
+}
+
+/**
+ * Format the round directory name per SPEC §9 `reviews/rNN/`.
+ * Rounds are 1-indexed and zero-padded to two digits. Higher numbers
+ * are emitted unpadded (rare in practice — max rounds is small).
+ */
+export function roundDirFor(reviewsDir: string, round: number): string {
+  const padded = round < 100 ? String(round).padStart(2, "0") : String(round);
+  return path.join(reviewsDir, `r${padded}`);
+}
+
+/**
+ * Read round.json. Returns null if absent, throws with file path on any
+ * parse or schema failure so the caller can surface an exit-1 message.
+ */
+export function readRound(file: string): Round | null {
+  if (!existsSync(file)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch (err) {
+    throw new Error(
+      `round.json at ${file} could not be read: ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `round.json at ${file} is not valid JSON: ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+  const result = roundSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `round.json at ${file} failed schema validation: ${result.error.message}`,
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Atomic write of round.json: validate -> .tmp -> fsync -> rename ->
+ * fsync parent. Mirrors writeState; see SPEC §7 atomicity guarantee.
+ */
+export function writeRound(file: string, round: Round): void {
+  const parsed = roundSchema.safeParse(round);
+  if (!parsed.success) {
+    throw new Error(
+      `refusing to write invalid round to ${file}: ${parsed.error.message}`,
+    );
+  }
+  const dir = path.dirname(file);
+  mkdirSync(dir, { recursive: true });
+
+  const tmp = path.join(dir, `.${path.basename(file)}.tmp.${process.pid}`);
+  const payload = `${JSON.stringify(parsed.data, null, 2)}\n`;
+
+  const fd = openSync(tmp, "w", 0o644);
+  try {
+    writeSync(fd, payload, 0, "utf8");
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+
+  try {
+    renameSync(tmp, file);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+
+  try {
+    const dfd = openSync(dir, "r");
+    try {
+      fsyncSync(dfd);
+    } finally {
+      closeSync(dfd);
+    }
+  } catch {
+    // Platform-specific; rename is already atomic. See src/state/store.ts.
+  }
+}

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,0 +1,146 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import path from "node:path";
+
+import { stateSchema, type State } from "./types.ts";
+
+export interface NewStateArgs {
+  readonly slug: string;
+  readonly now: string;
+}
+
+/**
+ * Build a fresh state.json record for a new spec.
+ * Starts in phase `detect`, round 0, `planned`, version `0.0.0`.
+ */
+export function newState(args: NewStateArgs): State {
+  const fresh: State = {
+    slug: args.slug,
+    phase: "detect",
+    round_index: 0,
+    version: "0.0.0",
+    persona: null,
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    round_state: "planned",
+    exit: null,
+    created_at: args.now,
+    updated_at: args.now,
+  };
+  return stateSchema.parse(fresh);
+}
+
+/**
+ * Read state.json from disk. Returns `null` if the file is absent.
+ * Throws a contextual Error if the file is present but malformed or
+ * schema-invalid — callers surface that as exit 1 per SPEC §7.
+ */
+export function readState(file: string): State | null {
+  if (!existsSync(file)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch (err) {
+    throw new Error(
+      `state.json at ${file} could not be read: ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `state.json at ${file} is not valid JSON: ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+  const result = stateSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `state.json at ${file} failed schema validation: ${result.error.message}`,
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Read state.json, throwing if missing. Useful on resume where absence
+ * is itself a user error (exit 1: "no spec found").
+ */
+export function readStateOrThrow(file: string): State {
+  const s = readState(file);
+  if (s === null) {
+    throw new Error(`state.json not found at ${file}`);
+  }
+  return s;
+}
+
+/**
+ * Atomic write: validate → write to `.tmp.<pid>.<n>` sibling → fsync →
+ * rename over the target → fsync the parent directory. A crash mid-write
+ * leaves either the old file or nothing, never a half-written state.json.
+ *
+ * SPEC §7: "Read/write with atomic write (temp file + fsync + rename) so
+ * a crash mid-write never corrupts state.json."
+ */
+export function writeState(file: string, state: State): void {
+  const parsed = stateSchema.safeParse(state);
+  if (!parsed.success) {
+    throw new Error(
+      `refusing to write invalid state to ${file}: ${parsed.error.message}`,
+    );
+  }
+  const dir = path.dirname(file);
+  mkdirSync(dir, { recursive: true });
+
+  const tmp = path.join(dir, `.${path.basename(file)}.tmp.${process.pid}`);
+  const payload = `${JSON.stringify(parsed.data, null, 2)}\n`;
+
+  const fd = openSync(tmp, "w", 0o644);
+  try {
+    writeSync(fd, payload, 0, "utf8");
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+
+  try {
+    renameSync(tmp, file);
+  } catch (err) {
+    // Best-effort cleanup if rename failed; surface the original error.
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+
+  // fsync the directory so the rename is durable across a crash.
+  try {
+    const dfd = openSync(dir, "r");
+    try {
+      fsyncSync(dfd);
+    } finally {
+      closeSync(dfd);
+    }
+  } catch {
+    // Some platforms (notably Windows) do not allow fsync on a dir fd.
+    // The rename remains atomic — directory-fsync is a durability upgrade,
+    // not a correctness requirement for the "never corrupt" guarantee.
+  }
+}

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,0 +1,162 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { z } from "zod";
+
+// SPEC §5 — eight phases in canonical order.
+export const PHASES = [
+  "detect",
+  "branch_lock_preflight",
+  "persona",
+  "context",
+  "interview",
+  "draft",
+  "review_loop",
+  "publish",
+] as const;
+export type Phase = (typeof PHASES)[number];
+export const phaseSchema = z.enum(PHASES);
+
+// SPEC §7 — six round states including lead_terminal.
+export const ROUND_STATES = [
+  "planned",
+  "running",
+  "reviews_collected",
+  "lead_revised",
+  "committed",
+  "lead_terminal",
+] as const;
+export type RoundState = (typeof ROUND_STATES)[number];
+export const roundStateSchema = z.enum(ROUND_STATES);
+
+// SPEC §7 — reviewer seat status set.
+export const SEAT_STATES = [
+  "pending",
+  "ok",
+  "failed",
+  "schema_violation",
+  "timeout",
+] as const;
+export type SeatState = (typeof SEAT_STATES)[number];
+export const seatStateSchema = z.enum(SEAT_STATES);
+
+// SPEC §7 — round.json top-level status set.
+export const ROUND_STATUSES = [
+  "planned",
+  "running",
+  "complete",
+  "partial",
+  "abandoned",
+] as const;
+export type RoundStatus = (typeof ROUND_STATUSES)[number];
+export const roundStatusSchema = z.enum(ROUND_STATUSES);
+
+// ISO 8601 timestamp ending in Z. Kept narrow so malformed writes are caught.
+const isoTimestampSchema = z
+  .string()
+  .regex(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/,
+    "must be an ISO 8601 UTC timestamp ending in 'Z'",
+  );
+
+// SemVer, SPEC uses `X.Y.Z` version format (no pre-release tags for now).
+const semverSchema = z
+  .string()
+  .regex(/^\d+\.\d+\.\d+$/, "must match X.Y.Z SemVer");
+
+const personaSchema = z
+  .object({
+    skill: z.string().min(1),
+    accepted: z.boolean(),
+  })
+  .strict();
+
+const calibrationSchema = z
+  .object({
+    // Per SPEC §11: preflight coefficients tightened from prior runs.
+    prior_runs: z.number().int().nonnegative(),
+    midpoint_usd: z.number().nonnegative(),
+  })
+  .strict();
+
+const pushConsentSchema = z
+  .object({
+    remote: z.string().min(1),
+    granted: z.boolean(),
+    recorded_at: isoTimestampSchema,
+  })
+  .strict();
+
+// SPEC §12 — exit is recorded with reason string and round_index.
+const exitSchema = z
+  .object({
+    code: z.number().int().nonnegative(),
+    reason: z.string().min(1),
+    round_index: z.number().int().nonnegative(),
+  })
+  .strict();
+
+// SPEC §7 + §11 — resolved adapter snapshot recorded at round start.
+const adapterResolutionSchema = z
+  .object({
+    adapter: z.string().min(1),
+    model_id: z.string().min(1),
+    effort_requested: z.string().min(1),
+    effort_used: z.string().min(1),
+  })
+  .strict();
+
+export const stateSchema = z
+  .object({
+    slug: z.string().min(1),
+    phase: phaseSchema,
+    round_index: z.number().int().nonnegative(),
+    version: semverSchema,
+    persona: personaSchema.nullable(),
+    push_consent: pushConsentSchema.nullable(),
+    calibration: calibrationSchema.nullable(),
+    remote_stale: z.boolean(),
+    coupled_fallback: z.boolean(),
+    round_state: roundStateSchema,
+    exit: exitSchema.nullable(),
+    adapters: z
+      .object({
+        lead: adapterResolutionSchema,
+        reviewer_a: adapterResolutionSchema,
+        reviewer_b: adapterResolutionSchema,
+      })
+      .partial()
+      .strict()
+      .optional(),
+    created_at: isoTimestampSchema,
+    updated_at: isoTimestampSchema,
+  })
+  .strict();
+
+export type State = z.infer<typeof stateSchema>;
+
+export const roundSchema = z
+  .object({
+    round: z.number().int().positive(),
+    status: roundStatusSchema,
+    seats: z
+      .object({
+        reviewer_a: seatStateSchema,
+        reviewer_b: seatStateSchema,
+      })
+      .strict(),
+    started_at: isoTimestampSchema,
+    completed_at: isoTimestampSchema.optional(),
+  })
+  .strict();
+
+export type Round = z.infer<typeof roundSchema>;
+
+export const lockSchema = z
+  .object({
+    pid: z.number().int().positive(),
+    started_at: isoTimestampSchema,
+    slug: z.string().min(1),
+  })
+  .strict();
+
+export type Lock = z.infer<typeof lockSchema>;

--- a/tests/state/crash.test.ts
+++ b/tests/state/crash.test.ts
@@ -1,0 +1,122 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { newState, readState, writeState } from "../../src/state/store.ts";
+import { readRound, writeRound } from "../../src/state/round.ts";
+import type { Round } from "../../src/state/types.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-crash-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("state/store — crash recovery (SPEC §13 test 10)", () => {
+  test("kill -9 before rename leaves the previous state.json intact", async () => {
+    const file = path.join(tmp, "state.json");
+    const initial = newState({
+      slug: "demo",
+      now: "2026-04-19T00:00:00.000Z",
+    });
+    writeState(file, initial);
+    const originalBytes = readFileSync(file, "utf8");
+
+    // Spawn a Bun process that starts an atomic write but gets killed
+    // after opening the .tmp file and before the rename completes. The
+    // parent then asserts the original state.json is still valid.
+    const scriptPath = path.join(tmp, "crash.ts");
+    writeFileSync(
+      scriptPath,
+      `
+        import { openSync, writeSync, fsyncSync, closeSync } from "node:fs";
+        import path from "node:path";
+        const file = process.argv[2]!;
+        const dir = path.dirname(file);
+        const tmp = path.join(dir, "." + path.basename(file) + ".tmp." + process.pid);
+        const fd = openSync(tmp, "w", 0o644);
+        writeSync(fd, '{"partial": "write in progress"', 0, "utf8");
+        fsyncSync(fd);
+        closeSync(fd);
+        // Exit abnormally before the rename so state.json is untouched.
+        process.exit(137);
+      `,
+      "utf8",
+    );
+
+    const proc = Bun.spawn(["bun", "run", scriptPath, file], {
+      cwd: tmp,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const code = await proc.exited;
+    expect(code).toBe(137);
+
+    // The original file must still parse successfully against the schema.
+    const reread = readState(file);
+    expect(reread).toEqual(initial);
+    expect(readFileSync(file, "utf8")).toBe(originalBytes);
+
+    // The orphan .tmp file is still present — we do NOT treat it as
+    // state.json. It is harmless: the next writeState overwrites a
+    // fresh .tmp.<pid> sibling and renames over the target.
+    const entries = readdirSync(tmp).filter((e) => e !== "crash.ts");
+    expect(entries).toContain("state.json");
+    expect(entries.some((e) => e.startsWith(".state.json.tmp."))).toBe(true);
+
+    // Subsequent legitimate write cleans up over itself.
+    const next = {
+      ...initial,
+      updated_at: "2026-04-19T00:01:00.000Z",
+      remote_stale: true,
+    };
+    writeState(file, next);
+    const afterRecovery = readState(file);
+    expect(afterRecovery?.remote_stale).toBe(true);
+  });
+
+  test("kill -9 between critique write and round.json update leaves previous round.json intact", () => {
+    const reviewsDir = path.join(tmp, "r01");
+    const roundFile = path.join(reviewsDir, "round.json");
+    const critiqueFile = path.join(reviewsDir, "claude.md");
+
+    const base: Round = {
+      round: 1,
+      status: "planned",
+      seats: { reviewer_a: "pending", reviewer_b: "pending" },
+      started_at: "2026-04-19T02:00:00.000Z",
+    };
+    writeRound(roundFile, base);
+
+    // Simulate the orphan-critique condition: the process writes the
+    // critique file then dies before it can update round.json.
+    writeFileSync(critiqueFile, "# Partial critique\nunfinished\n", "utf8");
+
+    // Recovery read: round.json still says both seats pending.
+    const recovered = readRound(roundFile);
+    expect(recovered).toEqual(base);
+    expect(recovered?.seats.reviewer_a).toBe("pending");
+    expect(recovered?.seats.reviewer_b).toBe("pending");
+
+    // Critique file is preserved for post-mortem per SPEC §7 ("Partial
+    // outputs on disk are preserved ... but never read as complete
+    // critiques"), but the resume logic will ignore it because
+    // round.json.seats.* != "ok".
+    expect(existsSync(critiqueFile)).toBe(true);
+    expect(readFileSync(critiqueFile, "utf8")).toContain("Partial critique");
+  });
+});

--- a/tests/state/lock.hooks.test.ts
+++ b/tests/state/lock.hooks.test.ts
@@ -35,22 +35,22 @@ describe("state/lock — installReleaseHooks (SPEC §8)", () => {
 
     // Collected via a spy emitter so we never install real signal handlers
     // into the Bun test runner (which would leak across tests).
-    const listeners: Record<string, () => void> = {};
+    const listeners = new Map<string, () => void>();
     const detach = installReleaseHooks(handle, {
       onSignal: (sig, cb) => {
-        listeners[sig] = cb;
+        listeners.set(sig, cb);
       },
       onExit: (cb) => {
-        listeners.exit = cb;
+        listeners.set("exit", cb);
       },
     });
 
-    expect(listeners.SIGINT).toBeDefined();
-    expect(listeners.SIGTERM).toBeDefined();
-    expect(listeners.exit).toBeDefined();
+    expect(listeners.get("SIGINT")).toBeDefined();
+    expect(listeners.get("SIGTERM")).toBeDefined();
+    expect(listeners.get("exit")).toBeDefined();
 
     // Simulate an exit firing the hook.
-    listeners.exit?.();
+    listeners.get("exit")?.();
     expect(existsSync(lockPath)).toBe(false);
 
     detach();

--- a/tests/state/lock.hooks.test.ts
+++ b/tests/state/lock.hooks.test.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  acquireLock,
+  installReleaseHooks,
+  releaseLock,
+} from "../../src/state/lock.ts";
+
+let tmp: string;
+let lockPath: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-lock-hooks-"));
+  mkdirSync(path.join(tmp, ".samospec"), { recursive: true });
+  lockPath = path.join(tmp, ".samospec", ".lock");
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("state/lock — installReleaseHooks (SPEC §8)", () => {
+  test("returns a detach function; calling it removes listeners and releases", () => {
+    const handle = acquireLock({
+      lockPath,
+      slug: "demo",
+      now: Date.now(),
+      maxWallClockMinutes: 240,
+    });
+
+    // Collected via a spy emitter so we never install real signal handlers
+    // into the Bun test runner (which would leak across tests).
+    const listeners: Record<string, () => void> = {};
+    const detach = installReleaseHooks(handle, {
+      onSignal: (sig, cb) => {
+        listeners[sig] = cb;
+      },
+      onExit: (cb) => {
+        listeners.exit = cb;
+      },
+    });
+
+    expect(listeners.SIGINT).toBeDefined();
+    expect(listeners.SIGTERM).toBeDefined();
+    expect(listeners.exit).toBeDefined();
+
+    // Simulate an exit firing the hook.
+    listeners.exit?.();
+    expect(existsSync(lockPath)).toBe(false);
+
+    detach();
+  });
+
+  test("detach function unregisters the previously installed listeners", () => {
+    const handle = acquireLock({
+      lockPath,
+      slug: "demo",
+      now: Date.now(),
+      maxWallClockMinutes: 240,
+    });
+
+    const removed: string[] = [];
+    const detach = installReleaseHooks(handle, {
+      onSignal: () => {
+        /* no-op */
+      },
+      onExit: () => {
+        /* no-op */
+      },
+      offSignal: (sig) => {
+        removed.push(sig);
+      },
+      offExit: () => {
+        removed.push("exit");
+      },
+    });
+
+    detach();
+    expect(removed.sort()).toEqual(["SIGINT", "SIGTERM", "exit"].sort());
+    releaseLock(handle);
+  });
+});

--- a/tests/state/lock.test.ts
+++ b/tests/state/lock.test.ts
@@ -1,0 +1,248 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  LockContendedError,
+  LockStaleReason,
+  StaleLockInfo,
+  acquireLock,
+  isLockStale,
+  readLock,
+  releaseLock,
+} from "../../src/state/lock.ts";
+
+const MINUTE = 60_000;
+
+let tmp: string;
+let lockPath: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-lock-"));
+  mkdirSync(path.join(tmp, ".samospec"), { recursive: true });
+  lockPath = path.join(tmp, ".samospec", ".lock");
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function aliveButNotUs(): number {
+  // PID 1 is guaranteed alive on POSIX and not us; used to simulate a
+  // live concurrent owner without actually spawning a second process.
+  return 1;
+}
+
+describe("state/lock — acquire + release", () => {
+  test("acquireLock creates the lock file with pid + slug + started_at", () => {
+    const handle = acquireLock({
+      lockPath,
+      slug: "demo",
+      now: Date.now(),
+      maxWallClockMinutes: 240,
+    });
+    expect(existsSync(lockPath)).toBe(true);
+    const onDisk = readLock(lockPath);
+    expect(onDisk?.pid).toBe(handle.pid);
+    expect(onDisk?.slug).toBe("demo");
+    releaseLock(handle);
+  });
+
+  test("releaseLock removes the lock file", () => {
+    const handle = acquireLock({
+      lockPath,
+      slug: "demo",
+      now: Date.now(),
+      maxWallClockMinutes: 240,
+    });
+    releaseLock(handle);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("releaseLock is idempotent on an already-gone file", () => {
+    const handle = acquireLock({
+      lockPath,
+      slug: "demo",
+      now: Date.now(),
+      maxWallClockMinutes: 240,
+    });
+    releaseLock(handle);
+    releaseLock(handle); // must not throw
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("a second acquire while held throws LockContendedError with PID message", () => {
+    const first = acquireLock({
+      lockPath,
+      slug: "demo",
+      now: Date.now(),
+      maxWallClockMinutes: 240,
+    });
+    expect(() =>
+      acquireLock({
+        lockPath,
+        slug: "demo",
+        now: Date.now(),
+        maxWallClockMinutes: 240,
+      }),
+    ).toThrow(LockContendedError);
+    try {
+      acquireLock({
+        lockPath,
+        slug: "demo",
+        now: Date.now(),
+        maxWallClockMinutes: 240,
+      });
+    } catch (err) {
+      expect((err as Error).message).toContain(String(first.pid));
+    }
+    releaseLock(first);
+  });
+});
+
+describe("state/lock — stale detection (SPEC §8)", () => {
+  test("isLockStale returns null for a fresh live-PID lock", () => {
+    const now = Date.now();
+    const info: StaleLockInfo = {
+      lock: {
+        pid: process.pid, // alive, and known-fresh
+        slug: "demo",
+        started_at: new Date(now - MINUTE).toISOString(),
+      },
+      now,
+      maxWallClockMinutes: 240,
+    };
+    expect(isLockStale(info)).toBeNull();
+  });
+
+  test("isLockStale reports pid_dead when the PID is gone", () => {
+    const now = Date.now();
+    const info: StaleLockInfo = {
+      lock: {
+        // Very large PID unlikely to exist.
+        pid: 99999999,
+        slug: "demo",
+        started_at: new Date(now - MINUTE).toISOString(),
+      },
+      now,
+      maxWallClockMinutes: 240,
+    };
+    expect(isLockStale(info)).toBe<LockStaleReason>("pid_dead");
+  });
+
+  test("isLockStale reports age_exceeded past max_wall_clock + 30min buffer", () => {
+    const now = Date.now();
+    const info: StaleLockInfo = {
+      lock: {
+        // Use our own PID so the pid_dead path does not short-circuit;
+        // ensure age is older than 240 + 30 minutes.
+        pid: process.pid,
+        slug: "demo",
+        started_at: new Date(now - (240 + 31) * MINUTE).toISOString(),
+      },
+      now,
+      maxWallClockMinutes: 240,
+    };
+    expect(isLockStale(info)).toBe<LockStaleReason>("age_exceeded");
+  });
+
+  test("isLockStale honours a custom maxWallClockMinutes", () => {
+    const now = Date.now();
+    const info: StaleLockInfo = {
+      lock: {
+        pid: process.pid,
+        slug: "demo",
+        started_at: new Date(now - 40 * MINUTE).toISOString(),
+      },
+      now,
+      maxWallClockMinutes: 5, // 5 + 30 = 35 buffer, age 40 is stale
+    };
+    expect(isLockStale(info)).toBe<LockStaleReason>("age_exceeded");
+  });
+});
+
+describe("state/lock — acquire against stale file", () => {
+  test("acquireLock auto-removes a stale lock and succeeds", () => {
+    const now = Date.now();
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: 99999999,
+        slug: "demo",
+        started_at: new Date(now - MINUTE).toISOString(),
+      }),
+      "utf8",
+    );
+    const handle = acquireLock({
+      lockPath,
+      slug: "demo",
+      now,
+      maxWallClockMinutes: 240,
+    });
+    expect(handle.pid).toBe(process.pid);
+    releaseLock(handle);
+  });
+
+  test("acquireLock refuses when holder is alive and lock is fresh", () => {
+    const now = Date.now();
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: aliveButNotUs(),
+        slug: "demo",
+        started_at: new Date(now - MINUTE).toISOString(),
+      }),
+      "utf8",
+    );
+    expect(() =>
+      acquireLock({
+        lockPath,
+        slug: "demo",
+        now,
+        maxWallClockMinutes: 240,
+      }),
+    ).toThrow(LockContendedError);
+  });
+
+  test("acquireLock auto-removes an age-exceeded lock even if PID is alive", () => {
+    const now = Date.now();
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        pid: aliveButNotUs(),
+        slug: "demo",
+        started_at: new Date(now - (240 + 31) * MINUTE).toISOString(),
+      }),
+      "utf8",
+    );
+    const handle = acquireLock({
+      lockPath,
+      slug: "demo",
+      now,
+      maxWallClockMinutes: 240,
+    });
+    expect(handle.pid).toBe(process.pid);
+    releaseLock(handle);
+  });
+
+  test("acquireLock overwrites a malformed lock file as if stale", () => {
+    writeFileSync(lockPath, "not json at all", "utf8");
+    const handle = acquireLock({
+      lockPath,
+      slug: "demo",
+      now: Date.now(),
+      maxWallClockMinutes: 240,
+    });
+    expect(handle.pid).toBe(process.pid);
+    releaseLock(handle);
+  });
+});

--- a/tests/state/lock.test.ts
+++ b/tests/state/lock.test.ts
@@ -13,12 +13,12 @@ import path from "node:path";
 
 import {
   LockContendedError,
-  LockStaleReason,
-  StaleLockInfo,
   acquireLock,
   isLockStale,
   readLock,
   releaseLock,
+  type LockStaleReason,
+  type StaleLockInfo,
 } from "../../src/state/lock.ts";
 
 const MINUTE = 60_000;
@@ -81,27 +81,27 @@ describe("state/lock — acquire + release", () => {
   });
 
   test("a second acquire while held throws LockContendedError with PID message", () => {
+    // Simulate a second invocation by using a distinct pid + alive probe.
+    const firstPid = process.pid;
     const first = acquireLock({
       lockPath,
       slug: "demo",
       now: Date.now(),
       maxWallClockMinutes: 240,
+      pid: firstPid,
     });
-    expect(() =>
-      acquireLock({
-        lockPath,
-        slug: "demo",
-        now: Date.now(),
-        maxWallClockMinutes: 240,
-      }),
-    ).toThrow(LockContendedError);
+    const secondArgs = {
+      lockPath,
+      slug: "demo",
+      now: Date.now(),
+      maxWallClockMinutes: 240,
+      pid: firstPid + 1,
+      // Treat the first-PID holder as alive even from the second caller.
+      isPidAlive: () => true,
+    };
+    expect(() => acquireLock(secondArgs)).toThrow(LockContendedError);
     try {
-      acquireLock({
-        lockPath,
-        slug: "demo",
-        now: Date.now(),
-        maxWallClockMinutes: 240,
-      });
+      acquireLock(secondArgs);
     } catch (err) {
       expect((err as Error).message).toContain(String(first.pid));
     }

--- a/tests/state/phase.test.ts
+++ b/tests/state/phase.test.ts
@@ -1,0 +1,119 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  isLegalPhaseTransition,
+  advancePhase,
+  PHASE_ORDER,
+  PhaseTransitionError,
+} from "../../src/state/phase.ts";
+import { PHASES, type Phase } from "../../src/state/types.ts";
+
+describe("state/phase — phase table (SPEC §5)", () => {
+  test("PHASE_ORDER matches the canonical SPEC §5 order", () => {
+    expect(PHASE_ORDER).toEqual([...PHASES]);
+  });
+});
+
+describe("state/phase — legality predicate", () => {
+  test("forward-by-one transitions are legal", () => {
+    for (let i = 0; i < PHASE_ORDER.length - 1; i++) {
+      const from = PHASE_ORDER[i] as Phase;
+      const to = PHASE_ORDER[i + 1] as Phase;
+      expect(isLegalPhaseTransition(from, to)).toBe(true);
+    }
+  });
+
+  test("self-transitions are legal (re-entrancy during retries)", () => {
+    for (const p of PHASE_ORDER) {
+      expect(isLegalPhaseTransition(p, p)).toBe(true);
+    }
+  });
+
+  test("backward transitions are always illegal", () => {
+    for (let i = 1; i < PHASE_ORDER.length; i++) {
+      for (let j = 0; j < i; j++) {
+        const from = PHASE_ORDER[i] as Phase;
+        const to = PHASE_ORDER[j] as Phase;
+        expect(isLegalPhaseTransition(from, to)).toBe(false);
+      }
+    }
+  });
+
+  test("skipping phases forward is illegal", () => {
+    expect(isLegalPhaseTransition("detect", "persona")).toBe(false);
+    expect(isLegalPhaseTransition("context", "draft")).toBe(false);
+    expect(isLegalPhaseTransition("interview", "publish")).toBe(false);
+  });
+});
+
+describe("state/phase — advancePhase", () => {
+  test("advances forward by one and stamps updated_at", () => {
+    const before = {
+      slug: "demo",
+      phase: "detect" as Phase,
+      round_index: 0,
+      version: "0.0.0",
+      persona: null,
+      push_consent: null,
+      calibration: null,
+      remote_stale: false,
+      coupled_fallback: false,
+      round_state: "planned" as const,
+      exit: null,
+      created_at: "2026-04-19T00:00:00.000Z",
+      updated_at: "2026-04-19T00:00:00.000Z",
+    };
+    const after = advancePhase(before, "branch_lock_preflight", {
+      now: "2026-04-19T00:00:01.000Z",
+    });
+    expect(after.phase).toBe("branch_lock_preflight");
+    expect(after.updated_at).toBe("2026-04-19T00:00:01.000Z");
+    expect(after.created_at).toBe("2026-04-19T00:00:00.000Z");
+  });
+
+  test("throws PhaseTransitionError for illegal backward move", () => {
+    const before = {
+      slug: "demo",
+      phase: "review_loop" as Phase,
+      round_index: 0,
+      version: "0.0.0",
+      persona: null,
+      push_consent: null,
+      calibration: null,
+      remote_stale: false,
+      coupled_fallback: false,
+      round_state: "planned" as const,
+      exit: null,
+      created_at: "2026-04-19T00:00:00.000Z",
+      updated_at: "2026-04-19T00:00:00.000Z",
+    };
+    expect(() =>
+      advancePhase(before, "detect", { now: "2026-04-19T00:00:01.000Z" }),
+    ).toThrow(PhaseTransitionError);
+  });
+
+  test("allows self-transition to stamp updated_at without phase change", () => {
+    const before = {
+      slug: "demo",
+      phase: "interview" as Phase,
+      round_index: 0,
+      version: "0.0.0",
+      persona: null,
+      push_consent: null,
+      calibration: null,
+      remote_stale: false,
+      coupled_fallback: false,
+      round_state: "planned" as const,
+      exit: null,
+      created_at: "2026-04-19T00:00:00.000Z",
+      updated_at: "2026-04-19T00:00:00.000Z",
+    };
+    const after = advancePhase(before, "interview", {
+      now: "2026-04-19T00:00:01.000Z",
+    });
+    expect(after.phase).toBe("interview");
+    expect(after.updated_at).toBe("2026-04-19T00:00:01.000Z");
+  });
+});

--- a/tests/state/phase.test.ts
+++ b/tests/state/phase.test.ts
@@ -19,8 +19,9 @@ describe("state/phase — phase table (SPEC §5)", () => {
 describe("state/phase — legality predicate", () => {
   test("forward-by-one transitions are legal", () => {
     for (let i = 0; i < PHASE_ORDER.length - 1; i++) {
-      const from = PHASE_ORDER[i] as Phase;
-      const to = PHASE_ORDER[i + 1] as Phase;
+      const from = PHASE_ORDER[i];
+      const to = PHASE_ORDER[i + 1];
+      if (from === undefined || to === undefined) continue;
       expect(isLegalPhaseTransition(from, to)).toBe(true);
     }
   });
@@ -34,8 +35,9 @@ describe("state/phase — legality predicate", () => {
   test("backward transitions are always illegal", () => {
     for (let i = 1; i < PHASE_ORDER.length; i++) {
       for (let j = 0; j < i; j++) {
-        const from = PHASE_ORDER[i] as Phase;
-        const to = PHASE_ORDER[j] as Phase;
+        const from = PHASE_ORDER[i];
+        const to = PHASE_ORDER[j];
+        if (from === undefined || to === undefined) continue;
         expect(isLegalPhaseTransition(from, to)).toBe(false);
       }
     }

--- a/tests/state/property.test.ts
+++ b/tests/state/property.test.ts
@@ -1,0 +1,220 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  PhaseTransitionError,
+  advancePhase,
+  PHASE_ORDER,
+} from "../../src/state/phase.ts";
+import {
+  ROUND_TRANSITIONS,
+  RoundTransitionError,
+  applyRoundTransition,
+} from "../../src/state/round.ts";
+import { readState, writeState, newState } from "../../src/state/store.ts";
+import {
+  ROUND_STATES,
+  type Phase,
+  type RoundState,
+  type State,
+} from "../../src/state/types.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-prop-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+// Arbitrary: non-negative integer timestamp in ISO form.
+const isoTimeArb = fc
+  .integer({ min: 0, max: 4_000_000_000_000 })
+  .map((ms) => new Date(ms).toISOString());
+
+type Action =
+  | { readonly kind: "advancePhase"; readonly to: Phase; readonly now: string }
+  | {
+      readonly kind: "applyRound";
+      readonly to: RoundState;
+      readonly now: string;
+    };
+
+const phaseActionArb: fc.Arbitrary<Action> = fc.record({
+  kind: fc.constant("advancePhase" as const),
+  to: fc.constantFrom(...PHASE_ORDER),
+  now: isoTimeArb,
+});
+
+const roundActionArb: fc.Arbitrary<Action> = fc.record({
+  kind: fc.constant("applyRound" as const),
+  to: fc.constantFrom(...ROUND_STATES),
+  now: isoTimeArb,
+});
+
+const actionArb = fc.oneof(phaseActionArb, roundActionArb);
+
+function applyAction(state: State, a: Action): State {
+  if (a.kind === "advancePhase") {
+    return advancePhase(state, a.to, { now: a.now });
+  }
+  return applyRoundTransition(state, a.to, { now: a.now });
+}
+
+describe("state/phase + state/round — property-based invariants (SPEC §13 test 1)", () => {
+  test("state.json is always parseable after any legal action sequence", () => {
+    fc.assert(
+      fc.property(fc.array(actionArb, { maxLength: 30 }), (actions) => {
+        const file = path.join(tmp, `state-${Math.random()}.json`);
+        let state = newState({
+          slug: "demo",
+          now: "2026-04-19T00:00:00.000Z",
+        });
+        writeState(file, state);
+
+        for (const a of actions) {
+          try {
+            state = applyAction(state, a);
+            writeState(file, state);
+          } catch (err) {
+            if (
+              err instanceof PhaseTransitionError ||
+              err instanceof RoundTransitionError
+            ) {
+              continue; // illegal action: ignored, file must remain valid
+            }
+            throw err;
+          }
+          const reread = readState(file);
+          expect(reread).toEqual(state);
+        }
+      }),
+      { numRuns: 150 },
+    );
+  });
+
+  test("phase never goes backwards through any legal sequence", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.constantFrom(...PHASE_ORDER), { maxLength: 40 }),
+        fc.array(isoTimeArb, { maxLength: 40 }),
+        (targets, times) => {
+          let state = newState({
+            slug: "demo",
+            now: "2026-04-19T00:00:00.000Z",
+          });
+          let prevIndex = PHASE_ORDER.indexOf(state.phase);
+          for (let i = 0; i < targets.length; i++) {
+            const to = targets[i];
+            const now = times[i] ?? "2026-04-19T00:00:00.000Z";
+            if (to === undefined) continue;
+            try {
+              state = advancePhase(state, to, { now });
+            } catch {
+              continue;
+            }
+            const idx = PHASE_ORDER.indexOf(state.phase);
+            expect(idx).toBeGreaterThanOrEqual(prevIndex);
+            prevIndex = idx;
+          }
+        },
+      ),
+      { numRuns: 150 },
+    );
+  });
+
+  test("version is monotonically non-decreasing across writes", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            major: fc.integer({ min: 0, max: 10 }),
+            minor: fc.integer({ min: 0, max: 99 }),
+            patch: fc.integer({ min: 0, max: 99 }),
+          }),
+          { maxLength: 20 },
+        ),
+        (bumps) => {
+          const file = path.join(tmp, `state-${Math.random()}.json`);
+          let state = newState({
+            slug: "demo",
+            now: "2026-04-19T00:00:00.000Z",
+          });
+          writeState(file, state);
+          let prev = state.version;
+          const sorted = [...bumps].sort(
+            (a, b) =>
+              a.major - b.major || a.minor - b.minor || a.patch - b.patch,
+          );
+          for (const b of sorted) {
+            const next = `${b.major}.${b.minor}.${b.patch}`;
+            const bumpedState: State = {
+              ...state,
+              version: next,
+              updated_at: "2026-04-19T00:00:01.000Z",
+            };
+            // Only write when non-decreasing — we are asserting invariance
+            // under the write path, not testing the external bumper.
+            if (cmpSemver(next, prev) < 0) continue;
+            state = bumpedState;
+            writeState(file, state);
+            const reread = readState(file);
+            expect(reread?.version).toBe(next);
+            expect(
+              cmpSemver(reread?.version ?? "0.0.0", prev),
+            ).toBeGreaterThanOrEqual(0);
+            prev = next;
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  test("round transitions always land on a state listed in ROUND_TRANSITIONS", () => {
+    fc.assert(
+      fc.property(fc.array(roundActionArb, { maxLength: 50 }), (actions) => {
+        let state = newState({
+          slug: "demo",
+          now: "2026-04-19T00:00:00.000Z",
+        });
+        for (const a of actions) {
+          const before = state.round_state;
+          const allowed = ROUND_TRANSITIONS[before];
+          try {
+            state = applyAction(state, a);
+          } catch (err) {
+            if (err instanceof RoundTransitionError) {
+              expect(allowed).not.toContain(
+                a.kind === "applyRound" ? a.to : before,
+              );
+              continue;
+            }
+            throw err;
+          }
+          if (a.kind !== "applyRound") continue;
+          expect(allowed).toContain(a.to);
+        }
+      }),
+      { numRuns: 150 },
+    );
+  });
+});
+
+function cmpSemver(a: string, b: string): number {
+  const pa = a.split(".").map((x) => Number(x));
+  const pb = b.split(".").map((x) => Number(x));
+  for (let i = 0; i < 3; i++) {
+    const ai = pa[i] ?? 0;
+    const bi = pb[i] ?? 0;
+    if (ai !== bi) return ai - bi;
+  }
+  return 0;
+}

--- a/tests/state/round.test.ts
+++ b/tests/state/round.test.ts
@@ -1,0 +1,215 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  ROUND_TRANSITIONS,
+  RoundTransitionError,
+  applyRoundTransition,
+  isLegalRoundTransition,
+  newRound,
+  readRound,
+  roundDirFor,
+  writeRound,
+} from "../../src/state/round.ts";
+import {
+  ROUND_STATES,
+  type Round,
+  type RoundState,
+} from "../../src/state/types.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-round-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("state/round — transition table (SPEC §7)", () => {
+  test("ROUND_TRANSITIONS matches the SPEC §7 table exactly", () => {
+    // From SPEC §7 round state machine:
+    // planned -> running
+    // running -> reviews_collected | lead_terminal | running (retry-in-place)
+    // reviews_collected -> lead_revised | lead_terminal
+    // lead_revised -> committed | lead_terminal
+    // committed -> planned (start next round)
+    // lead_terminal is terminal (no outgoing)
+    expect(ROUND_TRANSITIONS.planned.sort()).toEqual(["running"]);
+    expect(ROUND_TRANSITIONS.running.sort()).toEqual(
+      ["lead_terminal", "reviews_collected", "running"].sort(),
+    );
+    expect(ROUND_TRANSITIONS.reviews_collected.sort()).toEqual(
+      ["lead_revised", "lead_terminal"].sort(),
+    );
+    expect(ROUND_TRANSITIONS.lead_revised.sort()).toEqual(
+      ["committed", "lead_terminal"].sort(),
+    );
+    expect(ROUND_TRANSITIONS.committed.sort()).toEqual(["planned"]);
+    expect(ROUND_TRANSITIONS.lead_terminal).toEqual([]);
+  });
+
+  test("isLegalRoundTransition accepts every entry in the table", () => {
+    for (const from of ROUND_STATES) {
+      const targets = ROUND_TRANSITIONS[from];
+      for (const to of targets) {
+        expect(isLegalRoundTransition(from, to)).toBe(true);
+      }
+    }
+  });
+
+  test("isLegalRoundTransition rejects any pair not in the table", () => {
+    for (const from of ROUND_STATES) {
+      const allowed = new Set<RoundState>(ROUND_TRANSITIONS[from]);
+      for (const to of ROUND_STATES) {
+        if (allowed.has(to)) continue;
+        expect(isLegalRoundTransition(from, to)).toBe(false);
+      }
+    }
+  });
+
+  test("lead_terminal has no outgoing transitions", () => {
+    for (const to of ROUND_STATES) {
+      expect(isLegalRoundTransition("lead_terminal", to)).toBe(false);
+    }
+  });
+});
+
+describe("state/round — applyRoundTransition", () => {
+  const base = {
+    slug: "demo",
+    phase: "review_loop" as const,
+    round_index: 1,
+    version: "0.1.0",
+    persona: null,
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    round_state: "planned" as const,
+    exit: null,
+    created_at: "2026-04-19T00:00:00.000Z",
+    updated_at: "2026-04-19T00:00:00.000Z",
+  };
+
+  test("legal transition bumps round_state and updated_at", () => {
+    const after = applyRoundTransition(base, "running", {
+      now: "2026-04-19T00:01:00.000Z",
+    });
+    expect(after.round_state).toBe("running");
+    expect(after.updated_at).toBe("2026-04-19T00:01:00.000Z");
+    expect(after.round_index).toBe(1);
+  });
+
+  test("committed -> planned bumps round_index by 1", () => {
+    const before = { ...base, round_state: "committed" as const };
+    const after = applyRoundTransition(before, "planned", {
+      now: "2026-04-19T00:02:00.000Z",
+    });
+    expect(after.round_state).toBe("planned");
+    expect(after.round_index).toBe(2);
+  });
+
+  test("illegal transition throws RoundTransitionError", () => {
+    expect(() =>
+      applyRoundTransition(base, "committed", {
+        now: "2026-04-19T00:02:00.000Z",
+      }),
+    ).toThrow(RoundTransitionError);
+  });
+
+  test("lead_terminal is absorbing — no outgoing transition succeeds", () => {
+    const terminal = { ...base, round_state: "lead_terminal" as const };
+    for (const to of ROUND_STATES) {
+      expect(() =>
+        applyRoundTransition(terminal, to, {
+          now: "2026-04-19T00:03:00.000Z",
+        }),
+      ).toThrow(RoundTransitionError);
+    }
+  });
+});
+
+describe("state/round — round.json sidecar (SPEC §7)", () => {
+  test("newRound returns a planned round with both seats pending", () => {
+    const r = newRound({ round: 3, now: "2026-04-19T01:00:00.000Z" });
+    expect(r).toEqual({
+      round: 3,
+      status: "planned",
+      seats: { reviewer_a: "pending", reviewer_b: "pending" },
+      started_at: "2026-04-19T01:00:00.000Z",
+    });
+  });
+
+  test("roundDirFor formats the rNN directory per SPEC §9", () => {
+    expect(roundDirFor("/specs/demo/reviews", 1)).toBe(
+      "/specs/demo/reviews/r01",
+    );
+    expect(roundDirFor("/specs/demo/reviews", 12)).toBe(
+      "/specs/demo/reviews/r12",
+    );
+  });
+
+  test("writeRound + readRound round-trip a round record", () => {
+    const file = path.join(tmp, "r01", "round.json");
+    const r: Round = newRound({
+      round: 1,
+      now: "2026-04-19T02:00:00.000Z",
+    });
+    writeRound(file, r);
+    const loaded = readRound(file);
+    expect(loaded).toEqual(r);
+  });
+
+  test("readRound returns null on missing file", () => {
+    const file = path.join(tmp, "missing.json");
+    expect(readRound(file)).toBeNull();
+  });
+
+  test("readRound throws on malformed JSON", () => {
+    const file = path.join(tmp, "round.json");
+    writeFileSync(file, "not json", "utf8");
+    expect(() => readRound(file)).toThrow(/round\.json/);
+  });
+
+  test("readRound throws on schema violation", () => {
+    const file = path.join(tmp, "round.json");
+    writeFileSync(
+      file,
+      JSON.stringify({ round: 1, status: "???" }),
+      "utf8",
+    );
+    expect(() => readRound(file)).toThrow(/round\.json/);
+  });
+
+  test("writeRound is atomic: no .tmp sibling left behind on success", () => {
+    const dir = path.join(tmp, "atomic");
+    const file = path.join(dir, "round.json");
+    const r = newRound({ round: 1, now: "2026-04-19T03:00:00.000Z" });
+    writeRound(file, r);
+    expect(existsSync(file)).toBe(true);
+    expect(readdirSync(dir)).toEqual(["round.json"]);
+  });
+
+  test("writeRound refuses an invalid round record", () => {
+    const file = path.join(tmp, "round.json");
+    const bogus = {
+      round: 0,
+      status: "planned",
+      seats: { reviewer_a: "pending", reviewer_b: "pending" },
+      started_at: "2026-04-19T00:00:00.000Z",
+    } as unknown as Round;
+    expect(() => writeRound(file, bogus)).toThrow(/round/i);
+  });
+});

--- a/tests/state/round.test.ts
+++ b/tests/state/round.test.ts
@@ -46,17 +46,18 @@ describe("state/round — transition table (SPEC §7)", () => {
     // lead_revised -> committed | lead_terminal
     // committed -> planned (start next round)
     // lead_terminal is terminal (no outgoing)
-    expect(ROUND_TRANSITIONS.planned.sort()).toEqual(["running"]);
-    expect(ROUND_TRANSITIONS.running.sort()).toEqual(
-      ["lead_terminal", "reviews_collected", "running"].sort(),
+    const asSet = (xs: readonly RoundState[]): Set<RoundState> => new Set(xs);
+    expect(asSet(ROUND_TRANSITIONS.planned)).toEqual(asSet(["running"]));
+    expect(asSet(ROUND_TRANSITIONS.running)).toEqual(
+      asSet(["reviews_collected", "lead_terminal", "running"]),
     );
-    expect(ROUND_TRANSITIONS.reviews_collected.sort()).toEqual(
-      ["lead_revised", "lead_terminal"].sort(),
+    expect(asSet(ROUND_TRANSITIONS.reviews_collected)).toEqual(
+      asSet(["lead_revised", "lead_terminal"]),
     );
-    expect(ROUND_TRANSITIONS.lead_revised.sort()).toEqual(
-      ["committed", "lead_terminal"].sort(),
+    expect(asSet(ROUND_TRANSITIONS.lead_revised)).toEqual(
+      asSet(["committed", "lead_terminal"]),
     );
-    expect(ROUND_TRANSITIONS.committed.sort()).toEqual(["planned"]);
+    expect(asSet(ROUND_TRANSITIONS.committed)).toEqual(asSet(["planned"]));
     expect(ROUND_TRANSITIONS.lead_terminal).toEqual([]);
   });
 
@@ -185,11 +186,7 @@ describe("state/round — round.json sidecar (SPEC §7)", () => {
 
   test("readRound throws on schema violation", () => {
     const file = path.join(tmp, "round.json");
-    writeFileSync(
-      file,
-      JSON.stringify({ round: 1, status: "???" }),
-      "utf8",
-    );
+    writeFileSync(file, JSON.stringify({ round: 1, status: "???" }), "utf8");
     expect(() => readRound(file)).toThrow(/round\.json/);
   });
 

--- a/tests/state/store.test.ts
+++ b/tests/state/store.test.ts
@@ -1,0 +1,108 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  readState,
+  writeState,
+  readStateOrThrow,
+  newState,
+} from "../../src/state/store.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-store-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("state/store — read + write (SPEC §7)", () => {
+  test("writeState + readState round-trips a fresh state", () => {
+    const file = path.join(tmp, "state.json");
+    const fresh = newState({ slug: "demo", now: "2026-04-19T00:00:00.000Z" });
+    writeState(file, fresh);
+    const loaded = readState(file);
+    expect(loaded).toEqual(fresh);
+  });
+
+  test("readState returns null when the file is absent", () => {
+    const file = path.join(tmp, "missing.json");
+    expect(readState(file)).toBeNull();
+  });
+
+  test("readStateOrThrow throws when the file is absent", () => {
+    const file = path.join(tmp, "missing.json");
+    expect(() => readStateOrThrow(file)).toThrow(/not found/i);
+  });
+
+  test("readState throws a clear error when the file is malformed JSON", () => {
+    const file = path.join(tmp, "state.json");
+    writeFileSync(file, "not json at all", "utf8");
+    expect(() => readState(file)).toThrow(/state\.json/);
+  });
+
+  test("readState throws a clear error when the schema is violated", () => {
+    const file = path.join(tmp, "state.json");
+    writeFileSync(file, JSON.stringify({ slug: "demo" }), "utf8");
+    expect(() => readState(file)).toThrow(/state\.json/);
+  });
+
+  test("writeState creates the parent directory if missing", () => {
+    const file = path.join(tmp, "nested", "deep", "state.json");
+    const fresh = newState({ slug: "demo", now: "2026-04-19T00:00:00.000Z" });
+    writeState(file, fresh);
+    expect(existsSync(file)).toBe(true);
+  });
+
+  test("writeState is atomic: no temp file left after success", () => {
+    const dir = path.join(tmp, "atomic");
+    mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, "state.json");
+    writeState(
+      file,
+      newState({ slug: "demo", now: "2026-04-19T00:00:00.000Z" }),
+    );
+    const entries = readdirSync(dir);
+    // Only the final file; the .tmp.* sibling has been renamed away.
+    expect(entries).toEqual(["state.json"]);
+  });
+
+  test("writeState preserves the previous file if called with an invalid state", () => {
+    const file = path.join(tmp, "state.json");
+    const fresh = newState({ slug: "demo", now: "2026-04-19T00:00:00.000Z" });
+    writeState(file, fresh);
+    const bogus = { ...fresh, phase: "not_a_phase" } as unknown as typeof fresh;
+    expect(() => writeState(file, bogus)).toThrow(/state/i);
+    const reread = readState(file);
+    expect(reread).toEqual(fresh);
+  });
+
+  test("newState starts in detect phase, round 0, planned, version 0.0.0", () => {
+    const s = newState({ slug: "demo", now: "2026-04-19T00:00:00.000Z" });
+    expect(s.phase).toBe("detect");
+    expect(s.round_index).toBe(0);
+    expect(s.round_state).toBe("planned");
+    expect(s.version).toBe("0.0.0");
+    expect(s.remote_stale).toBe(false);
+    expect(s.coupled_fallback).toBe(false);
+    expect(s.persona).toBeNull();
+    expect(s.push_consent).toBeNull();
+    expect(s.calibration).toBeNull();
+    expect(s.exit).toBeNull();
+    expect(s.created_at).toBe("2026-04-19T00:00:00.000Z");
+    expect(s.updated_at).toBe("2026-04-19T00:00:00.000Z");
+  });
+});

--- a/tests/state/types.test.ts
+++ b/tests/state/types.test.ts
@@ -1,0 +1,218 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  PHASES,
+  ROUND_STATES,
+  SEAT_STATES,
+  ROUND_STATUSES,
+  stateSchema,
+  roundSchema,
+  lockSchema,
+  type Phase,
+  type RoundState,
+} from "../../src/state/types.ts";
+
+const minimalState = {
+  slug: "demo",
+  phase: "detect" as Phase,
+  round_index: 0,
+  version: "0.0.0",
+  persona: null,
+  push_consent: null,
+  calibration: null,
+  remote_stale: false,
+  coupled_fallback: false,
+  round_state: "planned" as RoundState,
+  exit: null,
+  created_at: "2026-04-19T00:00:00.000Z",
+  updated_at: "2026-04-19T00:00:00.000Z",
+};
+
+describe("state/types — phase + round state tables (SPEC §5, §7)", () => {
+  test("PHASES lists all eight SPEC §5 phases", () => {
+    expect(PHASES).toEqual([
+      "detect",
+      "branch_lock_preflight",
+      "persona",
+      "context",
+      "interview",
+      "draft",
+      "review_loop",
+      "publish",
+    ]);
+  });
+
+  test("ROUND_STATES lists the six SPEC §7 states", () => {
+    expect(ROUND_STATES).toEqual([
+      "planned",
+      "running",
+      "reviews_collected",
+      "lead_revised",
+      "committed",
+      "lead_terminal",
+    ]);
+  });
+
+  test("SEAT_STATES lists the five reviewer seat labels", () => {
+    expect(SEAT_STATES).toEqual([
+      "pending",
+      "ok",
+      "failed",
+      "schema_violation",
+      "timeout",
+    ]);
+  });
+
+  test("ROUND_STATUSES lists the five round sidecar status labels", () => {
+    expect(ROUND_STATUSES).toEqual([
+      "planned",
+      "running",
+      "complete",
+      "partial",
+      "abandoned",
+    ]);
+  });
+});
+
+describe("state/types — state.json zod schema (SPEC §5, §7)", () => {
+  test("accepts a minimal valid state with all required fields", () => {
+    const parsed = stateSchema.parse(minimalState);
+    expect(parsed.slug).toBe("demo");
+    expect(parsed.phase).toBe("detect");
+    expect(parsed.round_index).toBe(0);
+    expect(parsed.version).toBe("0.0.0");
+    expect(parsed.round_state).toBe("planned");
+    expect(parsed.remote_stale).toBe(false);
+    expect(parsed.coupled_fallback).toBe(false);
+  });
+
+  test("rejects an unknown phase value", () => {
+    const bad = { ...minimalState, phase: "bogus" };
+    expect(() => stateSchema.parse(bad)).toThrow();
+  });
+
+  test("rejects an unknown round_state value", () => {
+    const bad = { ...minimalState, round_state: "nope" };
+    expect(() => stateSchema.parse(bad)).toThrow();
+  });
+
+  test("rejects a negative round_index", () => {
+    const bad = { ...minimalState, round_index: -1 };
+    expect(() => stateSchema.parse(bad)).toThrow();
+  });
+
+  test("rejects a non-SemVer version string", () => {
+    const bad = { ...minimalState, version: "1.0" };
+    expect(() => stateSchema.parse(bad)).toThrow();
+  });
+
+  test("rejects extra unknown top-level fields", () => {
+    const bad = { ...minimalState, wat: true };
+    expect(() => stateSchema.parse(bad)).toThrow();
+  });
+
+  test("accepts a populated persona record", () => {
+    const parsed = stateSchema.parse({
+      ...minimalState,
+      persona: { skill: "security", accepted: true },
+    });
+    expect(parsed.persona?.skill).toBe("security");
+  });
+
+  test("accepts an exit record with reason + round_index", () => {
+    const parsed = stateSchema.parse({
+      ...minimalState,
+      exit: { code: 4, reason: "lead_terminal", round_index: 2 },
+    });
+    expect(parsed.exit?.code).toBe(4);
+  });
+});
+
+describe("state/types — round.json zod schema (SPEC §7)", () => {
+  test("accepts a minimal planned round", () => {
+    const parsed = roundSchema.parse({
+      round: 1,
+      status: "planned",
+      seats: { reviewer_a: "pending", reviewer_b: "pending" },
+      started_at: "2026-04-19T00:00:00.000Z",
+    });
+    expect(parsed.round).toBe(1);
+    expect(parsed.seats.reviewer_a).toBe("pending");
+  });
+
+  test("allows completed_at on a completed round", () => {
+    const parsed = roundSchema.parse({
+      round: 1,
+      status: "complete",
+      seats: { reviewer_a: "ok", reviewer_b: "ok" },
+      started_at: "2026-04-19T00:00:00.000Z",
+      completed_at: "2026-04-19T01:00:00.000Z",
+    });
+    expect(parsed.completed_at).toBeDefined();
+  });
+
+  test("rejects round index 0 (rounds are 1-indexed in SPEC §9)", () => {
+    expect(() =>
+      roundSchema.parse({
+        round: 0,
+        status: "planned",
+        seats: { reviewer_a: "pending", reviewer_b: "pending" },
+        started_at: "2026-04-19T00:00:00.000Z",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects an unknown seat label", () => {
+    expect(() =>
+      roundSchema.parse({
+        round: 1,
+        status: "planned",
+        seats: { reviewer_a: "zorp", reviewer_b: "pending" },
+        started_at: "2026-04-19T00:00:00.000Z",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("state/types — .lock zod schema (SPEC §8)", () => {
+  test("accepts a minimal lock record", () => {
+    const parsed = lockSchema.parse({
+      pid: 4242,
+      started_at: "2026-04-19T00:00:00.000Z",
+      slug: "demo",
+    });
+    expect(parsed.pid).toBe(4242);
+  });
+
+  test("rejects a non-integer pid", () => {
+    expect(() =>
+      lockSchema.parse({
+        pid: 4242.5,
+        started_at: "2026-04-19T00:00:00.000Z",
+        slug: "demo",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects a negative pid", () => {
+    expect(() =>
+      lockSchema.parse({
+        pid: -1,
+        started_at: "2026-04-19T00:00:00.000Z",
+        slug: "demo",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects an empty slug", () => {
+    expect(() =>
+      lockSchema.parse({
+        pid: 4242,
+        started_at: "2026-04-19T00:00:00.000Z",
+        slug: "",
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2.

Lands the Sprint 1 state primitives — phase machine, round state machine, and repo lockfile — behind zod schemas with atomic writes and stale-lock detection per SPEC §5, §7, and §8.

## Scope

- `src/state/types.ts` — `Phase`, `RoundState`, `SeatState`, `RoundStatus` enums + strict zod schemas for `state.json`, `round.json`, and `.samospec/.lock`. Schemas reject extra keys, negative counters, non-SemVer versions, and non-ISO-UTC timestamps.
- `src/state/store.ts` — atomic `readState` / `readStateOrThrow` / `writeState` with `.tmp` + fsync + rename + parent-dir fsync, so a crash mid-write never corrupts `state.json` (SPEC §7).
- `src/state/phase.ts` — `PHASE_ORDER`, `isLegalPhaseTransition` (forward-by-one + self only), `advancePhase`, `PhaseTransitionError`.
- `src/state/round.ts` — `ROUND_TRANSITIONS` table (including `lead_terminal` absorbing), `applyRoundTransition` (committed -> planned bumps `round_index`), `newRound`, `roundDirFor`, atomic `readRound` / `writeRound`.
- `src/state/lock.ts` — `acquireLock` / `releaseLock` / `isLockStale` + `installReleaseHooks` for SIGINT/SIGTERM/exit. Stale detection combines `process.kill(pid, 0)` + `started_at > max_wall_clock + 30min` per SPEC §8. Concurrent second invocation raises `LockContendedError` carrying the holder's PID for the exit-2 path.

## Acceptance criteria

### Phase machine (SPEC §5, §7)

- [x] Zod schema for `state.json` covering slug, phase, round_index, version, persona, push_consent, calibration, remote_stale, coupled_fallback, adapters, exit flags, timestamps.
- [x] Types for phases: `detect`, `branch_lock_preflight`, `persona`, `context`, `interview`, `draft`, `review_loop`, `publish`.
- [x] Read/write with atomic write (temp file + fsync + rename).
- [x] Schema-validated read on every invocation; malformed throws a contextual Error for exit-1 surface.

### Round state machine (SPEC §7)

- [x] Six states: `planned`, `running`, `reviews_collected`, `lead_revised`, `committed`, `lead_terminal`.
- [x] `round.json` sidecar schema `{ round, status, seats, started_at, completed_at? }`.
- [x] Invalid transitions throw `RoundTransitionError`.
- [x] Write ordering documented in code: critique write -> fsync -> `round.json` update -> fsync (see `src/state/round.ts` header comment on `ROUND_TRANSITIONS`).
- [x] Recovery rule validated in `tests/state/crash.test.ts`: orphan critique is preserved on disk but ignored because `round.json.seats.*` != `"ok"`.

### Repo lockfile (SPEC §8)

- [x] `.samospec/.lock` JSON `{ pid, started_at, slug }`.
- [x] Acquire on invocation; release hooks for normal exit + SIGINT + SIGTERM.
- [x] Stale detection via dead-PID probe OR age beyond `max_wall_clock + 30min`.
- [x] Concurrent second invocation throws `LockContendedError` whose message contains the holder's PID (-> exit 2 in the CLI layer).

### TDD requirement

- [x] Property-based tests via `fast-check` — 150 runs per property, locking in SPEC §13 test 1 invariants.
- [x] Unit tests for lockfile: acquire/release, stale-by-PID, stale-by-age, malformed-file-as-stale, concurrent-acquire.
- [x] Integration test: spawn Bun subprocess, kill mid-write, re-read `state.json`, assert byte-equality (SPEC §13 test 10).
- [x] Red-green history visible in the commit log: every feat commit is preceded by a test commit on the same surface.

## Testing evidence

```
$ bun test
bun test v1.3.5 (1e86cebd)

 79 pass
 0 fail
 2107 expect() calls
Ran 79 tests across 10 files. [198ms]
```

Property-test counts: 4 properties × 150 runs = 600 random action sequences exercised; ~1900 expect() calls inside the property block alone.

```
$ bun run test:coverage
File                | % Funcs | % Lines | Uncovered Line #s
--------------------|---------|---------|-------------------
All files           |   94.44 |   97.55 |
 src/cli.ts         |  100.00 |  100.00 |
 src/state/lock.ts  |   66.67 |   96.30 | 207,210,213,216
 src/state/phase.ts |  100.00 |  100.00 |
 src/state/round.ts |  100.00 |  100.00 |
 src/state/store.ts |  100.00 |   89.02 | 56-59,88,123,125-127
 src/state/types.ts |  100.00 |  100.00 |
```

- Overall lines 97.55% (well above SPEC §13 80% floor).
- `src/state/phase.ts`, `src/state/round.ts`, `src/state/types.ts` all at 100% functions + lines.
- Uncovered `state/store.ts` lines are I/O error-handler branches (read failure, rename failure) that are non-deterministic to trigger synthetically; remaining `state/lock.ts` lines are default-emitter adapter closures that use real `process.on` and are exercised via the injected emitter seam in tests.

```
$ bun run lint        # clean
$ bun run format:check # All matched files use Prettier code style!
$ bun run typecheck    # clean
```

## Out-of-scope / follow-ups

- Git layer integration (Issue #3).
- CLI commands that consume these primitives (Issue #4).
- Adapter contract (Issue #5).

This PR deliberately only lands the pure in-process state primitives so each of those follow-up issues can wire them without rebasing on a moving target.

Red-green TDD commit history is preserved for reviewer inspection.
