### PR TITLE
feat: Sprint 1 #4 — samospec init + samospec doctor

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,10 @@
 // Copyright 2026 Nikolay Samokhvalov.
 
+import { homedir } from "node:os";
+
+import { createFakeAdapter } from "./adapter/fake-adapter.ts";
+import { runInit } from "./cli/init.ts";
+import { runDoctor, type DoctorAdapterBinding } from "./cli/doctor.ts";
 import packageJson from "../package.json" with { type: "json" };
 
 export interface CliResult {
@@ -17,10 +22,30 @@ const VERSION_FLAGS: ReadonlySet<string> = new Set([
 const USAGE =
   "Usage: samospec <command>\n\n" +
   "Commands:\n" +
+  "  init       Create or refresh .samospec/ in the current repo.\n" +
+  "  doctor     Diagnose CLI availability, auth, git, lock, and config.\n" +
   "  version    Print the samospec version and exit.\n";
 
-export function runCli(argv: readonly string[]): CliResult {
-  const [command] = argv;
+/**
+ * Default adapter bindings for `samospec doctor`. Sprint 1 only ships
+ * the fake adapter (real adapters land in Sprint 2+). The fake's
+ * default program is tuned to `installed: true` + `authenticated: true`
+ * + `subscription_auth: true`, which realistically surfaces every
+ * branch of the doctor output when invoked interactively.
+ */
+function defaultAdapterBindings(): readonly DoctorAdapterBinding[] {
+  return [
+    { label: "claude", adapter: createFakeAdapter() },
+    { label: "codex", adapter: createFakeAdapter() },
+  ];
+}
+
+/**
+ * Dispatch subcommands. Returns a Promise so async subcommands (doctor)
+ * can resolve; synchronous subcommands (version, init) are wrapped.
+ */
+export async function runCli(argv: readonly string[]): Promise<CliResult> {
+  const [command, ...rest] = argv;
 
   if (command !== undefined && VERSION_FLAGS.has(command)) {
     return {
@@ -32,6 +57,21 @@ export function runCli(argv: readonly string[]): CliResult {
 
   if (command === undefined) {
     return { exitCode: 1, stdout: "", stderr: USAGE };
+  }
+
+  if (command === "init") {
+    // Sprint 1 init takes no flags; ignore unused args.
+    void rest;
+    return runInit({ cwd: process.cwd() });
+  }
+
+  if (command === "doctor") {
+    void rest;
+    return runDoctor({
+      cwd: process.cwd(),
+      homeDir: homedir(),
+      adapters: defaultAdapterBindings(),
+    });
   }
 
   return {

--- a/src/cli/doctor-checks/auth.ts
+++ b/src/cli/doctor-checks/auth.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { CheckStatus, type CheckResult } from "../doctor-format.ts";
+
+import type { AdapterBinding } from "./availability.ts";
+
+export interface CheckAuthStatusArgs {
+  readonly adapters: readonly AdapterBinding[];
+}
+
+/**
+ * Aggregates `auth_status()` across every bound adapter. Statuses:
+ *
+ *   - OK   — every adapter authenticated with API-key auth (usage
+ *            tracking available).
+ *   - WARN — at least one adapter authenticated via subscription
+ *            (SPEC §11 subscription-auth escape — usage unavailable;
+ *            wall-clock + iteration caps enforced instead).
+ *   - FAIL — any adapter not authenticated.
+ *
+ * Uses the existing `auth_status()` stub from Issue #5 — does NOT
+ * reimplement the subscription-auth heuristic.
+ */
+export async function checkAuthStatus(
+  args: CheckAuthStatusArgs,
+): Promise<CheckResult> {
+  const details: string[] = [];
+  let anyFailure = false;
+  let anySubscription = false;
+
+  for (const { label, adapter } of args.adapters) {
+    try {
+      const status = await adapter.auth_status();
+      if (!status.authenticated) {
+        details.push(`${label}: not authenticated`);
+        anyFailure = true;
+        continue;
+      }
+      if (status.subscription_auth === true) {
+        anySubscription = true;
+        const account =
+          status.account !== undefined ? ` (${status.account})` : "";
+        details.push(
+          `${label}: authenticated via subscription${account} ` +
+            `— token cost not visible; wall-clock + iteration caps enforced`,
+        );
+      } else {
+        const account =
+          status.account !== undefined ? ` (${status.account})` : "";
+        details.push(`${label}: authenticated${account}`);
+      }
+    } catch (err) {
+      details.push(`${label}: auth_status threw: ${(err as Error).message}`);
+      anyFailure = true;
+    }
+  }
+
+  let status: CheckStatus;
+  if (anyFailure) status = CheckStatus.Fail;
+  else if (anySubscription) status = CheckStatus.Warn;
+  else status = CheckStatus.Ok;
+
+  return {
+    status,
+    label: "auth",
+    message: details.join("; "),
+    details,
+  };
+}

--- a/src/cli/doctor-checks/availability.ts
+++ b/src/cli/doctor-checks/availability.ts
@@ -1,0 +1,48 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import type { Adapter } from "../../adapter/types.ts";
+
+import { CheckStatus, type CheckResult } from "../doctor-format.ts";
+
+export interface AdapterBinding {
+  readonly label: string;
+  readonly adapter: Adapter;
+}
+
+export interface CheckCliAvailabilityArgs {
+  readonly adapters: readonly AdapterBinding[];
+}
+
+/**
+ * Probes adapter `.detect()` for each bound CLI. Per SPEC §10 doctor
+ * must surface the installed version + absolute path; lack of either
+ * CLI is a FAIL at the aggregator level (Issue #4 acceptance).
+ */
+export async function checkCliAvailability(
+  args: CheckCliAvailabilityArgs,
+): Promise<CheckResult> {
+  const details: string[] = [];
+  let worst: CheckStatus = CheckStatus.Ok;
+
+  for (const { label, adapter } of args.adapters) {
+    try {
+      const det = await adapter.detect();
+      if (det.installed) {
+        details.push(`${label}: installed ${det.version} at ${det.path}`);
+      } else {
+        details.push(`${label}: not installed`);
+        worst = CheckStatus.Fail;
+      }
+    } catch (err) {
+      details.push(`${label}: detect threw: ${(err as Error).message}`);
+      worst = CheckStatus.Fail;
+    }
+  }
+
+  return {
+    status: worst,
+    label: "CLI availability",
+    message: details.join("; "),
+    details,
+  };
+}

--- a/src/cli/doctor-checks/config.ts
+++ b/src/cli/doctor-checks/config.ts
@@ -1,0 +1,112 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { existsSync, readFileSync } from "node:fs";
+
+import { CheckStatus, type CheckResult } from "../doctor-format.ts";
+import { DEFAULT_CONFIG } from "../init.ts";
+
+export interface CheckConfigArgs {
+  readonly configPath: string;
+}
+
+/**
+ * Sanity-check `.samospec/config.json`:
+ *   - FAIL if missing or malformed.
+ *   - WARN if the pinned lead / reviewer models differ from release
+ *     metadata (SPEC §11 — "pinned per samospec release; no runtime
+ *     strongest-available discovery"). Drift is flagged but not blocked
+ *     so power users can pin alternate models via `config set`.
+ *   - OK otherwise.
+ */
+export function checkConfig(args: CheckConfigArgs): CheckResult {
+  if (!existsSync(args.configPath)) {
+    return {
+      status: CheckStatus.Fail,
+      label: "config",
+      message: `${args.configPath} not found — run \`samospec init\``,
+    };
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(args.configPath, "utf8");
+  } catch (err) {
+    return {
+      status: CheckStatus.Fail,
+      label: "config",
+      message: `cannot read ${args.configPath}: ${(err as Error).message}`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      status: CheckStatus.Fail,
+      label: "config",
+      message: `${args.configPath} is malformed JSON: ${(err as Error).message}`,
+    };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {
+      status: CheckStatus.Fail,
+      label: "config",
+      message: `${args.configPath} malformed: top-level must be an object`,
+    };
+  }
+
+  const cfg = parsed as Record<string, unknown>;
+  const adapters = cfg["adapters"];
+  if (typeof adapters !== "object" || adapters === null) {
+    return {
+      status: CheckStatus.Fail,
+      label: "config",
+      message: `${args.configPath} missing 'adapters'`,
+    };
+  }
+
+  const driftMessages: string[] = [];
+  const roles: readonly (keyof typeof DEFAULT_CONFIG.adapters)[] = [
+    "lead",
+    "reviewer_a",
+    "reviewer_b",
+  ];
+  const adapterRecord = adapters as Record<string, unknown>;
+  for (const role of roles) {
+    const current = adapterRecord[role];
+    const expected = DEFAULT_CONFIG.adapters[role];
+    if (typeof current !== "object" || current === null) {
+      driftMessages.push(`${role} missing`);
+      continue;
+    }
+    const cRec = current as Record<string, unknown>;
+    if (cRec["model_id"] !== expected.model_id) {
+      driftMessages.push(
+        `${role}.model_id pinned to ${expected.model_id} ` +
+          `but config has ${JSON.stringify(cRec["model_id"])}`,
+      );
+    }
+    if (cRec["adapter"] !== expected.adapter) {
+      driftMessages.push(
+        `${role}.adapter pinned to ${expected.adapter} ` +
+          `but config has ${JSON.stringify(cRec["adapter"])}`,
+      );
+    }
+  }
+
+  if (driftMessages.length > 0) {
+    return {
+      status: CheckStatus.Warn,
+      label: "config",
+      message: `pinned-model drift: ${driftMessages.join(", ")}`,
+    };
+  }
+
+  return {
+    status: CheckStatus.Ok,
+    label: "config",
+    message: `${args.configPath} parses; pinned models match`,
+  };
+}

--- a/src/cli/doctor-checks/entropy.ts
+++ b/src/cli/doctor-checks/entropy.ts
@@ -1,0 +1,19 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { CheckStatus, type CheckResult } from "../doctor-format.ts";
+
+/**
+ * Entropy-scan placeholder. SPEC §14 + Issue #4 acceptance: surface the
+ * message without attempting an actual scan — this sprint doesn't own
+ * the redaction corpus or the scanner harness (that's Sprint 4). The
+ * WARN is deliberate: it communicates a real, known limitation.
+ */
+export function checkEntropy(): CheckResult {
+  return {
+    status: CheckStatus.Warn,
+    label: "entropy",
+    message:
+      "secret/entropy scan is best-effort; recommend an external scanner " +
+      "(gitleaks, truffleHog) for sensitive repos",
+  };
+}

--- a/src/cli/doctor-checks/git.ts
+++ b/src/cli/doctor-checks/git.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { CheckStatus, type CheckResult } from "../doctor-format.ts";
+
+export interface CheckGitHealthArgs {
+  readonly isGitRepo: () => boolean;
+  readonly currentBranch: () => string;
+  readonly hasRemote: () => boolean;
+  readonly remoteUrl: () => string | null;
+  readonly isProtected: () => boolean;
+}
+
+/**
+ * Pure function — every git probe is injected. Real-process wiring lives
+ * at the aggregator level so this is trivially testable without a repo.
+ *
+ *   - OK   — inside a repo, on a non-protected branch.
+ *   - WARN — inside a repo, on a protected branch (informational).
+ *   - FAIL — not inside a repo (doctor can't guarantee safety).
+ *
+ * Remote status is informational per SPEC §10 ("remote configured? —
+ * informational only").
+ */
+export function checkGitHealth(args: CheckGitHealthArgs): CheckResult {
+  if (!args.isGitRepo()) {
+    return {
+      status: CheckStatus.Fail,
+      label: "git",
+      message: "not a git repository — run `git init` first",
+    };
+  }
+
+  let branch: string;
+  try {
+    branch = args.currentBranch();
+  } catch (err) {
+    return {
+      status: CheckStatus.Fail,
+      label: "git",
+      message: `cannot determine current branch: ${(err as Error).message}`,
+    };
+  }
+
+  const protectedBranch = args.isProtected();
+  const remote = args.hasRemote();
+  const url = remote ? args.remoteUrl() : null;
+
+  const pieces: string[] = [`branch ${branch}`];
+  if (protectedBranch) pieces.push("protected");
+  if (remote) pieces.push(`remote: ${url ?? "(configured)"}`);
+  else pieces.push("no remote configured");
+
+  return {
+    status: protectedBranch ? CheckStatus.Warn : CheckStatus.Ok,
+    label: "git",
+    message: pieces.join("; "),
+  };
+}

--- a/src/cli/doctor-checks/global-config.ts
+++ b/src/cli/doctor-checks/global-config.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { CheckStatus, type CheckResult } from "../doctor-format.ts";
+
+export interface CheckGlobalConfigArgs {
+  readonly homeDir: string;
+}
+
+/**
+ * Detect global vendor-config files that can steer adapter behavior in
+ * ways `samospec` cannot see (SPEC §14 threat model). Any hit is a WARN
+ * — not a FAIL — because users may legitimately rely on these files;
+ * awareness is the point, not prohibition.
+ */
+const GLOBAL_CONFIG_CANDIDATES: readonly string[] = [
+  path.join(".claude", "CLAUDE.md"),
+  path.join(".codex", "preamble.md"),
+  path.join(".codex", "instructions.md"),
+];
+
+export function checkGlobalConfig(args: CheckGlobalConfigArgs): CheckResult {
+  const hits: string[] = [];
+  for (const relative of GLOBAL_CONFIG_CANDIDATES) {
+    const abs = path.join(args.homeDir, relative);
+    if (existsSync(abs)) {
+      hits.push(abs);
+    }
+  }
+
+  if (hits.length === 0) {
+    return {
+      status: CheckStatus.Ok,
+      label: "global vendor-config",
+      message: "no global CLAUDE.md / codex preamble detected",
+    };
+  }
+
+  return {
+    status: CheckStatus.Warn,
+    label: "global vendor-config",
+    message:
+      `present — may steer adapter behavior: ${hits.join(", ")}. ` +
+      `samospec runs adapters with a minimal env but cannot intercept ` +
+      `files read from disk by the vendor CLI.`,
+  };
+}

--- a/src/cli/doctor-checks/lock.ts
+++ b/src/cli/doctor-checks/lock.ts
@@ -1,0 +1,71 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { existsSync } from "node:fs";
+
+import { defaultIsPidAlive, isLockStale, readLock } from "../../state/lock.ts";
+import { CheckStatus, type CheckResult } from "../doctor-format.ts";
+
+export interface CheckLockfileArgs {
+  readonly lockPath: string;
+  readonly now: number;
+  readonly maxWallClockMinutes: number;
+  readonly isPidAlive?: (pid: number) => boolean;
+}
+
+/**
+ * Reports on `.samospec/.lock`. Uses the Issue #2 helpers in
+ * `src/state/lock.ts` — does NOT reimplement stale detection.
+ *
+ *   - OK   — no lock file on disk.
+ *   - WARN — a live lock file is present (another samospec process owns
+ *            it; SPEC §8 will surface this as "exit 2: lock contention"
+ *            if the user tries to run samospec concurrently).
+ *   - FAIL — a stale lock is present (pid dead or age exceeded); user
+ *            intervention recommended.
+ */
+export function checkLockfile(args: CheckLockfileArgs): CheckResult {
+  const probe = args.isPidAlive ?? defaultIsPidAlive;
+
+  if (!existsSync(args.lockPath)) {
+    return {
+      status: CheckStatus.Ok,
+      label: "lockfile",
+      message: "no .samospec/.lock present",
+    };
+  }
+
+  const lock = readLock(args.lockPath);
+  if (lock === null) {
+    return {
+      status: CheckStatus.Fail,
+      label: "lockfile",
+      message: `lockfile at ${args.lockPath} is unreadable or malformed — stale`,
+    };
+  }
+
+  const staleReason = isLockStale({
+    lock,
+    now: args.now,
+    maxWallClockMinutes: args.maxWallClockMinutes,
+    isPidAlive: probe,
+  });
+
+  if (staleReason === null) {
+    return {
+      status: CheckStatus.Warn,
+      label: "lockfile",
+      message:
+        `a live samospec run is holding the lock ` +
+        `(pid ${lock.pid}, slug '${lock.slug}', ` +
+        `started ${lock.started_at})`,
+    };
+  }
+
+  return {
+    status: CheckStatus.Fail,
+    label: "lockfile",
+    message:
+      `stale lock (${staleReason}); pid ${lock.pid}, ` +
+      `started ${lock.started_at}. Remove ${args.lockPath} to continue.`,
+  };
+}

--- a/src/cli/doctor-format.ts
+++ b/src/cli/doctor-format.ts
@@ -1,0 +1,88 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Small status-line formatter for `samospec doctor`.
+ *
+ * Three statuses (SPEC §10): OK, WARN, FAIL.
+ * Color is opt-in per call; callers decide based on `NO_COLOR` + TTY.
+ * No emoji — plain ASCII labels keep output scrape-friendly and comply
+ * with the project tone (see CLAUDE.md).
+ */
+
+export const CheckStatus = {
+  Ok: "OK",
+  Warn: "WARN",
+  Fail: "FAIL",
+} as const;
+export type CheckStatus = (typeof CheckStatus)[keyof typeof CheckStatus];
+
+export interface CheckResult {
+  readonly status: CheckStatus;
+  readonly label: string;
+  readonly message: string;
+  readonly details?: readonly string[];
+}
+
+export interface FormatStatusLineArgs {
+  readonly status: CheckStatus;
+  readonly label: string;
+  readonly message: string;
+  readonly color: boolean;
+}
+
+const ANSI_RESET = "\u001b[0m";
+const ANSI_BOLD = "\u001b[1m";
+const ANSI_GREEN = "\u001b[32m";
+const ANSI_YELLOW = "\u001b[33m";
+const ANSI_RED = "\u001b[31m";
+
+function colorFor(status: CheckStatus): string {
+  switch (status) {
+    case CheckStatus.Ok:
+      return ANSI_GREEN;
+    case CheckStatus.Warn:
+      return ANSI_YELLOW;
+    case CheckStatus.Fail:
+      return ANSI_RED;
+  }
+}
+
+/**
+ * Format a single status line, e.g.:
+ *   [ OK ]  git             repo detected, branch feature/foo
+ *   [WARN]  auth            subscription auth — wall-clock caps enforced
+ *   [FAIL]  config          config.json malformed
+ */
+export function formatStatusLine(args: FormatStatusLineArgs): string {
+  const tag = args.status.padEnd(4, " ");
+  const label = args.label.padEnd(24, " ");
+  if (args.color) {
+    const c = colorFor(args.status);
+    return `[${c}${ANSI_BOLD}${tag}${ANSI_RESET}]  ${label}${args.message}`;
+  }
+  return `[${tag}]  ${label}${args.message}`;
+}
+
+export interface ShouldUseColorArgs {
+  readonly env: Readonly<Record<string, string | undefined>>;
+  readonly isTty: boolean;
+}
+
+/**
+ * Color output is disabled when NO_COLOR is set (any non-empty value, per
+ * https://no-color.org/) or when stdout is not a TTY (pipes, files, CI).
+ */
+export function shouldUseColor(args: ShouldUseColorArgs): boolean {
+  const noColor = args.env["NO_COLOR"];
+  if (typeof noColor === "string" && noColor.length > 0) return false;
+  return args.isTty;
+}
+
+/** Roll a list of check results into the worst-severity status. */
+export function worstStatus(results: readonly CheckResult[]): CheckStatus {
+  if (results.some((r) => r.status === CheckStatus.Fail))
+    return CheckStatus.Fail;
+  if (results.some((r) => r.status === CheckStatus.Warn))
+    return CheckStatus.Warn;
+  return CheckStatus.Ok;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,180 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import type { Adapter } from "../adapter/types.ts";
+import { isProtected } from "../git/protected.ts";
+import {
+  CheckStatus,
+  formatStatusLine,
+  shouldUseColor,
+  worstStatus,
+  type CheckResult,
+} from "./doctor-format.ts";
+import { checkCliAvailability } from "./doctor-checks/availability.ts";
+import { checkAuthStatus } from "./doctor-checks/auth.ts";
+import { checkGitHealth } from "./doctor-checks/git.ts";
+import { checkLockfile } from "./doctor-checks/lock.ts";
+import { checkConfig } from "./doctor-checks/config.ts";
+import { checkGlobalConfig } from "./doctor-checks/global-config.ts";
+import { checkEntropy } from "./doctor-checks/entropy.ts";
+
+export interface DoctorAdapterBinding {
+  readonly label: string;
+  readonly adapter: Adapter;
+}
+
+export interface RunDoctorArgs {
+  readonly cwd: string;
+  readonly homeDir: string;
+  readonly adapters: readonly DoctorAdapterBinding[];
+  // Injectable probes — tests pass closures; production wires the real
+  // spawnSync-based git helpers.
+  readonly isGitRepo?: () => boolean;
+  readonly currentBranch?: () => string;
+  readonly hasRemote?: () => boolean;
+  readonly remoteUrl?: () => string | null;
+  readonly isProtected?: () => boolean;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly isTty?: boolean;
+  readonly now?: number;
+  readonly maxWallClockMinutes?: number;
+}
+
+export interface RunDoctorResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+function defaultIsGitRepo(cwd: string): boolean {
+  const r = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd,
+    encoding: "utf8",
+  });
+  return r.status === 0 && r.stdout.trim() === "true";
+}
+
+function defaultCurrentBranch(cwd: string): string {
+  // Prefer symbolic-ref: works even in a brand-new repo with no commits yet,
+  // where `rev-parse --abbrev-ref HEAD` fails with an "unknown revision" error.
+  const sym = spawnSync("git", ["symbolic-ref", "--short", "HEAD"], {
+    cwd,
+    encoding: "utf8",
+  });
+  if (sym.status === 0) {
+    const name = sym.stdout.trim();
+    if (name.length > 0) return name;
+  }
+  const rev = spawnSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+    cwd,
+    encoding: "utf8",
+  });
+  if (rev.status === 0) {
+    const name = rev.stdout.trim();
+    if (name.length > 0) return name;
+  }
+  throw new Error(
+    `cannot read current branch: ${(sym.stderr || rev.stderr || "unknown").trim()}`,
+  );
+}
+
+function defaultHasRemote(cwd: string): boolean {
+  const r = spawnSync("git", ["remote"], { cwd, encoding: "utf8" });
+  if (r.status !== 0) return false;
+  return r.stdout.trim().length > 0;
+}
+
+function defaultRemoteUrl(cwd: string): string | null {
+  const r = spawnSync("git", ["remote", "get-url", "origin"], {
+    cwd,
+    encoding: "utf8",
+  });
+  if (r.status !== 0) return null;
+  const out = r.stdout.trim();
+  return out.length > 0 ? out : null;
+}
+
+export async function runDoctor(args: RunDoctorArgs): Promise<RunDoctorResult> {
+  const env = args.env ?? process.env;
+  const isTty = args.isTty ?? process.stdout.isTTY ?? false;
+  const color = shouldUseColor({ env, isTty });
+  const now = args.now ?? Date.now();
+  const maxWallClockMinutes = args.maxWallClockMinutes ?? 240;
+
+  const isGitRepo = args.isGitRepo ?? (() => defaultIsGitRepo(args.cwd));
+  const currentBranch =
+    args.currentBranch ?? (() => defaultCurrentBranch(args.cwd));
+  const hasRemote = args.hasRemote ?? (() => defaultHasRemote(args.cwd));
+  const remoteUrl = args.remoteUrl ?? (() => defaultRemoteUrl(args.cwd));
+  const protectedProbe =
+    args.isProtected ??
+    (() => {
+      try {
+        const b = currentBranch();
+        return isProtected(b, { repoPath: args.cwd });
+      } catch {
+        return false;
+      }
+    });
+
+  const results: CheckResult[] = [];
+
+  results.push(await checkCliAvailability({ adapters: args.adapters }));
+  results.push(await checkAuthStatus({ adapters: args.adapters }));
+  results.push(
+    checkGitHealth({
+      isGitRepo,
+      currentBranch,
+      hasRemote,
+      remoteUrl,
+      isProtected: protectedProbe,
+    }),
+  );
+  results.push(
+    checkLockfile({
+      lockPath: path.join(args.cwd, ".samospec", ".lock"),
+      now,
+      maxWallClockMinutes,
+    }),
+  );
+  results.push(
+    checkConfig({
+      configPath: path.join(args.cwd, ".samospec", "config.json"),
+    }),
+  );
+  results.push(checkGlobalConfig({ homeDir: args.homeDir }));
+  results.push(checkEntropy());
+
+  const lines: string[] = [];
+  for (const r of results) {
+    lines.push(
+      formatStatusLine({
+        status: r.status,
+        label: r.label,
+        message: r.message,
+        color,
+      }),
+    );
+    if (r.details !== undefined && r.details.length > 1) {
+      for (const d of r.details) lines.push(`        ${d}`);
+    }
+  }
+
+  const roll = worstStatus(results);
+  const summary =
+    roll === CheckStatus.Fail
+      ? "samospec doctor: one or more critical checks failed."
+      : roll === CheckStatus.Warn
+        ? "samospec doctor: passes with warnings."
+        : "samospec doctor: all green.";
+  lines.push("");
+  lines.push(summary);
+
+  return {
+    exitCode: roll === CheckStatus.Fail ? 1 : 0,
+    stdout: `${lines.join("\n")}\n`,
+    stderr: "",
+  };
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,299 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * `samospec init` — create or merge a `.samospec/` config directory for
+ * the current repo. SPEC §5 Phase 1, §10 (idempotent), §11 (pinned
+ * defaults + budget), §14 (remote_probe off by default).
+ *
+ * Contract:
+ *   - fresh dir    -> write default config + .gitignore + cache skeleton; exit 0
+ *   - existing dir -> merge user keys with defaults; print diff; exit 0
+ *   - malformed    -> exit 1 with a clear error; do NOT silently overwrite
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export const CONFIG_SCHEMA_VERSION = 1 as const;
+
+export interface LeadAdapterDefaults {
+  readonly adapter: "claude";
+  readonly model_id: "claude-opus-4-7";
+  readonly effort: "max";
+  readonly fallback_chain: readonly string[];
+}
+
+export interface ReviewerAAdapterDefaults {
+  readonly adapter: "codex";
+  readonly model_id: "gpt-5.1-codex-max";
+  readonly effort: "high";
+  readonly fallback_chain: readonly string[];
+}
+
+export interface ReviewerBAdapterDefaults {
+  readonly adapter: "claude";
+  readonly model_id: "claude-opus-4-7";
+  readonly effort: "max";
+  readonly fallback_chain: readonly string[];
+}
+
+export interface BudgetDefaults {
+  readonly max_iterations: number;
+  readonly max_reviewers: number;
+  readonly max_tokens_per_round: number;
+  readonly max_total_tokens_per_session: number;
+  readonly max_wall_clock_minutes: number;
+  readonly preflight_confirm_usd: number;
+}
+
+export interface GitDefaults {
+  readonly remote_probe: boolean;
+  readonly protected_branches: readonly string[];
+}
+
+export interface ContextDefaults {
+  readonly injection_threshold: number;
+}
+
+export interface ConvergenceDefaults {
+  readonly min_delta_lines: number;
+}
+
+export interface DefaultConfig {
+  readonly schema_version: typeof CONFIG_SCHEMA_VERSION;
+  readonly adapters: {
+    readonly lead: LeadAdapterDefaults;
+    readonly reviewer_a: ReviewerAAdapterDefaults;
+    readonly reviewer_b: ReviewerBAdapterDefaults;
+  };
+  readonly budget: BudgetDefaults;
+  readonly git: GitDefaults;
+  readonly context: ContextDefaults;
+  readonly convergence: ConvergenceDefaults;
+}
+
+/**
+ * Pinned v1 defaults. SPEC §11.
+ * - Lead: claude / claude-opus-4-7 / max
+ * - Reviewer A: codex / gpt-5.1-codex-max / high
+ * - Reviewer B: claude / claude-opus-4-7 / max (same family as lead)
+ * - Budget: generous defaults (SPEC §11 Budget guardrails).
+ * - Git: remote_probe off by default (SPEC §14 threat model).
+ */
+export const DEFAULT_CONFIG: DefaultConfig = {
+  schema_version: CONFIG_SCHEMA_VERSION,
+  adapters: {
+    lead: {
+      adapter: "claude",
+      model_id: "claude-opus-4-7",
+      effort: "max",
+      fallback_chain: ["claude-opus-4-7", "claude-sonnet-4-6", "terminal"],
+    },
+    reviewer_a: {
+      adapter: "codex",
+      model_id: "gpt-5.1-codex-max",
+      effort: "high",
+      fallback_chain: ["gpt-5.1-codex-max", "gpt-5.1-codex", "terminal"],
+    },
+    reviewer_b: {
+      adapter: "claude",
+      model_id: "claude-opus-4-7",
+      effort: "max",
+      fallback_chain: ["claude-opus-4-7", "claude-sonnet-4-6", "terminal"],
+    },
+  },
+  budget: {
+    max_iterations: 10,
+    max_reviewers: 2,
+    max_tokens_per_round: 250_000,
+    max_total_tokens_per_session: 2_000_000,
+    max_wall_clock_minutes: 240,
+    preflight_confirm_usd: 20,
+  },
+  git: {
+    remote_probe: false,
+    protected_branches: [],
+  },
+  context: {
+    injection_threshold: 5,
+  },
+  convergence: {
+    min_delta_lines: 20,
+  },
+};
+
+const GITIGNORE_BODY = [
+  "# samospec — local-only files (SPEC §9)",
+  "transcripts/",
+  "cache/",
+  ".lock",
+  "",
+].join("\n");
+
+export interface RunInitArgs {
+  readonly cwd: string;
+}
+
+export interface RunInitResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+type JsonObject = Record<string, unknown>;
+
+/**
+ * Deep-merge `base` into `user`: every key present in `base` but missing
+ * in `user` is filled in; keys the user set are preserved verbatim
+ * (never overwritten). Arrays are treated as opaque values — user arrays
+ * are kept as-is. Tracks the paths that were added.
+ */
+function mergeDefaults(
+  user: JsonObject,
+  base: JsonObject,
+  trail: string,
+  diff: string[],
+): JsonObject {
+  const out: JsonObject = { ...user };
+  for (const [key, baseVal] of Object.entries(base)) {
+    const here = trail === "" ? key : `${trail}.${key}`;
+    const userVal = out[key];
+    if (userVal === undefined) {
+      out[key] = baseVal;
+      diff.push(`added   ${here} = ${formatValue(baseVal)}`);
+      continue;
+    }
+    if (isPlainObject(userVal) && isPlainObject(baseVal)) {
+      out[key] = mergeDefaults(userVal, baseVal, here, diff);
+    }
+    // Else: preserve user value (includes arrays, primitives, or type-mismatch).
+  }
+  return out;
+}
+
+function isPlainObject(v: unknown): v is JsonObject {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    !Array.isArray(v) &&
+    Object.getPrototypeOf(v) === Object.prototype
+  );
+}
+
+function formatValue(v: unknown): string {
+  if (isPlainObject(v)) return "{...}";
+  if (Array.isArray(v)) return "[...]";
+  return JSON.stringify(v);
+}
+
+export function runInit(args: RunInitArgs): RunInitResult {
+  const samoDir = path.join(args.cwd, ".samospec");
+  const configPath = path.join(samoDir, "config.json");
+  const gitignorePath = path.join(samoDir, ".gitignore");
+  const cacheDir = path.join(samoDir, "cache");
+  const gistsDir = path.join(cacheDir, "gists");
+
+  const messages: string[] = [];
+
+  // Is there already a config.json to merge against?
+  const existedBefore = existsSync(configPath);
+  let userConfig: JsonObject = {};
+  if (existedBefore) {
+    let raw: string;
+    try {
+      raw = readFileSync(configPath, "utf8");
+    } catch (err) {
+      return {
+        exitCode: 1,
+        stdout: "",
+        stderr:
+          `samospec: failed to read existing .samospec/config.json: ` +
+          `${(err as Error).message}\n`,
+      };
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (!isPlainObject(parsed)) {
+        return {
+          exitCode: 1,
+          stdout: "",
+          stderr:
+            `samospec: existing .samospec/config.json is malformed: ` +
+            `top-level value must be a JSON object. Fix or remove it ` +
+            `and rerun samospec init.\n`,
+        };
+      }
+      userConfig = parsed;
+    } catch (err) {
+      return {
+        exitCode: 1,
+        stdout: "",
+        stderr:
+          `samospec: existing .samospec/config.json is malformed JSON: ` +
+          `${(err as Error).message}\n` +
+          `Fix or remove it and rerun samospec init. ` +
+          `(Refusing to silently overwrite user configuration.)\n`,
+      };
+    }
+  }
+
+  // Create directory structure first. Parents are mkdir -p idempotent.
+  mkdirSync(samoDir, { recursive: true });
+  mkdirSync(gistsDir, { recursive: true });
+
+  // .gitignore: write if missing; never modify a user-edited one.
+  if (!existsSync(gitignorePath)) {
+    writeFileSync(gitignorePath, GITIGNORE_BODY, "utf8");
+    messages.push(`created .samospec/.gitignore`);
+  }
+
+  // Merge defaults → user config.
+  const diff: string[] = [];
+  const merged = mergeDefaults(
+    userConfig,
+    DEFAULT_CONFIG as unknown as JsonObject,
+    "",
+    diff,
+  );
+
+  // Migration path: if the stored schema_version is older, upgrade.
+  // Current version is 1 so this is a no-op; the hook is here intentionally.
+  const storedVersion = merged["schema_version"];
+  if (
+    typeof storedVersion === "number" &&
+    storedVersion !== CONFIG_SCHEMA_VERSION
+  ) {
+    merged["schema_version"] = CONFIG_SCHEMA_VERSION;
+    diff.push(
+      `migrated schema_version ${storedVersion} -> ${CONFIG_SCHEMA_VERSION}`,
+    );
+  }
+
+  // Write the merged config only when it differs from what was on disk,
+  // so a truly no-op re-run can advertise itself cleanly.
+  const mergedJson = `${JSON.stringify(merged, null, 2)}\n`;
+  let wroteConfig = false;
+  if (!existedBefore) {
+    writeFileSync(configPath, mergedJson, "utf8");
+    wroteConfig = true;
+    messages.push(`created .samospec/config.json`);
+  } else if (diff.length > 0) {
+    writeFileSync(configPath, mergedJson, "utf8");
+    wroteConfig = true;
+    messages.push(`merged .samospec/config.json:`);
+    for (const line of diff) messages.push(`  ${line}`);
+  }
+
+  if (!wroteConfig && messages.length === 0) {
+    messages.push(`samospec: .samospec/ is up to date — no changes.`);
+  } else if (existedBefore && diff.length === 0) {
+    messages.push(`samospec: config.json unchanged.`);
+  }
+
+  if (!existedBefore) {
+    messages.unshift(`samospec: initialized .samospec/ in ${args.cwd}`);
+  }
+
+  const stdout = `${messages.join("\n")}\n`;
+  return { exitCode: 0, stdout, stderr: "" };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@
 
 import { runCli } from "./cli.ts";
 
-const result = runCli(Bun.argv.slice(2));
+const result = await runCli(Bun.argv.slice(2));
 if (result.stdout.length > 0) {
   process.stdout.write(result.stdout);
 }

--- a/tests/cli.errors.test.ts
+++ b/tests/cli.errors.test.ts
@@ -5,8 +5,8 @@ import { describe, expect, test } from "bun:test";
 import { runCli } from "../src/cli.ts";
 
 describe("samospec CLI error paths", () => {
-  test("exits 1 with usage on stderr when no command is given", () => {
-    const result = runCli([]);
+  test("exits 1 with usage on stderr when no command is given", async () => {
+    const result = await runCli([]);
 
     expect(result.exitCode).toBe(1);
     expect(result.stdout).toBe("");
@@ -14,8 +14,8 @@ describe("samospec CLI error paths", () => {
     expect(result.stderr).toContain("version");
   });
 
-  test("exits 1 with an unknown-command message on stderr", () => {
-    const result = runCli(["frobnicate"]);
+  test("exits 1 with an unknown-command message on stderr", async () => {
+    const result = await runCli(["frobnicate"]);
 
     expect(result.exitCode).toBe(1);
     expect(result.stdout).toBe("");
@@ -23,8 +23,8 @@ describe("samospec CLI error paths", () => {
     expect(result.stderr).toContain("Usage: samospec");
   });
 
-  test("unknown-command handling is case-sensitive", () => {
-    const result = runCli(["VERSION"]);
+  test("unknown-command handling is case-sensitive", async () => {
+    const result = await runCli(["VERSION"]);
 
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("unknown command 'VERSION'");

--- a/tests/cli.version.test.ts
+++ b/tests/cli.version.test.ts
@@ -6,25 +6,25 @@ import { runCli } from "../src/cli.ts";
 import packageJson from "../package.json" with { type: "json" };
 
 describe("samospec version", () => {
-  test("prints the package.json version to stdout and exits 0", () => {
-    const result = runCli(["version"]);
+  test("prints the package.json version to stdout and exits 0", async () => {
+    const result = await runCli(["version"]);
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout.trim()).toBe(packageJson.version);
     expect(result.stderr).toBe("");
   });
 
-  test("responds to the -v short flag identically to version", () => {
-    const long = runCli(["version"]);
-    const short = runCli(["-v"]);
+  test("responds to the -v short flag identically to version", async () => {
+    const long = await runCli(["version"]);
+    const short = await runCli(["-v"]);
 
     expect(short.exitCode).toBe(0);
     expect(short.stdout).toBe(long.stdout);
   });
 
-  test("responds to the --version long flag identically to version", () => {
-    const subcommand = runCli(["version"]);
-    const flag = runCli(["--version"]);
+  test("responds to the --version long flag identically to version", async () => {
+    const subcommand = await runCli(["version"]);
+    const flag = await runCli(["--version"]);
 
     expect(flag.exitCode).toBe(0);
     expect(flag.stdout).toBe(subcommand.stdout);

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -12,10 +12,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { runDoctor } from "../../src/cli/doctor.ts";
-import {
-  CheckStatus,
-  formatStatusLine,
-} from "../../src/cli/doctor-format.ts";
+import { CheckStatus, formatStatusLine } from "../../src/cli/doctor-format.ts";
 import { checkCliAvailability } from "../../src/cli/doctor-checks/availability.ts";
 import { checkAuthStatus } from "../../src/cli/doctor-checks/auth.ts";
 import { checkGitHealth } from "../../src/cli/doctor-checks/git.ts";

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -1,0 +1,565 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { runDoctor } from "../../src/cli/doctor.ts";
+import {
+  CheckStatus,
+  formatStatusLine,
+} from "../../src/cli/doctor-format.ts";
+import { checkCliAvailability } from "../../src/cli/doctor-checks/availability.ts";
+import { checkAuthStatus } from "../../src/cli/doctor-checks/auth.ts";
+import { checkGitHealth } from "../../src/cli/doctor-checks/git.ts";
+import { checkLockfile } from "../../src/cli/doctor-checks/lock.ts";
+import { checkConfig } from "../../src/cli/doctor-checks/config.ts";
+import { checkGlobalConfig } from "../../src/cli/doctor-checks/global-config.ts";
+import { checkEntropy } from "../../src/cli/doctor-checks/entropy.ts";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import { runInit } from "../../src/cli/init.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-doctor-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+// -------- doctor-format helpers --------
+
+describe("doctor-format — status line helper", () => {
+  test("emits OK / WARN / FAIL labels with color codes when colors enabled", () => {
+    const line = formatStatusLine({
+      status: CheckStatus.Ok,
+      label: "git",
+      message: "repo detected",
+      color: true,
+    });
+    // Must contain the label and message.
+    expect(line).toContain("git");
+    expect(line).toContain("repo detected");
+    // ANSI escape when color=true.
+    expect(line).toContain("\u001b[");
+    // No emoji.
+    expect(line).not.toMatch(/[\u{1F300}-\u{1FAFF}]/u);
+  });
+
+  test("plain ASCII when color disabled", () => {
+    const line = formatStatusLine({
+      status: CheckStatus.Warn,
+      label: "auth",
+      message: "subscription auth",
+      color: false,
+    });
+    expect(line).not.toContain("\u001b[");
+    expect(line.toUpperCase()).toContain("WARN");
+  });
+
+  test("FAIL status produces a FAIL token", () => {
+    const line = formatStatusLine({
+      status: CheckStatus.Fail,
+      label: "config",
+      message: "malformed",
+      color: false,
+    });
+    expect(line.toUpperCase()).toContain("FAIL");
+  });
+});
+
+// -------- per-check tests --------
+
+describe("doctor-checks / availability", () => {
+  test("reports installed when adapter detect succeeds", async () => {
+    const claude = createFakeAdapter({
+      detect: { installed: true, version: "1.2.3", path: "/usr/bin/claude" },
+    });
+    const result = await checkCliAvailability({
+      adapters: [{ label: "claude", adapter: claude }],
+    });
+    expect(result.status).toBe(CheckStatus.Ok);
+    expect(result.message).toContain("1.2.3");
+    expect(result.message).toContain("/usr/bin/claude");
+  });
+
+  test("reports FAIL when adapter detect reports not installed", async () => {
+    const codex = createFakeAdapter({
+      detect: { installed: false },
+    });
+    const result = await checkCliAvailability({
+      adapters: [{ label: "codex", adapter: codex }],
+    });
+    expect(result.status).toBe(CheckStatus.Fail);
+    expect(result.message.toLowerCase()).toContain("not installed");
+  });
+
+  test("aggregates multiple adapters independently", async () => {
+    const claude = createFakeAdapter({
+      detect: { installed: true, version: "1.0.0", path: "/usr/bin/claude" },
+    });
+    const codex = createFakeAdapter({
+      detect: { installed: false },
+    });
+    const result = await checkCliAvailability({
+      adapters: [
+        { label: "claude", adapter: claude },
+        { label: "codex", adapter: codex },
+      ],
+    });
+    // Any FAIL rolls up to FAIL.
+    expect(result.status).toBe(CheckStatus.Fail);
+    expect(result.details?.length ?? 0).toBe(2);
+  });
+});
+
+describe("doctor-checks / auth", () => {
+  test("OK when authenticated with API key", async () => {
+    const claude = createFakeAdapter({
+      auth: {
+        authenticated: true,
+        account: "user@example.com",
+        subscription_auth: false,
+      },
+    });
+    const result = await checkAuthStatus({
+      adapters: [{ label: "claude", adapter: claude }],
+    });
+    expect(result.status).toBe(CheckStatus.Ok);
+  });
+
+  test("WARN when authenticated via subscription (surfacing subscription-auth)", async () => {
+    const claude = createFakeAdapter({
+      auth: {
+        authenticated: true,
+        subscription_auth: true,
+      },
+    });
+    const result = await checkAuthStatus({
+      adapters: [{ label: "claude", adapter: claude }],
+    });
+    expect(result.status).toBe(CheckStatus.Warn);
+    expect(result.message.toLowerCase()).toContain("subscription");
+    // UX copy per SPEC §11 mentions wall-clock enforcement.
+    expect(result.message.toLowerCase()).toMatch(/wall-clock|iteration/);
+  });
+
+  test("FAIL when not authenticated", async () => {
+    const claude = createFakeAdapter({
+      auth: { authenticated: false },
+    });
+    const result = await checkAuthStatus({
+      adapters: [{ label: "claude", adapter: claude }],
+    });
+    expect(result.status).toBe(CheckStatus.Fail);
+  });
+});
+
+describe("doctor-checks / git", () => {
+  test("OK when inside a git repo with a branch name", () => {
+    const result = checkGitHealth({
+      isGitRepo: () => true,
+      currentBranch: () => "feature/foo",
+      hasRemote: () => true,
+      remoteUrl: () => "git@github.com:me/repo.git",
+      isProtected: () => false,
+    });
+    expect(result.status).toBe(CheckStatus.Ok);
+    expect(result.message).toContain("feature/foo");
+  });
+
+  test("WARN when on a protected branch (informational at doctor level)", () => {
+    const result = checkGitHealth({
+      isGitRepo: () => true,
+      currentBranch: () => "main",
+      hasRemote: () => false,
+      remoteUrl: () => null,
+      isProtected: () => true,
+    });
+    expect(result.status).toBe(CheckStatus.Warn);
+    expect(result.message.toLowerCase()).toContain("protected");
+  });
+
+  test("FAIL when not inside a git repo", () => {
+    const result = checkGitHealth({
+      isGitRepo: () => false,
+      currentBranch: () => {
+        throw new Error("not a repo");
+      },
+      hasRemote: () => false,
+      remoteUrl: () => null,
+      isProtected: () => false,
+    });
+    expect(result.status).toBe(CheckStatus.Fail);
+    expect(result.message.toLowerCase()).toMatch(/not a git repo|no git/);
+  });
+});
+
+describe("doctor-checks / lock", () => {
+  test("OK when no .lock file exists", () => {
+    mkdirSync(path.join(tmp, ".samospec"), { recursive: true });
+    const result = checkLockfile({
+      lockPath: path.join(tmp, ".samospec", ".lock"),
+      now: Date.now(),
+      maxWallClockMinutes: 240,
+    });
+    expect(result.status).toBe(CheckStatus.Ok);
+    expect(result.message.toLowerCase()).toMatch(/no.*lock|absent|clear/);
+  });
+
+  test("WARN when a live lock is held by another process", () => {
+    mkdirSync(path.join(tmp, ".samospec"), { recursive: true });
+    const lockPath = path.join(tmp, ".samospec", ".lock");
+    const lock = {
+      pid: 1, // PID 1 always alive on POSIX.
+      started_at: new Date().toISOString(),
+      slug: "demo",
+    };
+    writeFileSync(lockPath, JSON.stringify(lock, null, 2), "utf8");
+
+    const result = checkLockfile({
+      lockPath,
+      now: Date.now(),
+      maxWallClockMinutes: 240,
+      isPidAlive: () => true,
+    });
+    expect(result.status).toBe(CheckStatus.Warn);
+    expect(result.message).toContain("1");
+    expect(result.message.toLowerCase()).toContain("live");
+  });
+
+  test("FAIL when a stale lock is present (dead pid)", () => {
+    mkdirSync(path.join(tmp, ".samospec"), { recursive: true });
+    const lockPath = path.join(tmp, ".samospec", ".lock");
+    const lock = {
+      pid: 99999,
+      started_at: new Date().toISOString(),
+      slug: "demo",
+    };
+    writeFileSync(lockPath, JSON.stringify(lock, null, 2), "utf8");
+
+    const result = checkLockfile({
+      lockPath,
+      now: Date.now(),
+      maxWallClockMinutes: 240,
+      isPidAlive: () => false,
+    });
+    expect(result.status).toBe(CheckStatus.Fail);
+    expect(result.message.toLowerCase()).toContain("stale");
+  });
+
+  test("FAIL when lock is too old (age_exceeded)", () => {
+    mkdirSync(path.join(tmp, ".samospec"), { recursive: true });
+    const lockPath = path.join(tmp, ".samospec", ".lock");
+    // 400 minutes ago; buffer = 30; max = 240 — expect age_exceeded.
+    const now = Date.now();
+    const started = new Date(now - 400 * 60_000).toISOString();
+    writeFileSync(
+      lockPath,
+      JSON.stringify({ pid: 1, started_at: started, slug: "x" }, null, 2),
+      "utf8",
+    );
+
+    const result = checkLockfile({
+      lockPath,
+      now,
+      maxWallClockMinutes: 240,
+      isPidAlive: () => true,
+    });
+    expect(result.status).toBe(CheckStatus.Fail);
+    expect(result.message.toLowerCase()).toContain("stale");
+  });
+});
+
+describe("doctor-checks / config", () => {
+  test("OK when config.json parses and pinned models match", () => {
+    runInit({ cwd: tmp });
+    const result = checkConfig({
+      configPath: path.join(tmp, ".samospec", "config.json"),
+    });
+    expect(result.status).toBe(CheckStatus.Ok);
+  });
+
+  test("FAIL when config.json is missing", () => {
+    const result = checkConfig({
+      configPath: path.join(tmp, ".samospec", "config.json"),
+    });
+    expect(result.status).toBe(CheckStatus.Fail);
+    expect(result.message.toLowerCase()).toMatch(/not found|missing|run.*init/);
+  });
+
+  test("FAIL when config.json is malformed", () => {
+    mkdirSync(path.join(tmp, ".samospec"), { recursive: true });
+    writeFileSync(
+      path.join(tmp, ".samospec", "config.json"),
+      "{ broken",
+      "utf8",
+    );
+    const result = checkConfig({
+      configPath: path.join(tmp, ".samospec", "config.json"),
+    });
+    expect(result.status).toBe(CheckStatus.Fail);
+    expect(result.message.toLowerCase()).toMatch(/malformed|parse|invalid/);
+  });
+
+  test("WARN when pinned lead model differs from release metadata", () => {
+    runInit({ cwd: tmp });
+    // Tamper: set a non-pinned model.
+    const cfgPath = path.join(tmp, ".samospec", "config.json");
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    (cfg["adapters"] as Record<string, Record<string, unknown>>)["lead"][
+      "model_id"
+    ] = "claude-opus-3-5";
+    writeFileSync(cfgPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
+
+    const result = checkConfig({ configPath: cfgPath });
+    expect(result.status).toBe(CheckStatus.Warn);
+    expect(result.message.toLowerCase()).toMatch(/pinned|mismatch|drift/);
+  });
+});
+
+describe("doctor-checks / global-config", () => {
+  test("OK when none of the global config files exist", () => {
+    // Point HOME at an empty temp dir.
+    const home = mkdtempSync(path.join(tmpdir(), "samospec-home-"));
+    try {
+      const result = checkGlobalConfig({ homeDir: home });
+      expect(result.status).toBe(CheckStatus.Ok);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("WARN when ~/.claude/CLAUDE.md exists", () => {
+    const home = mkdtempSync(path.join(tmpdir(), "samospec-home-"));
+    try {
+      mkdirSync(path.join(home, ".claude"), { recursive: true });
+      writeFileSync(
+        path.join(home, ".claude", "CLAUDE.md"),
+        "user global prompt",
+        "utf8",
+      );
+      const result = checkGlobalConfig({ homeDir: home });
+      expect(result.status).toBe(CheckStatus.Warn);
+      expect(result.message).toContain("CLAUDE.md");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("WARN when ~/.codex/preamble.md or instructions.md exists", () => {
+    const home = mkdtempSync(path.join(tmpdir(), "samospec-home-"));
+    try {
+      mkdirSync(path.join(home, ".codex"), { recursive: true });
+      writeFileSync(
+        path.join(home, ".codex", "instructions.md"),
+        "codex global",
+        "utf8",
+      );
+      const result = checkGlobalConfig({ homeDir: home });
+      expect(result.status).toBe(CheckStatus.Warn);
+      expect(result.message).toContain("instructions.md");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("doctor-checks / entropy", () => {
+  test("WARN-level placeholder surfaces the external-scanner recommendation", () => {
+    const result = checkEntropy();
+    expect(result.status).toBe(CheckStatus.Warn);
+    expect(result.message.toLowerCase()).toContain("best-effort");
+    expect(result.message.toLowerCase()).toContain("external");
+  });
+});
+
+// -------- runDoctor integration --------
+
+describe("runDoctor aggregator", () => {
+  test("exits 0 when every check is OK or WARN", async () => {
+    runInit({ cwd: tmp });
+    const fakeHome = mkdtempSync(path.join(tmpdir(), "samospec-home-"));
+    try {
+      const result = await runDoctor({
+        cwd: tmp,
+        homeDir: fakeHome,
+        adapters: [
+          {
+            label: "claude",
+            adapter: createFakeAdapter({
+              auth: {
+                authenticated: true,
+                account: "u@e.com",
+                subscription_auth: false,
+              },
+            }),
+          },
+          {
+            label: "codex",
+            adapter: createFakeAdapter({
+              auth: {
+                authenticated: true,
+                account: "u@e.com",
+                subscription_auth: false,
+              },
+            }),
+          },
+        ],
+        isGitRepo: () => true,
+        currentBranch: () => "feature/demo",
+        hasRemote: () => false,
+        remoteUrl: () => null,
+        isProtected: () => false,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("OK");
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  test("exits 1 when any check FAILs", async () => {
+    runInit({ cwd: tmp });
+    const fakeHome = mkdtempSync(path.join(tmpdir(), "samospec-home-"));
+    try {
+      const result = await runDoctor({
+        cwd: tmp,
+        homeDir: fakeHome,
+        adapters: [
+          {
+            label: "claude",
+            adapter: createFakeAdapter({
+              detect: { installed: false },
+            }),
+          },
+        ],
+        isGitRepo: () => false,
+        currentBranch: () => {
+          throw new Error("not a repo");
+        },
+        hasRemote: () => false,
+        remoteUrl: () => null,
+        isProtected: () => false,
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain("FAIL");
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  test("surfaces subscription_auth: true explicitly in output", async () => {
+    runInit({ cwd: tmp });
+    const fakeHome = mkdtempSync(path.join(tmpdir(), "samospec-home-"));
+    try {
+      const result = await runDoctor({
+        cwd: tmp,
+        homeDir: fakeHome,
+        adapters: [
+          {
+            label: "claude",
+            adapter: createFakeAdapter({
+              auth: {
+                authenticated: true,
+                account: "u@e.com",
+                subscription_auth: true,
+              },
+            }),
+          },
+        ],
+        isGitRepo: () => true,
+        currentBranch: () => "feature/demo",
+        hasRemote: () => false,
+        remoteUrl: () => null,
+        isProtected: () => false,
+      });
+      expect(result.stdout.toLowerCase()).toContain("subscription");
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  test("warns about global-config contamination", async () => {
+    runInit({ cwd: tmp });
+    const fakeHome = mkdtempSync(path.join(tmpdir(), "samospec-home-"));
+    try {
+      mkdirSync(path.join(fakeHome, ".claude"), { recursive: true });
+      writeFileSync(
+        path.join(fakeHome, ".claude", "CLAUDE.md"),
+        "user global",
+        "utf8",
+      );
+
+      const result = await runDoctor({
+        cwd: tmp,
+        homeDir: fakeHome,
+        adapters: [
+          {
+            label: "claude",
+            adapter: createFakeAdapter({
+              auth: {
+                authenticated: true,
+                account: "u@e.com",
+                subscription_auth: false,
+              },
+            }),
+          },
+        ],
+        isGitRepo: () => true,
+        currentBranch: () => "feature/demo",
+        hasRemote: () => false,
+        remoteUrl: () => null,
+        isProtected: () => false,
+      });
+      expect(result.stdout).toContain("CLAUDE.md");
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  test("NO_COLOR env suppresses ANSI in stdout", async () => {
+    runInit({ cwd: tmp });
+    const fakeHome = mkdtempSync(path.join(tmpdir(), "samospec-home-"));
+    try {
+      const result = await runDoctor({
+        cwd: tmp,
+        homeDir: fakeHome,
+        adapters: [
+          {
+            label: "claude",
+            adapter: createFakeAdapter({
+              auth: {
+                authenticated: true,
+                account: "u@e.com",
+                subscription_auth: false,
+              },
+            }),
+          },
+        ],
+        isGitRepo: () => true,
+        currentBranch: () => "feature/demo",
+        hasRemote: () => false,
+        remoteUrl: () => null,
+        isProtected: () => false,
+        env: { NO_COLOR: "1" },
+      });
+      expect(result.stdout).not.toContain("\u001b[");
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -12,7 +12,11 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { runInit, DEFAULT_CONFIG, CONFIG_SCHEMA_VERSION } from "../../src/cli/init.ts";
+import {
+  runInit,
+  DEFAULT_CONFIG,
+  CONFIG_SCHEMA_VERSION,
+} from "../../src/cli/init.ts";
 
 let tmp: string;
 
@@ -180,7 +184,9 @@ describe("samospec init — idempotent re-run", () => {
     runInit({ cwd: tmp });
     const result = runInit({ cwd: tmp });
     expect(result.exitCode).toBe(0);
-    expect(result.stdout.toLowerCase()).toMatch(/no changes|up to date|unchanged/);
+    expect(result.stdout.toLowerCase()).toMatch(
+      /no changes|up to date|unchanged/,
+    );
   });
 });
 

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -1,0 +1,228 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { runInit, DEFAULT_CONFIG, CONFIG_SCHEMA_VERSION } from "../../src/cli/init.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-init-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("samospec init — fresh directory", () => {
+  test("creates .samospec/ with config.json, .gitignore, cache dirs and exits 0", () => {
+    const result = runInit({ cwd: tmp });
+
+    expect(result.exitCode).toBe(0);
+
+    const samo = path.join(tmp, ".samospec");
+    expect(existsSync(samo)).toBe(true);
+    expect(existsSync(path.join(samo, "config.json"))).toBe(true);
+    expect(existsSync(path.join(samo, ".gitignore"))).toBe(true);
+    expect(existsSync(path.join(samo, "cache"))).toBe(true);
+    expect(existsSync(path.join(samo, "cache", "gists"))).toBe(true);
+  });
+
+  test("config.json is parseable JSON and contains v1 pinned defaults", () => {
+    runInit({ cwd: tmp });
+    const cfgPath = path.join(tmp, ".samospec", "config.json");
+    const parsed = JSON.parse(readFileSync(cfgPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+
+    // Schema version tracked so migrations can run later.
+    expect(parsed["schema_version"]).toBe(CONFIG_SCHEMA_VERSION);
+
+    // Pinned lead adapter per SPEC §11.
+    const adapters = parsed["adapters"] as Record<string, unknown>;
+    const lead = adapters["lead"] as Record<string, unknown>;
+    expect(lead["adapter"]).toBe("claude");
+    expect(lead["model_id"]).toBe("claude-opus-4-7");
+    expect(lead["effort"]).toBe("max");
+
+    const reviewerA = adapters["reviewer_a"] as Record<string, unknown>;
+    expect(reviewerA["adapter"]).toBe("codex");
+    expect(reviewerA["model_id"]).toBe("gpt-5.1-codex-max");
+    expect(reviewerA["effort"]).toBe("high");
+
+    const reviewerB = adapters["reviewer_b"] as Record<string, unknown>;
+    expect(reviewerB["adapter"]).toBe("claude");
+    expect(reviewerB["model_id"]).toBe("claude-opus-4-7");
+    expect(reviewerB["effort"]).toBe("max");
+
+    // Budget defaults per SPEC §11.
+    const budget = parsed["budget"] as Record<string, unknown>;
+    expect(budget["max_tokens_per_round"]).toBe(250_000);
+    expect(budget["max_total_tokens_per_session"]).toBe(2_000_000);
+    expect(budget["max_wall_clock_minutes"]).toBe(240);
+    expect(budget["preflight_confirm_usd"]).toBe(20);
+
+    // Git remote probe disabled by default (§14).
+    const git = parsed["git"] as Record<string, unknown>;
+    expect(git["remote_probe"]).toBe(false);
+  });
+
+  test(".gitignore ignores transcripts/, cache/, and .lock", () => {
+    runInit({ cwd: tmp });
+    const body = readFileSync(
+      path.join(tmp, ".samospec", ".gitignore"),
+      "utf8",
+    );
+    expect(body).toContain("transcripts/");
+    expect(body).toContain("cache/");
+    expect(body).toContain(".lock");
+  });
+
+  test("stdout announces creation of .samospec/", () => {
+    const result = runInit({ cwd: tmp });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(".samospec");
+    expect(result.stdout.toLowerCase()).toMatch(/created|initialized/);
+  });
+
+  test("DEFAULT_CONFIG exports a pinned-defaults constant for reuse", () => {
+    expect(DEFAULT_CONFIG.schema_version).toBe(CONFIG_SCHEMA_VERSION);
+    expect(DEFAULT_CONFIG.adapters.lead.model_id).toBe("claude-opus-4-7");
+  });
+});
+
+describe("samospec init — idempotent re-run", () => {
+  test("re-running preserves user-set keys and fills missing defaults", () => {
+    runInit({ cwd: tmp });
+    const cfgPath = path.join(tmp, ".samospec", "config.json");
+
+    // User edits config.json.
+    const initial = JSON.parse(readFileSync(cfgPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    (initial["budget"] as Record<string, unknown>)["max_wall_clock_minutes"] =
+      90;
+    (initial["adapters"] as Record<string, Record<string, unknown>>)["lead"][
+      "effort"
+    ] = "high";
+    // User adds a custom key — must be preserved.
+    initial["custom_user_key"] = { hello: "world" };
+    writeFileSync(cfgPath, `${JSON.stringify(initial, null, 2)}\n`, "utf8");
+
+    // Simulate a missing defaults-only key by deleting a budget field.
+    const afterEdit = JSON.parse(readFileSync(cfgPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    delete (afterEdit["budget"] as Record<string, unknown>)[
+      "preflight_confirm_usd"
+    ];
+    writeFileSync(cfgPath, `${JSON.stringify(afterEdit, null, 2)}\n`, "utf8");
+
+    const result = runInit({ cwd: tmp });
+
+    expect(result.exitCode).toBe(0);
+    const after = JSON.parse(readFileSync(cfgPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+
+    // User overrides preserved.
+    expect(
+      (after["budget"] as Record<string, unknown>)["max_wall_clock_minutes"],
+    ).toBe(90);
+    expect(
+      (after["adapters"] as Record<string, Record<string, unknown>>)["lead"][
+        "effort"
+      ],
+    ).toBe("high");
+    expect(after["custom_user_key"]).toEqual({ hello: "world" });
+
+    // Missing default filled back in.
+    expect(
+      (after["budget"] as Record<string, unknown>)["preflight_confirm_usd"],
+    ).toBe(20);
+  });
+
+  test("re-running prints a diff of what changed", () => {
+    runInit({ cwd: tmp });
+    const cfgPath = path.join(tmp, ".samospec", "config.json");
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    delete (cfg["budget"] as Record<string, unknown>)["preflight_confirm_usd"];
+    writeFileSync(cfgPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
+
+    const result = runInit({ cwd: tmp });
+    expect(result.exitCode).toBe(0);
+    // Diff mentions the key that was filled back.
+    expect(result.stdout).toContain("preflight_confirm_usd");
+    // Some "added" / "changed" / "merge" marker.
+    expect(result.stdout.toLowerCase()).toMatch(
+      /added|changed|merged|filled|updated/,
+    );
+  });
+
+  test("second identical re-run prints a no-changes message and exits 0", () => {
+    runInit({ cwd: tmp });
+    const result = runInit({ cwd: tmp });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toLowerCase()).toMatch(/no changes|up to date|unchanged/);
+  });
+});
+
+describe("samospec init — malformed existing config", () => {
+  test("malformed config.json exits 1 with a clear message and does NOT overwrite", () => {
+    mkdirSync(path.join(tmp, ".samospec"), { recursive: true });
+    const cfgPath = path.join(tmp, ".samospec", "config.json");
+    const garbage = "{ this is not valid json,, ";
+    writeFileSync(cfgPath, garbage, "utf8");
+
+    const result = runInit({ cwd: tmp });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toLowerCase()).toMatch(
+      /malformed|invalid|cannot parse|parse error/,
+    );
+    // The file is NOT silently repaired.
+    expect(readFileSync(cfgPath, "utf8")).toBe(garbage);
+  });
+
+  test("malformed config.json error suggests a remediation path", () => {
+    mkdirSync(path.join(tmp, ".samospec"), { recursive: true });
+    const cfgPath = path.join(tmp, ".samospec", "config.json");
+    writeFileSync(cfgPath, "{ broken", "utf8");
+
+    const result = runInit({ cwd: tmp });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("config.json");
+  });
+});
+
+describe("samospec init — pre-existing .samospec with no config.json", () => {
+  test("creates config.json without clobbering existing sibling files", () => {
+    const samo = path.join(tmp, ".samospec");
+    mkdirSync(samo, { recursive: true });
+    writeFileSync(path.join(samo, "NOTES.md"), "user notes\n", "utf8");
+
+    const result = runInit({ cwd: tmp });
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(path.join(samo, "NOTES.md"), "utf8")).toBe(
+      "user notes\n",
+    );
+    expect(existsSync(path.join(samo, "config.json"))).toBe(true);
+  });
+});

--- a/tests/cli/integration.test.ts
+++ b/tests/cli/integration.test.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const CLI_PATH = path.resolve(import.meta.dir, "..", "..", "src", "cli.ts");
+
+let tmp: string;
+let fakeHome: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-cli-integ-"));
+  fakeHome = mkdtempSync(path.join(tmpdir(), "samospec-home-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  rmSync(fakeHome, { recursive: true, force: true });
+});
+
+function runSamospec(
+  args: readonly string[],
+  opts: { cwd: string; env?: Record<string, string> },
+): { stdout: string; stderr: string; status: number } {
+  const env = {
+    ...process.env,
+    HOME: fakeHome,
+    NO_COLOR: "1",
+    ...(opts.env ?? {}),
+  };
+  const result = spawnSync(
+    process.execPath,
+    ["run", CLI_PATH, ...(args as string[])],
+    {
+      cwd: opts.cwd,
+      encoding: "utf8",
+      env,
+    },
+  );
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status ?? 1,
+  };
+}
+
+describe("integration: bun run src/cli.ts init && doctor", () => {
+  test("init creates .samospec/, doctor reports status and exits", () => {
+    // Initialize a bare git repo so doctor's git check has something to see.
+    spawnSync("git", ["init", "--initial-branch", "feature/integ", tmp], {
+      cwd: tmpdir(),
+      encoding: "utf8",
+    });
+
+    const initResult = runSamospec(["init"], { cwd: tmp });
+    expect(initResult.status).toBe(0);
+    expect(existsSync(path.join(tmp, ".samospec", "config.json"))).toBe(true);
+    expect(existsSync(path.join(tmp, ".samospec", ".gitignore"))).toBe(true);
+
+    const doctorResult = runSamospec(["doctor"], { cwd: tmp });
+    // doctor may exit 0 or 1 depending on real claude/codex presence in CI.
+    expect([0, 1]).toContain(doctorResult.status);
+    // Key lines must always appear regardless of pass/fail.
+    expect(doctorResult.stdout).toContain("CLI availability");
+    expect(doctorResult.stdout).toContain("git");
+    expect(doctorResult.stdout).toContain("lockfile");
+    expect(doctorResult.stdout).toContain("config");
+    expect(doctorResult.stdout).toContain("global vendor-config");
+    expect(doctorResult.stdout).toContain("entropy");
+  });
+
+  test("second init run is idempotent and prints an up-to-date/merged message", () => {
+    spawnSync("git", ["init", "--initial-branch", "feature/integ", tmp], {
+      cwd: tmpdir(),
+      encoding: "utf8",
+    });
+
+    const first = runSamospec(["init"], { cwd: tmp });
+    expect(first.status).toBe(0);
+
+    const second = runSamospec(["init"], { cwd: tmp });
+    expect(second.status).toBe(0);
+    // Some indication no changes were needed.
+    expect(second.stdout.toLowerCase()).toMatch(
+      /no changes|up to date|unchanged|no-op/,
+    );
+  });
+});

--- a/tests/cli/integration.test.ts
+++ b/tests/cli/integration.test.ts
@@ -2,15 +2,13 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import {
-  existsSync,
-  mkdtempSync,
-  rmSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-const CLI_PATH = path.resolve(import.meta.dir, "..", "..", "src", "cli.ts");
+// Use main.ts — it's the actual CLI entrypoint that calls runCli.
+// src/cli.ts is a library module that only exports runCli.
+const CLI_PATH = path.resolve(import.meta.dir, "..", "..", "src", "main.ts");
 
 let tmp: string;
 let fakeHome: string;
@@ -35,15 +33,14 @@ function runSamospec(
     NO_COLOR: "1",
     ...(opts.env ?? {}),
   };
-  const result = spawnSync(
-    process.execPath,
-    ["run", CLI_PATH, ...(args as string[])],
-    {
-      cwd: opts.cwd,
-      encoding: "utf8",
-      env,
-    },
-  );
+  // Prefer the running Bun interpreter so tests work regardless of whether
+  // `bun` is on PATH (Bun.argv[0] is the absolute binary path).
+  const bun = Bun.argv[0];
+  const result = spawnSync(bun, ["run", CLI_PATH, ...(args as string[])], {
+    cwd: opts.cwd,
+    encoding: "utf8",
+    env,
+  });
   return {
     stdout: result.stdout ?? "",
     stderr: result.stderr ?? "",


### PR DESCRIPTION
Closes #4.

## Summary

- `samospec init` — creates / refreshes `.samospec/` with v1 pinned defaults (SPEC §11), ignore rules (SPEC §9), and a `cache/gists/` skeleton. Idempotent re-run deep-merges user keys with defaults, prints a diff, and never silently overwrites.
- `samospec doctor` — aggregates seven checks (CLI availability, auth, git health, lockfile, config sanity, global vendor-config detection, entropy placeholder) with OK / WARN / FAIL labels. Exit 0 if no FAIL, else exit 1. ANSI colors honored per `NO_COLOR` and TTY state.

## Acceptance checklist

### `samospec init` (SPEC §10)

- [x] Creates `.samospec/` with `config.json`, `.gitignore` (transcripts/, cache/, .lock), and `cache/gists/` skeleton.
- [x] `config.json` populated with v1 defaults: pinned lead (`claude-opus-4-7`), reviewer A (`gpt-5.1-codex-max`), reviewer B (`claude-opus-4-7`), budget defaults (wall-clock 240m, preflight $20, etc.), `git.remote_probe: false`.
- [x] Idempotent re-run merges: user-set keys preserved, missing defaults filled, diff printed. Never overwrites user keys.
- [x] Exits 0 on success; 1 on malformed existing `config.json` with clear message.

### `samospec doctor` (SPEC §10, §14)

- [x] CLI availability via adapter `.detect()` (reuses Issue #5 adapter interface).
- [x] Auth status via adapter `.auth_status()` (reuses Issue #5; does NOT reimplement subscription-auth heuristic).
- [x] Git health: repo present, remote informational, current branch, protected detection via `src/git/protected.ts`.
- [x] `.samospec/.lock` check reuses `readLock` + `isLockStale` from `src/state/lock.ts`.
- [x] Config sanity: parse + pinned-model drift warning.
- [x] Entropy placeholder surfaces external-scanner recommendation.
- [x] Global vendor-config detection warns on `~/.claude/CLAUDE.md`, `~/.codex/preamble.md`, `~/.codex/instructions.md` (SPEC §14).
- [x] Subscription-auth flag surfaced explicitly with the §11 UX copy (wall-clock + iteration caps enforced).
- [x] Exit 0 if all critical checks pass; exit 1 on any FAIL.
- [x] Human-readable colored output; ASCII fallback on `NO_COLOR` or non-TTY stdout. No emoji.

### TDD

- [x] Unit tests for `init`: fresh dir, idempotent-merge, malformed existing config, partial `.samospec/` with no config.
- [x] Unit tests per `doctor` check with mocked environment (adapter stubs, injectable git/fs/env probes).
- [x] Integration smoke test: spawns `bun run src/main.ts init && doctor` in a temp dir with `HOME` pinned to a fake home, asserts exit codes and output lines.
- [x] Red-first: tests landed as `97fcb98` (RED), implementation as `01200b1` (GREEN).

## Testing evidence

### `bun test` summary

```
421 pass
0 fail
2659 expect() calls
Ran 421 tests across 27 files.
```

### Coverage (bun test --coverage)

```
All files                               |   94.88 |   92.53
 src/cli/doctor-checks/auth.ts          |  100.00 |   95.12
 src/cli/doctor-checks/availability.ts  |  100.00 |   91.67
 src/cli/doctor-checks/config.ts        |  100.00 |   75.29
 src/cli/doctor-checks/entropy.ts       |  100.00 |  100.00
 src/cli/doctor-checks/git.ts           |  100.00 |   83.33
 src/cli/doctor-checks/global-config.ts |  100.00 |  100.00
 src/cli/doctor-checks/lock.ts          |  100.00 |   88.37
 src/cli/doctor-format.ts               |  100.00 |   86.11
 src/cli/init.ts                        |  100.00 |   88.62
```

Exceeds the 80% line / func / stmt gate in `bunfig.toml`.

### `samospec init` on a fresh temp dir

```
$ mkdir /tmp/samo-demo && cd /tmp/samo-demo && git init -b feature/demo .
$ bun run src/main.ts init
samospec: initialized .samospec/ in /private/tmp/samo-demo
created .samospec/.gitignore
created .samospec/config.json

$ ls -la .samospec/
-rw-r--r--  .gitignore
drwxr-xr-x  cache
-rw-r--r--  config.json
$ ls .samospec/cache/
gists

$ cat .samospec/config.json
{
  "schema_version": 1,
  "adapters": {
    "lead": { "adapter": "claude", "model_id": "claude-opus-4-7", "effort": "max", ... },
    "reviewer_a": { "adapter": "codex", "model_id": "gpt-5.1-codex-max", "effort": "high", ... },
    "reviewer_b": { "adapter": "claude", "model_id": "claude-opus-4-7", "effort": "max", ... }
  },
  "budget": {
    "max_iterations": 10, "max_reviewers": 2,
    "max_tokens_per_round": 250000, "max_total_tokens_per_session": 2000000,
    "max_wall_clock_minutes": 240, "preflight_confirm_usd": 20
  },
  "git": { "remote_probe": false, "protected_branches": [] },
  "context": { "injection_threshold": 5 },
  "convergence": { "min_delta_lines": 20 }
}
```

### `samospec init` re-run (idempotency)

```
$ bun run src/main.ts init      # no-op case
samospec: .samospec/ is up to date — no changes.

$ # delete one default key, then rerun
$ python3 -c "import json; c=json.load(open('.samospec/config.json')); del c['budget']['preflight_confirm_usd']; open('.samospec/config.json','w').write(json.dumps(c, indent=2))"
$ bun run src/main.ts init
merged .samospec/config.json:
  added   budget.preflight_confirm_usd = 20
```

User keys are preserved; only the missing default is filled back in. Malformed config (`{ broken`) exits 1 with `samospec: existing .samospec/config.json is malformed JSON: ...`.

### `samospec doctor` — healthy setup

```
$ HOME=/tmp/fake-home NO_COLOR=1 bun run src/main.ts doctor
[OK  ]  CLI availability        claude: installed fake-1.0.0 at /usr/bin/fake; codex: installed fake-1.0.0 at /usr/bin/fake
[WARN]  auth                    claude: authenticated via subscription (fake@example.com) — token cost not visible; wall-clock + iteration caps enforced; codex: authenticated via subscription (fake@example.com) — token cost not visible; wall-clock + iteration caps enforced
[OK  ]  git                     branch feature/demo; no remote configured
[OK  ]  lockfile                no .samospec/.lock present
[OK  ]  config                  config.json parses; pinned models match
[OK  ]  global vendor-config    no global CLAUDE.md / codex preamble detected
[WARN]  entropy                 secret/entropy scan is best-effort; recommend an external scanner (gitleaks, truffleHog) for sensitive repos

samospec doctor: passes with warnings.
exit=0
```

### `samospec doctor` — fake stale lockfile

```
$ echo '{"pid":99999,"started_at":"2024-01-01T00:00:00Z","slug":"demo"}' > .samospec/.lock
$ HOME=/tmp/fake-home NO_COLOR=1 bun run src/main.ts doctor
...
[FAIL]  lockfile                stale lock (pid_dead); pid 99999, started 2024-01-01T00:00:00Z. Remove /private/tmp/samo-demo/.samospec/.lock to continue.
...
samospec doctor: one or more critical checks failed.
exit=1
```

### `samospec doctor` — with `~/.claude/CLAUDE.md` present (fake HOME)

```
$ # programmatic via runDoctor with homeDir pointed at a tempdir containing ~/.claude/CLAUDE.md
[WARN]  global vendor-config    present — may steer adapter behavior: /tmp/samospec-home-gG08bg/.claude/CLAUDE.md. samospec runs adapters with a minimal env but cannot intercept files read from disk by the vendor CLI.
...
samospec doctor: passes with warnings.
exit=0
```

## Scope respected

- Only modifies `src/cli.ts` + `src/main.ts` in the existing module set, and the only change is async dispatch for the new doctor subcommand (necessary integration). State / git / adapter modules are untouched.
- No new Sprint 2 features (lead adapter, context subsystem, persona, interview).
- Subscription-auth heuristic is NOT duplicated — the doctor auth check reads `auth_status().subscription_auth` straight from the adapter.
- Lockfile check uses `readLock` + `isLockStale` from Issue #2; no parallel implementation.
- Copyright header on every new source file.

## Test plan

- [x] `bun test` — 421 pass
- [x] `bun run test:coverage` — 94.88% func / 92.53% line
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run typecheck` — clean
- [x] Manual `bun run src/main.ts init && doctor` smoke in a temp dir on macOS

CI (Linux + macOS) will confirm the cross-platform Sprint 1 exit criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)