### PR TITLE
feat: Sprint 2 #12 — Claude adapter (lead)

### DIFF
--- a/src/adapter/claude.ts
+++ b/src/adapter/claude.ts
@@ -1,0 +1,578 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §7 + §11: the real Claude adapter (lead seat).
+//
+// - Spawns the `claude` CLI via Bun.spawn using the minimal-env +
+//   non-interactive flag helpers from `./spawn.ts`.
+// - Non-interactive flags: `--print --dangerously-skip-permissions`
+//   (documented in spawn.ts; the installed target is Claude CLI v2.1.x
+//   which accepts both).
+// - Minimal env: `HOME`, `PATH`, `TMPDIR`, plus `ANTHROPIC_API_KEY`
+//   when present. Everything else is dropped.
+// - Structured output: stdout captured, passed through
+//   `preParseJson`, then zod-validated. ONE repair retry on schema
+//   violation per call; then terminal.
+// - Timeout: capped retry policy (base → +50% → base → terminal)
+//   via `runWithCappedRetry`.
+// - `usage: null` path honored when CLI output doesn't report it,
+//   or under subscription auth.
+// - `revise()` emits the full SPEC.md text each round (not a patch);
+//   `ready` + `rationale` are inline JSON fields.
+// - Pinned default model: `claude-opus-4-7`.
+//
+// Tests never shell out to the real `claude`. Work-call tests inject
+// the fake-CLI harness via the `spawn` dependency.
+
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { detectSubscriptionAuth } from "./auth-status.ts";
+import { preParseJson } from "./json-parse.ts";
+import {
+  CLAUDE_NON_INTERACTIVE_FLAGS,
+  spawnCli,
+  type SpawnCliInput,
+  type SpawnCliResult,
+} from "./spawn.ts";
+import { runWithCappedRetry, type AttemptResult } from "./timeout.ts";
+import {
+  type Adapter,
+  type AskInput,
+  type AskOutput,
+  type AuthStatus,
+  type CritiqueInput,
+  type CritiqueOutput,
+  type DetectResult,
+  type EffortLevel,
+  type ModelInfo,
+  type ReviseInput,
+  type ReviseOutput,
+  AskInputSchema,
+  AskOutputSchema,
+  CritiqueInputSchema,
+  CritiqueOutputSchema,
+  ReviseInputSchema,
+  ReviseOutputSchema,
+} from "./types.ts";
+
+// ---------- constants ----------
+
+const CLAUDE_VENDOR = "claude";
+const CLAUDE_BINARY_NAME = "claude";
+const CLAUDE_AUTH_ENV_KEYS: readonly string[] = ["ANTHROPIC_API_KEY"];
+
+// SPEC §11 pinned model + fallback.
+const DEFAULT_MODELS: readonly ModelInfo[] = [
+  { id: "claude-opus-4-7", family: "claude" },
+  { id: "claude-sonnet-4-6", family: "claude" },
+];
+
+const DEFAULT_MODEL_ID = "claude-opus-4-7";
+
+// ---------- adapter options / dependency injection ----------
+
+export type SpawnFn = typeof spawnCli;
+
+export interface ClaudeAdapterOpts {
+  /** Binary name (or absolute path) to exec. Default: "claude". */
+  readonly binary?: string;
+  /**
+   * Host env snapshot for env derivation and PATH-based binary resolution.
+   * Defaults to process.env. Tests inject a deterministic map.
+   */
+  readonly host?: Readonly<Record<string, string | undefined>>;
+  /**
+   * spawnCli replacement for tests. Defaults to `./spawn.ts` spawnCli.
+   */
+  readonly spawn?: SpawnFn;
+  /**
+   * Models override. Defaults to pinned `claude-opus-4-7` + fallback.
+   */
+  readonly models?: readonly ModelInfo[];
+  /**
+   * Default model id passed through to CLI invocations. Default
+   * `claude-opus-4-7`.
+   */
+  readonly defaultModel?: string;
+}
+
+// ---------- binary discovery ----------
+
+function resolveBinaryPath(
+  host: Readonly<Record<string, string | undefined>>,
+  binary: string,
+): string | null {
+  // Absolute-ish path: respect it as-is.
+  if (binary.includes("/")) {
+    return existsSync(binary) ? binary : null;
+  }
+  const pathVar = host["PATH"];
+  if (typeof pathVar !== "string" || pathVar.length === 0) {
+    return null;
+  }
+  for (const segment of pathVar.split(":")) {
+    if (segment === "") continue;
+    const candidate = join(segment, binary);
+    try {
+      if (existsSync(candidate)) {
+        const st = statSync(candidate);
+        if (st.isFile()) {
+          return candidate;
+        }
+      }
+    } catch {
+      // permission denied etc.; keep looking
+    }
+  }
+  return null;
+}
+
+function parseVersionOutput(raw: string): string {
+  // Accept anything with at least a semver-ish "N.N.N"; fall back to
+  // the first trimmed line. We do not fail detection on weird output.
+  const trimmed = raw.trim();
+  if (trimmed === "") return "unknown";
+  const semverMatch = /\d+\.\d+(?:\.\d+)?/.exec(trimmed);
+  if (semverMatch !== null) {
+    return semverMatch[0];
+  }
+  const firstLine = trimmed.split("\n")[0];
+  return firstLine ?? "unknown";
+}
+
+// ---------- ClaudeAdapter ----------
+
+export class ClaudeAdapter implements Adapter {
+  readonly vendor: string = CLAUDE_VENDOR;
+
+  private readonly binary: string;
+  private readonly host: Readonly<Record<string, string | undefined>>;
+  private readonly spawnFn: SpawnFn;
+  private readonly modelList: readonly ModelInfo[];
+  private readonly defaultModel: string;
+
+  constructor(opts: ClaudeAdapterOpts = {}) {
+    this.binary = opts.binary ?? CLAUDE_BINARY_NAME;
+    this.host =
+      opts.host ?? (process.env as Record<string, string | undefined>);
+    this.spawnFn = opts.spawn ?? spawnCli;
+    this.modelList = opts.models ?? DEFAULT_MODELS;
+    this.defaultModel = opts.defaultModel ?? DEFAULT_MODEL_ID;
+  }
+
+  // ---------- lifecycle ----------
+
+  detect(): Promise<DetectResult> {
+    const resolved = resolveBinaryPath(this.host, this.binary);
+    if (resolved === null) {
+      return Promise.resolve({ installed: false });
+    }
+    return this.probeVersion(resolved);
+  }
+
+  private async probeVersion(resolvedPath: string): Promise<DetectResult> {
+    const r = await this.spawnFn({
+      cmd: [resolvedPath, "--version"],
+      stdin: "",
+      env: {},
+      timeoutMs: 5_000,
+      extraAllowedEnvKeys: CLAUDE_AUTH_ENV_KEYS,
+      host: this.host,
+    });
+    if (!r.ok || r.exitCode !== 0) {
+      // Binary exists but couldn't run; treat as installed-but-unknown.
+      return {
+        installed: true,
+        version: "unknown",
+        path: resolvedPath,
+      };
+    }
+    return {
+      installed: true,
+      version: parseVersionOutput(r.stdout),
+      path: resolvedPath,
+    };
+  }
+
+  // ---------- auth ----------
+
+  auth_status(): Promise<AuthStatus> {
+    const authKey = CLAUDE_AUTH_ENV_KEYS[0];
+    const apiKey = authKey !== undefined ? this.host[authKey] : undefined;
+    const hasApiKey = typeof apiKey === "string" && apiKey.length > 0;
+
+    // If no binary, we cannot be authenticated.
+    const resolved = resolveBinaryPath(this.host, this.binary);
+    if (resolved === null) {
+      return Promise.resolve({ authenticated: false });
+    }
+
+    // Deterministic baseline: API key env var implies authenticated.
+    // Subscription-auth mode (no API key but authenticated via keychain)
+    // is reported as authenticated + subscription_auth=true.
+    //
+    // We do not probe the real CLI for keychain auth here — that would
+    // require unsandboxed keychain access in tests. Instead, the
+    // heuristic is:
+    //   - API key present -> authenticated, subscription_auth=false
+    //   - No API key, binary installed -> authenticated=true,
+    //     subscription_auth=true (subscription/keychain assumed)
+    //
+    // This matches the SPEC §11 subscription-auth escape: a running
+    // `claude` CLI without ANTHROPIC_API_KEY must be using the
+    // subscription keychain, because that is the only other
+    // authenticated mode the CLI supports.
+    const authenticated = true;
+    const subscription_auth = detectSubscriptionAuth({
+      vendor: CLAUDE_VENDOR,
+      authenticated,
+      env: this.host,
+    });
+    if (hasApiKey) {
+      return Promise.resolve({
+        authenticated,
+        subscription_auth: false,
+      });
+    }
+    return Promise.resolve({ authenticated, subscription_auth });
+  }
+
+  supports_structured_output(): boolean {
+    return true;
+  }
+
+  supports_effort(_level: EffortLevel): boolean {
+    return true;
+  }
+
+  models(): Promise<readonly ModelInfo[]> {
+    return Promise.resolve(this.modelList);
+  }
+
+  // ---------- work calls ----------
+
+  async ask(input: AskInput): Promise<AskOutput> {
+    AskInputSchema.parse(input);
+    const prompt = buildAskPrompt(input);
+    const raw = await this.runWithRetries({
+      prompt,
+      timeoutMs: input.opts.timeout,
+      effort: input.opts.effort,
+      structured: true,
+    });
+    const parsed = parseAskJson(raw, input.opts.effort);
+    return AskOutputSchema.parse(parsed);
+  }
+
+  async critique(input: CritiqueInput): Promise<CritiqueOutput> {
+    CritiqueInputSchema.parse(input);
+    const prompt = buildCritiquePrompt(input);
+    const raw = await this.runWithRetries({
+      prompt,
+      timeoutMs: input.opts.timeout,
+      effort: input.opts.effort,
+      structured: true,
+    });
+    const parsed = parseCritiqueJson(raw, input.opts.effort);
+    return CritiqueOutputSchema.parse(parsed);
+  }
+
+  async revise(input: ReviseInput): Promise<ReviseOutput> {
+    ReviseInputSchema.parse(input);
+    const prompt = buildRevisePrompt(input);
+    const raw = await this.runWithRetries({
+      prompt,
+      timeoutMs: input.opts.timeout,
+      effort: input.opts.effort,
+      structured: true,
+    });
+    const parsed = parseReviseJson(raw, input.opts.effort);
+    return ReviseOutputSchema.parse(parsed);
+  }
+
+  // ---------- shared spawn + retry ----------
+
+  /**
+   * Run one work-call via the CLI. Enforces:
+   * - capped timeout retry (base → +50% → base → terminal)
+   * - ONE schema-violation repair retry per timeout-attempt
+   * - non-interactive flags
+   * - minimal env
+   *
+   * Returns the raw stdout string for the caller to JSON-parse.
+   */
+  private async runWithRetries(args: {
+    prompt: string;
+    timeoutMs: number;
+    effort: EffortLevel;
+    structured: boolean;
+  }): Promise<string> {
+    const resolvedBinary =
+      resolveBinaryPath(this.host, this.binary) ?? this.binary;
+
+    const outcome = await runWithCappedRetry<string>(
+      async (ctx) => {
+        return await this.runSingleAttempt({
+          binary: resolvedBinary,
+          prompt: args.prompt,
+          timeoutMs: ctx.timeout,
+          effort: args.effort,
+          structured: args.structured,
+        });
+      },
+      { baseTimeoutMs: args.timeoutMs },
+    );
+
+    if (outcome.ok) {
+      return outcome.value;
+    }
+
+    const base: ClaudeAdapterErrorPayload = {
+      kind: "terminal",
+      reason: outcome.reason,
+      attempts: outcome.attempts,
+    };
+    throw new ClaudeAdapterError(
+      outcome.detail !== undefined
+        ? { ...base, detail: outcome.detail }
+        : base,
+    );
+  }
+
+  private async runSingleAttempt(args: {
+    binary: string;
+    prompt: string;
+    timeoutMs: number;
+    effort: EffortLevel;
+    structured: boolean;
+  }): Promise<AttemptResult<string>> {
+    // First call.
+    const first = await this.spawnOnce({
+      binary: args.binary,
+      prompt: args.prompt,
+      timeoutMs: args.timeoutMs,
+      effort: args.effort,
+    });
+
+    if (!first.ok) {
+      if (first.reason === "timeout") {
+        return { ok: false, reason: "timeout" };
+      }
+      return {
+        ok: false,
+        reason: "other",
+        detail: `spawn_error: ${first.detail ?? ""}`,
+      };
+    }
+    if (first.exitCode !== 0) {
+      return classifyExit(first.exitCode, first.stderr);
+    }
+
+    if (!args.structured) {
+      return { ok: true, value: first.stdout };
+    }
+
+    // Structured: run pre-parser; on schema violation, ONE repair
+    // retry within this single timeout-attempt.
+    const parsed = preParseJson(first.stdout);
+    if (parsed.ok) {
+      return { ok: true, value: first.stdout };
+    }
+
+    const repairPrompt = buildRepairPrompt(args.prompt, first.stdout);
+    const repair = await this.spawnOnce({
+      binary: args.binary,
+      prompt: repairPrompt,
+      timeoutMs: args.timeoutMs,
+      effort: args.effort,
+    });
+
+    if (!repair.ok) {
+      if (repair.reason === "timeout") {
+        return { ok: false, reason: "timeout" };
+      }
+      return {
+        ok: false,
+        reason: "other",
+        detail: `spawn_error: ${repair.detail ?? ""}`,
+      };
+    }
+    if (repair.exitCode !== 0) {
+      return classifyExit(repair.exitCode, repair.stderr);
+    }
+
+    const parsedRepair = preParseJson(repair.stdout);
+    if (!parsedRepair.ok) {
+      return {
+        ok: false,
+        reason: "schema_violation",
+        detail: parsedRepair.error.message,
+      };
+    }
+    return { ok: true, value: repair.stdout };
+  }
+
+  private async spawnOnce(args: {
+    binary: string;
+    prompt: string;
+    timeoutMs: number;
+    effort: EffortLevel;
+  }): Promise<SpawnCliResult> {
+    const cmd: readonly string[] = [
+      args.binary,
+      ...CLAUDE_NON_INTERACTIVE_FLAGS,
+      "--model",
+      this.defaultModel,
+    ];
+    const input: SpawnCliInput = {
+      cmd,
+      stdin: args.prompt,
+      env: {},
+      timeoutMs: args.timeoutMs,
+      extraAllowedEnvKeys: CLAUDE_AUTH_ENV_KEYS,
+      host: this.host,
+    };
+    return await this.spawnFn(input);
+  }
+}
+
+// ---------- prompt builders ----------
+
+function buildAskPrompt(input: AskInput): string {
+  const ctx = input.context === "" ? "" : `\n\nContext:\n${input.context}\n`;
+  return (
+    "You are the samospec lead. Respond ONLY with a JSON object matching " +
+    'the schema { "answer": string, "usage": null, "effort_used": ' +
+    `"${input.opts.effort}" }. Do not wrap in code fences.` +
+    ctx +
+    `\n\nQuestion:\n${input.prompt}\n`
+  );
+}
+
+function buildCritiquePrompt(input: CritiqueInput): string {
+  return (
+    "You are the samospec reviewer. Return ONLY a JSON object matching " +
+    'the review-taxonomy schema: { "findings": Array<{ "category": ' +
+    'string, "text": string, "severity": "major"|"minor" }>, "summary":' +
+    ' string, "suggested_next_version": string, "usage": null, ' +
+    `"effort_used": "${input.opts.effort}" }. Do not wrap in code fences.` +
+    `\n\nGuidelines:\n${input.guidelines}\n\nSpec:\n${input.spec}\n`
+  );
+}
+
+function buildRevisePrompt(input: ReviseInput): string {
+  return (
+    "You are the samospec lead. Emit the FULL revised SPEC.md text — " +
+    "not a patch. Return ONLY a JSON object: { \"spec\": <full text>, " +
+    '"ready": boolean, "rationale": string, "usage": null, ' +
+    `"effort_used": "${input.opts.effort}" }. Do not wrap in code ` +
+    `fences.\n\nCurrent spec:\n${input.spec}\n\nReviews (JSON):\n` +
+    `${JSON.stringify(input.reviews)}\n\nDecisions so far (JSON):\n` +
+    `${JSON.stringify(input.decisions_history)}\n`
+  );
+}
+
+function buildRepairPrompt(originalPrompt: string, badOutput: string): string {
+  return (
+    "Your previous response was not valid JSON per the required schema." +
+    " Re-emit ONLY the required JSON object. No prose, no code fences. " +
+    "Previous invalid output was:\n" +
+    badOutput +
+    "\n\nRe-attempt the original request:\n" +
+    originalPrompt
+  );
+}
+
+// ---------- response parsing ----------
+
+function parseAskJson(raw: string, requestedEffort: EffortLevel): unknown {
+  const parsed = preParseJson<Record<string, unknown>>(raw);
+  if (!parsed.ok) {
+    throw new ClaudeAdapterError({
+      kind: "terminal",
+      reason: "schema_violation",
+      detail: parsed.error.message,
+    });
+  }
+  return normalizeUsageAndEffort(parsed.value, requestedEffort);
+}
+
+function parseCritiqueJson(raw: string, requestedEffort: EffortLevel): unknown {
+  const parsed = preParseJson<Record<string, unknown>>(raw);
+  if (!parsed.ok) {
+    throw new ClaudeAdapterError({
+      kind: "terminal",
+      reason: "schema_violation",
+      detail: parsed.error.message,
+    });
+  }
+  return normalizeUsageAndEffort(parsed.value, requestedEffort);
+}
+
+function parseReviseJson(raw: string, requestedEffort: EffortLevel): unknown {
+  const parsed = preParseJson<Record<string, unknown>>(raw);
+  if (!parsed.ok) {
+    throw new ClaudeAdapterError({
+      kind: "terminal",
+      reason: "schema_violation",
+      detail: parsed.error.message,
+    });
+  }
+  return normalizeUsageAndEffort(parsed.value, requestedEffort);
+}
+
+function normalizeUsageAndEffort(
+  value: Record<string, unknown>,
+  requestedEffort: EffortLevel,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...value };
+  if (!("usage" in out)) {
+    out["usage"] = null;
+  }
+  if (!("effort_used" in out)) {
+    out["effort_used"] = requestedEffort;
+  }
+  return out;
+}
+
+// ---------- error classification ----------
+
+function classifyExit(
+  exitCode: number,
+  stderr: string,
+): AttemptResult<string> {
+  // Stderr-heuristic classification per SPEC §7 failure classes.
+  // Non-zero exit is terminal unless stderr matches a known retryable
+  // pattern (rate limit, network, 5xx).
+  const lower = stderr.toLowerCase();
+  const retryable =
+    lower.includes("rate limit") ||
+    lower.includes("rate-limit") ||
+    lower.includes("network error") ||
+    lower.includes("timeout") ||
+    /\b5\d{2}\b/.test(stderr);
+  return {
+    ok: false,
+    reason: retryable ? "timeout" : "other",
+    detail: `exit ${String(exitCode)}: ${stderr.trim()}`,
+  };
+}
+
+// ---------- error type ----------
+
+export interface ClaudeAdapterErrorPayload {
+  readonly kind: "terminal";
+  readonly reason: "timeout" | "schema_violation" | "other";
+  readonly detail?: string;
+  readonly attempts?: number;
+}
+
+export class ClaudeAdapterError extends Error {
+  readonly payload: ClaudeAdapterErrorPayload;
+  constructor(payload: ClaudeAdapterErrorPayload) {
+    const detail = payload.detail ?? "";
+    super(`Claude adapter ${payload.reason}: ${detail}`);
+    this.name = "ClaudeAdapterError";
+    this.payload = payload;
+  }
+}

--- a/src/adapter/claude.ts
+++ b/src/adapter/claude.ts
@@ -333,9 +333,7 @@ export class ClaudeAdapter implements Adapter {
       attempts: outcome.attempts,
     };
     throw new ClaudeAdapterError(
-      outcome.detail !== undefined
-        ? { ...base, detail: outcome.detail }
-        : base,
+      outcome.detail !== undefined ? { ...base, detail: outcome.detail } : base,
     );
   }
 
@@ -463,7 +461,7 @@ function buildCritiquePrompt(input: CritiqueInput): string {
 function buildRevisePrompt(input: ReviseInput): string {
   return (
     "You are the samospec lead. Emit the FULL revised SPEC.md text — " +
-    "not a patch. Return ONLY a JSON object: { \"spec\": <full text>, " +
+    'not a patch. Return ONLY a JSON object: { "spec": <full text>, ' +
     '"ready": boolean, "rationale": string, "usage": null, ' +
     `"effort_used": "${input.opts.effort}" }. Do not wrap in code ` +
     `fences.\n\nCurrent spec:\n${input.spec}\n\nReviews (JSON):\n` +
@@ -537,10 +535,7 @@ function normalizeUsageAndEffort(
 
 // ---------- error classification ----------
 
-function classifyExit(
-  exitCode: number,
-  stderr: string,
-): AttemptResult<string> {
+function classifyExit(exitCode: number, stderr: string): AttemptResult<string> {
   // Stderr-heuristic classification per SPEC §7 failure classes.
   // Non-zero exit is terminal unless stderr matches a known retryable
   // pattern (rate limit, network, 5xx).

--- a/src/adapter/schemas.ts
+++ b/src/adapter/schemas.ts
@@ -1,0 +1,27 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Shared schema barrel (SPEC §7 review taxonomy + §7 lead-ready
+// protocol). Re-exports the review-taxonomy and revise response
+// schemas so future callers can import from a single stable location
+// without pulling the full adapter type surface.
+//
+// Authoritative definitions live in ./types.ts. This file exists so
+// downstream modules (loop, reviewer, render) can depend on the
+// schemas directly without re-exporting adapter internals.
+
+export {
+  FindingCategorySchema,
+  FindingSeveritySchema,
+  FindingSchema,
+  CritiqueInputSchema,
+  CritiqueOutputSchema,
+  DecisionSchema,
+  ReviseInputSchema,
+  ReviseOutputSchema,
+  type FindingCategory,
+  type Finding,
+  type CritiqueInput,
+  type CritiqueOutput,
+  type ReviseInput,
+  type ReviseOutput,
+} from "./types.ts";

--- a/tests/adapter/claude.contract.test.ts
+++ b/tests/adapter/claude.contract.test.ts
@@ -1,0 +1,113 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Drives ClaudeAdapter through the shared contract helper
+// (SPEC §13 test 4). The adapter is wired to the fake-CLI harness
+// via an injected spawn. Fixtures live under
+// tests/fixtures/claude-fixtures/.
+
+import { afterAll, describe, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { ClaudeAdapter } from "../../src/adapter/claude.ts";
+import { runAdapterContract } from "../../src/adapter/contract-test.ts";
+import {
+  spawnCli,
+  type SpawnCliInput,
+  type SpawnCliResult,
+} from "../../src/adapter/spawn.ts";
+
+const FAKE_CLI = new URL("../fixtures/fake-cli.ts", import.meta.url).pathname;
+const BUN_DIR = dirname(process.execPath);
+
+function claudeFixture(name: string): string {
+  return new URL(`../fixtures/claude-fixtures/${name}`, import.meta.url)
+    .pathname;
+}
+
+const TMP: string[] = [];
+
+afterAll(() => {
+  for (const d of TMP) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+});
+
+function makeHost(): Record<string, string | undefined> {
+  const stateDir = mkdtempSync(join(tmpdir(), "samospec-contract-"));
+  TMP.push(stateDir);
+  // A fake "claude" binary path that resolveBinaryPath() can find.
+  const binDir = mkdtempSync(join(tmpdir(), "samospec-contract-bin-"));
+  TMP.push(binDir);
+  const binPath = join(binDir, "claude");
+  writeFileSync(binPath, "#!/usr/bin/env bash\necho 2.1.114\n");
+  Bun.spawnSync(["chmod", "+x", binPath]);
+  return {
+    PATH: `${BUN_DIR}:${binDir}`,
+    HOME: stateDir,
+    TMPDIR: stateDir,
+  };
+}
+
+/**
+ * Spawn delegator that forwards work-call spawns to the fake-CLI
+ * harness, keyed by a per-adapter state file so response branches
+ * advance. Detect (--version) spawns are satisfied inline so they
+ * don't consume a branch.
+ */
+function makeDelegator(
+  fixture: string,
+): (i: SpawnCliInput) => Promise<SpawnCliResult> {
+  const stateDir = mkdtempSync(join(tmpdir(), "samospec-contract-state-"));
+  TMP.push(stateDir);
+  const stateFile = join(stateDir, "state.json");
+  writeFileSync(stateFile, JSON.stringify({ call: 0 }));
+
+  return async (input: SpawnCliInput): Promise<SpawnCliResult> => {
+    // Intercept --version probes so they don't consume a branch.
+    if (input.cmd.includes("--version")) {
+      return {
+        ok: true,
+        exitCode: 0,
+        stdout: "2.1.114 (Claude Code)\n",
+        stderr: "",
+      };
+    }
+    const env: Record<string, string | undefined> = {
+      ...input.env,
+      FAKE_CLI_FIXTURE: fixture,
+      FAKE_CLI_STATE_FILE: stateFile,
+    };
+    const rewritten: SpawnCliInput = {
+      cmd: ["bun", "run", FAKE_CLI],
+      stdin: input.stdin,
+      env,
+      timeoutMs: input.timeoutMs,
+      extraAllowedEnvKeys: [
+        ...(input.extraAllowedEnvKeys ?? []),
+        "FAKE_CLI_FIXTURE",
+        "FAKE_CLI_STATE_FILE",
+      ],
+      ...(input.host !== undefined ? { host: input.host } : {}),
+    };
+    return await spawnCli(rewritten);
+  };
+}
+
+describe("ClaudeAdapter — shared contract (SPEC §13 test 4)", () => {
+  test("passes the full contract suite via fake-CLI trio fixture", async () => {
+    await runAdapterContract({
+      name: "claude",
+      makeAdapter: () =>
+        new ClaudeAdapter({
+          host: makeHost(),
+          spawn: makeDelegator(claudeFixture("contract-trio.json")),
+        }),
+    });
+  });
+});

--- a/tests/adapter/claude.test.ts
+++ b/tests/adapter/claude.test.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Tests for the Claude adapter (SPEC §7, §11, §13 test 4).
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ClaudeAdapter } from "../../src/adapter/claude.ts";
+
+const TMP_DIRS: string[] = [];
+
+function makeEmptyPathDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-empty-path-"));
+  TMP_DIRS.push(dir);
+  return dir;
+}
+
+function makeFakeBinaryDir(
+  name: string,
+  script: string,
+): { dir: string; binary: string } {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-fake-bin-"));
+  TMP_DIRS.push(dir);
+  const binary = join(dir, name);
+  writeFileSync(binary, `#!/usr/bin/env bash\n${script}\n`);
+  chmodSync(binary, 0o755);
+  return { dir, binary };
+}
+
+afterAll(() => {
+  for (const d of TMP_DIRS) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+});
+
+describe("ClaudeAdapter — lifecycle (SPEC §7, §11)", () => {
+  test("vendor is 'claude'", () => {
+    const adapter = new ClaudeAdapter();
+    expect(adapter.vendor).toBe("claude");
+  });
+
+  test("detect() returns { installed: false } when PATH has no claude binary", async () => {
+    const emptyDir = makeEmptyPathDir();
+    const adapter = new ClaudeAdapter({
+      host: { PATH: emptyDir, HOME: "/tmp" },
+    });
+    const result = await adapter.detect();
+    expect(result.installed).toBe(false);
+  });
+
+  test("detect() returns { installed: true, version, path } when claude binary exists", async () => {
+    const { dir, binary } = makeFakeBinaryDir(
+      "claude",
+      'echo "2.1.114 (Claude Code)"',
+    );
+    const adapter = new ClaudeAdapter({
+      host: { PATH: dir, HOME: "/tmp" },
+    });
+    const result = await adapter.detect();
+    expect(result.installed).toBe(true);
+    if (result.installed) {
+      expect(result.version.length).toBeGreaterThan(0);
+      expect(result.path).toBe(binary);
+    }
+  });
+
+  test("supports_structured_output() returns true", () => {
+    const adapter = new ClaudeAdapter();
+    expect(adapter.supports_structured_output()).toBe(true);
+  });
+
+  test("supports_effort() returns true for every effort level", () => {
+    const adapter = new ClaudeAdapter();
+    for (const level of ["max", "high", "medium", "low", "off"] as const) {
+      expect(adapter.supports_effort(level)).toBe(true);
+    }
+  });
+
+  test("models() returns pinned default model with family 'claude'", async () => {
+    const adapter = new ClaudeAdapter();
+    const models = await adapter.models();
+    expect(models.length).toBeGreaterThan(0);
+    const ids = models.map((m) => m.id);
+    expect(ids).toContain("claude-opus-4-7");
+    for (const m of models) {
+      expect(m.family).toBe("claude");
+    }
+  });
+});

--- a/tests/adapter/claude.test.ts
+++ b/tests/adapter/claude.test.ts
@@ -59,13 +59,15 @@ describe("ClaudeAdapter — lifecycle (SPEC §7, §11)", () => {
       "claude",
       'echo "2.1.114 (Claude Code)"',
     );
+    // Include /bin and /usr/bin on PATH so the shebang can resolve
+    // bash (macOS: /bin/bash; Linux: /bin/bash or /usr/bin/bash).
     const adapter = new ClaudeAdapter({
-      host: { PATH: dir, HOME: "/tmp" },
+      host: { PATH: `${dir}:/bin:/usr/bin`, HOME: "/tmp" },
     });
     const result = await adapter.detect();
     expect(result.installed).toBe(true);
     if (result.installed) {
-      expect(result.version.length).toBeGreaterThan(0);
+      expect(result.version).toBe("2.1.114");
       expect(result.path).toBe(binary);
     }
   });

--- a/tests/adapter/claude.work.test.ts
+++ b/tests/adapter/claude.work.test.ts
@@ -468,6 +468,57 @@ describe("ClaudeAdapter schema-violation repair (SPEC §7)", () => {
   });
 });
 
+// ---------- exit-code classification ----------
+
+describe("ClaudeAdapter exit-code classification (SPEC §7)", () => {
+  test("non-zero exit with terminal stderr -> terminal error, no retry", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 2,
+      stdout: "",
+      stderr: "unauthorized: no token",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ClaudeAdapterError);
+    if (err instanceof ClaudeAdapterError) {
+      expect(err.payload.kind).toBe("terminal");
+      expect(err.payload.reason).toBe("other");
+    }
+    // No retry: runWithCappedRetry bails on non-timeout failure.
+    expect(spy.calls.length).toBe(1);
+  });
+
+  test("non-zero exit with rate-limit stderr -> retried as timeout class", async () => {
+    // Every attempt returns the same rate-limit error; runWithCappedRetry
+    // retries 3 times before giving up.
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 1,
+      stdout: "",
+      stderr: "rate limit exceeded (429)",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ClaudeAdapterError);
+    expect(spy.calls.length).toBe(3);
+  });
+});
+
 // ---------- capped timeout retry ----------
 
 describe("ClaudeAdapter capped timeout retry (SPEC §7)", () => {

--- a/tests/adapter/claude.work.test.ts
+++ b/tests/adapter/claude.work.test.ts
@@ -279,6 +279,73 @@ describe("ClaudeAdapter spawn flags + minimal env (SPEC §7)", () => {
     expect(workCall.extraAllowedEnvKeys).toContain("ANTHROPIC_API_KEY");
   });
 
+  test("end-to-end minimal-env: fake-CLI child sees only allowlist keys (no host secrets leak)", async () => {
+    // Captures the child's env dump by wrapping the adapter's spawn
+    // with a "peek" layer: the wrapper records the child's stdout
+    // (the raw env_keys JSON) and then returns a canned schema-valid
+    // JSON to keep ask() happy.
+    const echoEnv = new URL(
+      "../fixtures/fake-cli-fixtures/echo-env.json",
+      import.meta.url,
+    ).pathname;
+    let capturedKeys: readonly string[] = [];
+
+    const peekSpawn = async (input: SpawnCliInput): Promise<SpawnCliResult> => {
+      // First, run the fake-cli for real to capture the env dump.
+      const env: Record<string, string | undefined> = {
+        ...input.env,
+        FAKE_CLI_FIXTURE: echoEnv,
+      };
+      const hostSnapshot: Record<string, string | undefined> = {
+        ...(input.host ?? {}),
+      };
+      const hostPath = hostSnapshot["PATH"] ?? "";
+      hostSnapshot["PATH"] =
+        hostPath === "" ? BUN_DIR : `${BUN_DIR}:${hostPath}`;
+
+      const raw = await spawnCli({
+        cmd: ["bun", "run", FAKE_CLI],
+        stdin: input.stdin,
+        env,
+        timeoutMs: input.timeoutMs,
+        extraAllowedEnvKeys: [
+          ...(input.extraAllowedEnvKeys ?? []),
+          "FAKE_CLI_FIXTURE",
+        ],
+        host: hostSnapshot,
+      });
+      if (raw.ok) {
+        const parsed = JSON.parse(raw.stdout) as { keys?: string[] };
+        capturedKeys = parsed.keys ?? [];
+      }
+      // Return canned JSON for ask() to validate cleanly.
+      return {
+        ok: true,
+        exitCode: 0,
+        stdout: '{"answer":"ok","usage":null,"effort_used":"max"}',
+        stderr: "",
+      };
+    };
+
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({
+      host: {
+        ...host,
+        TMPDIR: "/tmp",
+        ANTHROPIC_API_KEY: "sk-forwarded-value",
+        LEAKY_HOST_SECRET: "nope",
+      },
+      spawn: peekSpawn,
+    });
+
+    await adapter.ask(sampleAsk());
+
+    // Allowlist: HOME, PATH, TMPDIR, ANTHROPIC_API_KEY (+ harness
+    // FAKE_CLI_FIXTURE for the peek wrapper). Nothing else host-side.
+    expect(capturedKeys).toContain("ANTHROPIC_API_KEY");
+    expect(capturedKeys).not.toContain("LEAKY_HOST_SECRET");
+  });
+
   test("revise() returns ready + rationale from JSON body, not parsed from Markdown prose", async () => {
     const spy = makeSpy({
       ok: true,

--- a/tests/adapter/claude.work.test.ts
+++ b/tests/adapter/claude.work.test.ts
@@ -18,12 +18,7 @@
 // Fixtures live under tests/fixtures/claude-fixtures/.
 
 import { afterAll, describe, expect, test } from "bun:test";
-import {
-  mkdtempSync,
-  writeFileSync,
-  chmodSync,
-  rmSync,
-} from "node:fs";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -48,10 +43,8 @@ const BUN_DIR = dirname(process.execPath);
 const FAKE_CLI = new URL("../fixtures/fake-cli.ts", import.meta.url).pathname;
 
 function claudeFixture(name: string): string {
-  return new URL(
-    `../fixtures/claude-fixtures/${name}`,
-    import.meta.url,
-  ).pathname;
+  return new URL(`../fixtures/claude-fixtures/${name}`, import.meta.url)
+    .pathname;
 }
 
 const TMP: string[] = [];
@@ -110,7 +103,7 @@ function makeSpy(
       extraAllowedEnvKeys: [...(input.extraAllowedEnvKeys ?? [])],
     });
     const result = Array.isArray(scripted)
-      ? scripted[calls.length - 1] ?? scripted[scripted.length - 1]!
+      ? (scripted[calls.length - 1] ?? scripted[scripted.length - 1]!)
       : (scripted as SpawnCliResult);
     return Promise.resolve(result);
   };
@@ -149,8 +142,7 @@ function makeFakeCliSpy(opts: {
       ...(input.host ?? {}),
     };
     const hostPath = hostSnapshot["PATH"] ?? "";
-    const mergedPath =
-      hostPath === "" ? BUN_DIR : `${BUN_DIR}:${hostPath}`;
+    const mergedPath = hostPath === "" ? BUN_DIR : `${BUN_DIR}:${hostPath}`;
     hostSnapshot["PATH"] = mergedPath;
 
     const rewritten: SpawnCliInput = {
@@ -353,9 +345,7 @@ describe("ClaudeAdapter schema-violation repair (SPEC §7)", () => {
   });
 
   test("schema-violation then repair: first call garbage, second valid", async () => {
-    const stateFile = mkdtempSync(
-      join(tmpdir(), "samospec-claude-state-"),
-    );
+    const stateFile = mkdtempSync(join(tmpdir(), "samospec-claude-state-"));
     TMP.push(stateFile);
     const stateJson = join(stateFile, "call-state.json");
     writeFileSync(stateJson, JSON.stringify({ call: 0 }));

--- a/tests/adapter/claude.work.test.ts
+++ b/tests/adapter/claude.work.test.ts
@@ -1,0 +1,463 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Work-call tests for the Claude adapter. Uses a spawn-spy that
+// optionally delegates to the fake-CLI harness for end-to-end
+// stdout-through-pre-parser behavior.
+//
+// Covers (SPEC §7, §11, §13 test 4):
+// - auth_status: subscription_auth detection (both branches)
+// - spawn-spy: non-interactive flags (--print --dangerously-skip-permissions)
+// - spawn-spy: minimal env forwarded
+// - spawn-spy: --model pin
+// - schema-violation repair: one retry, then terminal
+// - `usage: null` path
+// - revise() emits JSON-backed `ready` + `rationale`
+// - capped timeout retry (base → +50% → base → terminal)
+// - Markdown-code-fence stripping end-to-end
+//
+// Fixtures live under tests/fixtures/claude-fixtures/.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+  mkdtempSync,
+  writeFileSync,
+  chmodSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { dirname } from "node:path";
+
+import { ClaudeAdapter, ClaudeAdapterError } from "../../src/adapter/claude.ts";
+import {
+  type AskInput,
+  type CritiqueInput,
+  type EffortLevel,
+  type ReviseInput,
+} from "../../src/adapter/types.ts";
+import {
+  type SpawnCliInput,
+  type SpawnCliResult,
+} from "../../src/adapter/spawn.ts";
+import { spawnCli } from "../../src/adapter/spawn.ts";
+
+// Tests that spawn the fake-cli need `bun` reachable via PATH.
+const BUN_DIR = dirname(process.execPath);
+
+const FAKE_CLI = new URL("../fixtures/fake-cli.ts", import.meta.url).pathname;
+
+function claudeFixture(name: string): string {
+  return new URL(
+    `../fixtures/claude-fixtures/${name}`,
+    import.meta.url,
+  ).pathname;
+}
+
+const TMP: string[] = [];
+
+function makeFakeBinaryDir(
+  name: string,
+  script: string,
+): { dir: string; binary: string } {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-claude-bin-"));
+  TMP.push(dir);
+  const binary = join(dir, name);
+  writeFileSync(binary, `#!/usr/bin/env bash\n${script}\n`);
+  chmodSync(binary, 0o755);
+  return { dir, binary };
+}
+
+afterAll(() => {
+  for (const d of TMP) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+});
+
+// ---------- spawn-spy ----------
+
+interface SpawnSpyCall {
+  readonly cmd: readonly string[];
+  readonly env: Record<string, string | undefined>;
+  readonly timeoutMs: number;
+  readonly stdinLen: number;
+  readonly extraAllowedEnvKeys: readonly string[];
+}
+
+interface SpawnSpy {
+  readonly spawn: (input: SpawnCliInput) => Promise<SpawnCliResult>;
+  readonly calls: SpawnSpyCall[];
+}
+
+/**
+ * Spy-only: records every call and returns a canned scripted result.
+ * `scripted` may be a single response or an array indexed by call #.
+ */
+function makeSpy(
+  scripted: SpawnCliResult | readonly SpawnCliResult[],
+): SpawnSpy {
+  const calls: SpawnSpyCall[] = [];
+  const spawn = (input: SpawnCliInput): Promise<SpawnCliResult> => {
+    calls.push({
+      cmd: [...input.cmd],
+      env: { ...input.env },
+      timeoutMs: input.timeoutMs,
+      stdinLen: input.stdin.length,
+      extraAllowedEnvKeys: [...(input.extraAllowedEnvKeys ?? [])],
+    });
+    const result = Array.isArray(scripted)
+      ? scripted[calls.length - 1] ?? scripted[scripted.length - 1]!
+      : (scripted as SpawnCliResult);
+    return Promise.resolve(result);
+  };
+  return { spawn, calls };
+}
+
+/**
+ * Hybrid spy: records every call, then delegates to the fake-CLI
+ * harness by rewriting the cmd to `bun run FAKE_CLI`. Forwards the
+ * fixture path + state file via env. Injects bun's dir into PATH so
+ * the subprocess can locate the bun runtime under minimal-env.
+ */
+function makeFakeCliSpy(opts: {
+  fixture: string;
+  stateFile?: string;
+}): SpawnSpy {
+  const calls: SpawnSpyCall[] = [];
+  const spawn = async (input: SpawnCliInput): Promise<SpawnCliResult> => {
+    calls.push({
+      cmd: [...input.cmd],
+      env: { ...input.env },
+      timeoutMs: input.timeoutMs,
+      stdinLen: input.stdin.length,
+      extraAllowedEnvKeys: [...(input.extraAllowedEnvKeys ?? [])],
+    });
+    const env: Record<string, string | undefined> = {
+      ...input.env,
+      FAKE_CLI_FIXTURE: opts.fixture,
+    };
+    if (opts.stateFile !== undefined) {
+      env["FAKE_CLI_STATE_FILE"] = opts.stateFile;
+    }
+    // Merge host PATH (for the fake-bin) with BUN_DIR (for the bun
+    // interpreter) so `bun run FAKE_CLI` resolves under minimal-env.
+    const hostSnapshot: Record<string, string | undefined> = {
+      ...(input.host ?? {}),
+    };
+    const hostPath = hostSnapshot["PATH"] ?? "";
+    const mergedPath =
+      hostPath === "" ? BUN_DIR : `${BUN_DIR}:${hostPath}`;
+    hostSnapshot["PATH"] = mergedPath;
+
+    const rewritten: SpawnCliInput = {
+      cmd: ["bun", "run", FAKE_CLI],
+      stdin: input.stdin,
+      env,
+      timeoutMs: input.timeoutMs,
+      extraAllowedEnvKeys: [
+        ...(input.extraAllowedEnvKeys ?? []),
+        "FAKE_CLI_FIXTURE",
+        "FAKE_CLI_STATE_FILE",
+      ],
+      host: hostSnapshot,
+    };
+    return await spawnCli(rewritten);
+  };
+  return { spawn, calls };
+}
+
+// ---------- helpers ----------
+
+const OPTS_MAX_120: { effort: EffortLevel; timeout: number } = {
+  effort: "max",
+  timeout: 120_000,
+};
+
+function makeInstalledHost(): {
+  host: Record<string, string | undefined>;
+  binaryPath: string;
+} {
+  const { dir, binary } = makeFakeBinaryDir("claude", 'echo "2.1.114"');
+  return {
+    host: { PATH: dir, HOME: "/tmp" },
+    binaryPath: binary,
+  };
+}
+
+function sampleAsk(): AskInput {
+  return { prompt: "ping", context: "", opts: OPTS_MAX_120 };
+}
+function sampleCritique(): CritiqueInput {
+  return {
+    spec: "# SPEC\n\nplaceholder",
+    guidelines: "be paranoid",
+    opts: OPTS_MAX_120,
+  };
+}
+function sampleRevise(): ReviseInput {
+  return {
+    spec: "# SPEC\n\nplaceholder",
+    reviews: [],
+    decisions_history: [],
+    opts: OPTS_MAX_120,
+  };
+}
+
+// ---------- auth_status ----------
+
+describe("ClaudeAdapter.auth_status (SPEC §11 subscription-auth)", () => {
+  test("no binary on PATH -> { authenticated: false }", async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "samospec-empty-"));
+    TMP.push(emptyDir);
+    const adapter = new ClaudeAdapter({
+      host: { PATH: emptyDir, HOME: "/tmp" },
+    });
+    const result = await adapter.auth_status();
+    expect(result.authenticated).toBe(false);
+  });
+
+  test("binary present + ANTHROPIC_API_KEY set -> subscription_auth=false", async () => {
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({
+      host: { ...host, ANTHROPIC_API_KEY: "sk-test-not-a-real-key" },
+    });
+    const result = await adapter.auth_status();
+    expect(result.authenticated).toBe(true);
+    expect(result.subscription_auth).toBe(false);
+  });
+
+  test("binary present + no API key -> subscription_auth=true (keychain assumed)", async () => {
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host });
+    const result = await adapter.auth_status();
+    expect(result.authenticated).toBe(true);
+    expect(result.subscription_auth).toBe(true);
+  });
+});
+
+// ---------- spawn-spy: flags + env + model ----------
+
+describe("ClaudeAdapter spawn flags + minimal env (SPEC §7)", () => {
+  test("ask() passes --print --dangerously-skip-permissions and --model pin", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: '{"answer":"ok","usage":null,"effort_used":"max"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+
+    await adapter.ask(sampleAsk());
+
+    // First spawn-spy call may be a version probe (detect-style).
+    // Look at the call that carried the prompt on stdin.
+    const workCall = spy.calls.find((c) => c.stdinLen > 0);
+    expect(workCall).toBeDefined();
+    if (workCall === undefined) return;
+    expect(workCall.cmd).toContain("--print");
+    expect(workCall.cmd).toContain("--dangerously-skip-permissions");
+    expect(workCall.cmd).toContain("--model");
+    expect(workCall.cmd).toContain("claude-opus-4-7");
+  });
+
+  test("work-call spawn forwards only HOME, PATH, TMPDIR, Claude auth vars", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: '{"answer":"ok","usage":null,"effort_used":"max"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({
+      host: { ...host, TMPDIR: "/tmp", ANTHROPIC_API_KEY: "sk-test" },
+      spawn: spy.spawn,
+    });
+    await adapter.ask(sampleAsk());
+
+    const workCall = spy.calls.find((c) => c.stdinLen > 0);
+    expect(workCall).toBeDefined();
+    if (workCall === undefined) return;
+    // extraAllowedEnvKeys must include the Claude auth key so spawnCli
+    // forwards it from host into child env.
+    expect(workCall.extraAllowedEnvKeys).toContain("ANTHROPIC_API_KEY");
+  });
+
+  test("revise() returns ready + rationale from JSON body, not parsed from Markdown prose", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout:
+        '{"spec":"# SPEC\\n\\nrevised.","ready":true,' +
+        '"rationale":"looks good","usage":null,"effort_used":"max"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+
+    const out = await adapter.revise(sampleRevise());
+    expect(out.ready).toBe(true);
+    expect(out.rationale).toBe("looks good");
+    expect(out.spec).toContain("# SPEC");
+    expect(out.usage).toBeNull();
+  });
+
+  test("revise() returns ready=false when model signals not ready", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout:
+        '{"spec":"# SPEC\\n\\n.","ready":false,' +
+        '"rationale":"more rounds","usage":null,"effort_used":"max"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+    const out = await adapter.revise(sampleRevise());
+    expect(out.ready).toBe(false);
+  });
+
+  test("usage defaults to null when CLI omits it", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      // No "usage" field in the response body at all.
+      stdout: '{"answer":"no usage info"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+    const out = await adapter.ask(sampleAsk());
+    expect(out.usage).toBeNull();
+    // effort_used defaults to requested when CLI omits it.
+    expect(out.effort_used).toBe("max");
+  });
+});
+
+// ---------- schema-violation repair (end-to-end via fake-CLI) ----------
+
+describe("ClaudeAdapter schema-violation repair (SPEC §7)", () => {
+  test("happy ask(): fake-CLI emits valid JSON once", async () => {
+    const spy = makeFakeCliSpy({
+      fixture: claudeFixture("ask-happy.json"),
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+    const out = await adapter.ask(sampleAsk());
+    expect(out.answer).toBe("hello from claude");
+    expect(out.usage).toBeNull();
+  });
+
+  test("schema-violation then repair: first call garbage, second valid", async () => {
+    const stateFile = mkdtempSync(
+      join(tmpdir(), "samospec-claude-state-"),
+    );
+    TMP.push(stateFile);
+    const stateJson = join(stateFile, "call-state.json");
+    writeFileSync(stateJson, JSON.stringify({ call: 0 }));
+
+    const spy = makeFakeCliSpy({
+      fixture: claudeFixture("ask-schema-repair.json"),
+      stateFile: stateJson,
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+
+    const out = await adapter.ask(sampleAsk());
+    expect(out.answer).toBe("repaired");
+    // Exactly two spawns: one bad, one repair.
+    expect(spy.calls.length).toBe(2);
+  });
+
+  test("schema-violation twice: terminal after ONE repair retry", async () => {
+    const spy = makeFakeCliSpy({
+      fixture: claudeFixture("ask-schema-fatal.json"),
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ClaudeAdapterError);
+    if (err instanceof ClaudeAdapterError) {
+      expect(err.payload.reason).toBe("schema_violation");
+      expect(err.payload.kind).toBe("terminal");
+    }
+    // Two spawns per timeout-attempt (original + repair). Since the
+    // repair fails, this is classified schema_violation and the
+    // capped-retry helper does NOT retry schema violations — so
+    // exactly 2 spawns total.
+    expect(spy.calls.length).toBe(2);
+  });
+
+  test("Markdown-fenced JSON is stripped and validated end-to-end", async () => {
+    const spy = makeFakeCliSpy({
+      fixture: claudeFixture("ask-fenced.json"),
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+
+    const out = await adapter.ask(sampleAsk());
+    expect(out.answer).toBe("fenced-ok");
+    expect(out.usage).toBeNull();
+  });
+});
+
+// ---------- capped timeout retry ----------
+
+describe("ClaudeAdapter capped timeout retry (SPEC §7)", () => {
+  test("three timeouts -> terminal; timeouts are base, +50%, base", async () => {
+    const spy = makeSpy({ ok: false, reason: "timeout" });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+
+    let err: unknown;
+    try {
+      await adapter.ask({
+        prompt: "slow",
+        context: "",
+        opts: { effort: "max", timeout: 1000 },
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ClaudeAdapterError);
+    if (err instanceof ClaudeAdapterError) {
+      expect(err.payload.reason).toBe("timeout");
+      expect(err.payload.kind).toBe("terminal");
+      expect(err.payload.attempts).toBe(3);
+    }
+    // capped retry schedule: 1000, 1500, 1000.
+    expect(spy.calls.length).toBe(3);
+    expect(spy.calls[0]?.timeoutMs).toBe(1000);
+    expect(spy.calls[1]?.timeoutMs).toBe(1500);
+    expect(spy.calls[2]?.timeoutMs).toBe(1000);
+  });
+});
+
+// ---------- critique ----------
+
+describe("ClaudeAdapter.critique (SPEC §7)", () => {
+  test("returns schema-valid findings + summary + suggested_next_version", async () => {
+    const spy = makeFakeCliSpy({
+      fixture: claudeFixture("critique-happy.json"),
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new ClaudeAdapter({ host, spawn: spy.spawn });
+
+    const out = await adapter.critique(sampleCritique());
+    expect(Array.isArray(out.findings)).toBe(true);
+    expect(out.findings.length).toBeGreaterThan(0);
+    expect(out.summary).toBeTruthy();
+    expect(out.suggested_next_version).toBeTruthy();
+    expect(out.usage).toBeNull();
+  });
+});

--- a/tests/adapter/schemas.test.ts
+++ b/tests/adapter/schemas.test.ts
@@ -1,0 +1,27 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Barrel sanity: src/adapter/schemas.ts re-exports the authoritative
+// review-taxonomy + revise schemas from ./types.ts. This keeps a
+// stable import path for downstream modules (loop, reviewer, render)
+// without entangling them with adapter internals.
+
+import { describe, expect, test } from "bun:test";
+
+import * as types from "../../src/adapter/types.ts";
+import * as schemas from "../../src/adapter/schemas.ts";
+
+describe("src/adapter/schemas.ts barrel (SPEC §7)", () => {
+  test("re-exports review-taxonomy schemas identical to types.ts", () => {
+    expect(schemas.FindingCategorySchema).toBe(types.FindingCategorySchema);
+    expect(schemas.FindingSeveritySchema).toBe(types.FindingSeveritySchema);
+    expect(schemas.FindingSchema).toBe(types.FindingSchema);
+    expect(schemas.CritiqueInputSchema).toBe(types.CritiqueInputSchema);
+    expect(schemas.CritiqueOutputSchema).toBe(types.CritiqueOutputSchema);
+  });
+
+  test("re-exports revise schemas identical to types.ts", () => {
+    expect(schemas.DecisionSchema).toBe(types.DecisionSchema);
+    expect(schemas.ReviseInputSchema).toBe(types.ReviseInputSchema);
+    expect(schemas.ReviseOutputSchema).toBe(types.ReviseOutputSchema);
+  });
+});

--- a/tests/fixtures/claude-fixtures/ask-fenced.json
+++ b/tests/fixtures/claude-fixtures/ask-fenced.json
@@ -1,0 +1,9 @@
+{
+  "script": [
+    {
+      "type": "stdout",
+      "text": "```json\n{\"answer\":\"fenced-ok\",\"usage\":null,\"effort_used\":\"max\"}\n```"
+    },
+    { "type": "exit", "code": 0 }
+  ]
+}

--- a/tests/fixtures/claude-fixtures/ask-happy.json
+++ b/tests/fixtures/claude-fixtures/ask-happy.json
@@ -1,0 +1,9 @@
+{
+  "script": [
+    {
+      "type": "stdout",
+      "text": "{\"answer\":\"hello from claude\",\"usage\":null,\"effort_used\":\"max\"}"
+    },
+    { "type": "exit", "code": 0 }
+  ]
+}

--- a/tests/fixtures/claude-fixtures/ask-schema-fatal.json
+++ b/tests/fixtures/claude-fixtures/ask-schema-fatal.json
@@ -1,0 +1,6 @@
+{
+  "script": [
+    { "type": "stdout", "text": "always garbage" },
+    { "type": "exit", "code": 0 }
+  ]
+}

--- a/tests/fixtures/claude-fixtures/ask-schema-repair.json
+++ b/tests/fixtures/claude-fixtures/ask-schema-repair.json
@@ -1,0 +1,19 @@
+{
+  "branches": {
+    "0": {
+      "script": [
+        { "type": "stdout", "text": "this is not json at all" },
+        { "type": "exit", "code": 0 }
+      ]
+    },
+    "default": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"answer\":\"repaired\",\"usage\":null,\"effort_used\":\"max\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/claude-fixtures/contract-trio.json
+++ b/tests/fixtures/claude-fixtures/contract-trio.json
@@ -1,0 +1,40 @@
+{
+  "branches": {
+    "0": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"answer\":\"ok\",\"usage\":null,\"effort_used\":\"max\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    },
+    "1": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"findings\":[{\"category\":\"ambiguity\",\"text\":\"x\",\"severity\":\"minor\"}],\"summary\":\"s\",\"suggested_next_version\":\"0.1.1\",\"usage\":null,\"effort_used\":\"max\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    },
+    "2": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"spec\":\"# SPEC\\n\\n.\",\"ready\":false,\"rationale\":\"one more round\",\"usage\":null,\"effort_used\":\"max\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    },
+    "default": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"answer\":\"extra-call\",\"usage\":null,\"effort_used\":\"max\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/claude-fixtures/critique-happy.json
+++ b/tests/fixtures/claude-fixtures/critique-happy.json
@@ -1,0 +1,9 @@
+{
+  "script": [
+    {
+      "type": "stdout",
+      "text": "{\"findings\":[{\"category\":\"ambiguity\",\"text\":\"'significant' — how significant?\",\"severity\":\"minor\"}],\"summary\":\"one minor ambiguity\",\"suggested_next_version\":\"0.1.1\",\"usage\":null,\"effort_used\":\"max\"}"
+    },
+    { "type": "exit", "code": 0 }
+  ]
+}

--- a/tests/fixtures/claude-fixtures/revise-happy.json
+++ b/tests/fixtures/claude-fixtures/revise-happy.json
@@ -1,0 +1,9 @@
+{
+  "script": [
+    {
+      "type": "stdout",
+      "text": "{\"spec\":\"# SPEC\\n\\nrevised.\",\"ready\":true,\"rationale\":\"ok\",\"usage\":null,\"effort_used\":\"max\"}"
+    },
+    { "type": "exit", "code": 0 }
+  ]
+}


### PR DESCRIPTION
Closes #12

## Summary

Implements `ClaudeAdapter` (SPEC §7, §11) — the lead-seat Claude CLI wrapper, first concrete adapter on top of the Sprint 1 interface, fake-CLI harness, JSON pre-parser, capped-timeout retry, and minimal-env spawn substrate.

- Lifecycle: `detect()` (PATH resolve + `--version` probe), `auth_status()` (env-heuristic subscription-auth escape), `supports_structured_output()` / `supports_effort()` (all levels), `models()` (pinned `claude-opus-4-7` + fallback `claude-sonnet-4-6`).
- Non-interactive flags: `--print --dangerously-skip-permissions` (constants from Sprint 1 `spawn.ts`, documented there for the v2.1.x target).
- Minimal env: only `HOME`, `PATH`, `TMPDIR`, `ANTHROPIC_API_KEY` forwarded; proved end-to-end by a peek spawn that captures the child's env dump.
- Work calls (`ask` / `critique` / `revise`): JSON pre-parser → zod validate; one repair retry on schema violation within a single timeout-attempt; capped timeout retry (base → +50% → base → terminal); `usage: null` default when CLI omits accounting; `effort_used` defaults to requested.
- `revise()` emits the full SPEC.md text each round (not a patch) with `ready` + `rationale` inline (SPEC §7 lead-ready protocol).
- Shared schema barrel at `src/adapter/schemas.ts` re-exports review-taxonomy + revise response types for downstream consumers (loop, reviewer, render).
- Contract test (SPEC §13 test 4): `runAdapterContract` drives `ClaudeAdapter` through a fake-CLI trio fixture, with `--version` probes stubbed inline so the branch counter isn't skewed.

## Files changed

- `src/adapter/claude.ts` — `ClaudeAdapter` + `ClaudeAdapterError`.
- `src/adapter/schemas.ts` — barrel re-exporting review-taxonomy + revise schemas.
- `tests/adapter/claude.test.ts` — lifecycle RED/GREEN (detect with empty PATH, detect with fake bin, supports_*, models).
- `tests/adapter/claude.work.test.ts` — auth_status + spawn-spy (flags, env, model pin) + schema-repair E2E + capped timeout retry + exit-code classification (17 tests).
- `tests/adapter/claude.contract.test.ts` — drives `runAdapterContract` through a branched fake-CLI fixture.
- `tests/adapter/schemas.test.ts` — barrel identity checks.
- `tests/fixtures/claude-fixtures/*.json` — scripted responses (ask-happy, ask-fenced, ask-schema-repair, ask-schema-fatal, critique-happy, revise-happy, contract-trio).

## Checklist

- [x] `ClaudeAdapter` implements the full `Adapter` interface
- [x] Non-interactive flags `--print --dangerously-skip-permissions` + `--model claude-opus-4-7` passed via spawn-spy verification
- [x] Minimal env: only HOME, PATH, TMPDIR, ANTHROPIC_API_KEY (end-to-end child-env dump)
- [x] `detect()` returns `{installed:false}` when binary missing (empty-PATH test)
- [x] `auth_status()` subscription-auth detection (both branches)
- [x] `supports_structured_output()` = true; `supports_effort()` true for all five levels
- [x] `models()` returns pinned defaults with family `claude`
- [x] `ask()` / `critique()` / `revise()` accept `{effort, timeout}`; `revise()` returns JSON-backed `ready` + `rationale`
- [x] Schema-violation: ONE repair retry within a timeout-attempt; terminal after second failure
- [x] Capped timeout retry: base → +50% → base → terminal (3 attempts)
- [x] `usage: null` default when CLI omits accounting
- [x] Markdown-code-fence stripping via shared `preParseJson`
- [x] Contract test passes through the full `runAdapterContract` helper

## Testing evidence

```
bun test 447/447 pass (30 files, ~16s)
bun run lint         no errors
bun run format:check All matched files use Prettier code style!
bun run typecheck    clean
coverage             src/adapter/claude.ts  97.06 / 95.54 (above 90% gate)
```

Spawn-spy + flag verification excerpt (from `tests/adapter/claude.work.test.ts`):

```ts
expect(workCall.cmd).toContain("--print");
expect(workCall.cmd).toContain("--dangerously-skip-permissions");
expect(workCall.cmd).toContain("--model");
expect(workCall.cmd).toContain("claude-opus-4-7");
```

Minimal-env end-to-end excerpt:

```ts
expect(capturedKeys).toContain("ANTHROPIC_API_KEY");
expect(capturedKeys).not.toContain("LEAKY_HOST_SECRET");
```

Capped-retry excerpt:

```
spy.calls[0].timeoutMs === 1000
spy.calls[1].timeoutMs === 1500  // +50%
spy.calls[2].timeoutMs === 1000  // back to base
attempts === 3, kind === "terminal"
```

## Scope guardrails respected

- Claude adapter only (lead seat); no Codex / OpenCode / Gemini.
- No persona system prompts; callers pass persona via `opts` / prompt.
- No context wiring; callers pass a context string.
- No real model calls in tests — only fake-CLI fixtures.
- Copyright + Markdown `- ` lists.

## Test plan

- [x] Full suite `bun test` green on this branch
- [x] `typecheck` / `lint` / `format:check` clean
- [x] Coverage above 90% for `src/adapter/claude.ts`
- [x] Manual sanity: `detect()` + `auth_status()` against the installed `claude 2.1.114` returns installed + version parsed + `subscription_auth` reflecting the env