### PR TITLE
feat: Sprint 2 #14 — preflight cost estimate + calibration + wall-clock overrun

### DIFF
--- a/src/policy/calibration.ts
+++ b/src/policy/calibration.ts
@@ -1,0 +1,158 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §11 calibration storage.
+//
+// `.samospec/config.json` gains a `calibration` object:
+//
+//   {
+//     "calibration": {
+//       "sample_count": 0,
+//       "tokens_per_round": [],
+//       "rounds_to_converge": [],
+//       "cost_per_run_usd": []
+//     }
+//   }
+//
+// This module exposes the typed read + the pure write helper
+// (`recordSession`) that will be wired into the end-of-session
+// save path by Issue #15 (Sprint 3). It also ships the blend-weight
+// helper used by `preflight.ts`:
+//
+//   blendWeight = min(sample_count, 10) / 10
+//
+// Policy (SPEC §11):
+//   - sample_count < 3  -> calibration is ignored (below floor)
+//   - 3 <= count < 10   -> blended with defaults
+//   - count >= 10       -> calibration dominates
+//
+// Arrays cap at 20; drop the oldest entry on overflow.
+
+import { z } from "zod";
+
+// ---------- constants ----------
+
+/** SPEC §11: preflight uses calibration only when sample_count >= floor. */
+export const CALIBRATION_FLOOR = 3 as const;
+
+/** SPEC §11: arrays are capped at this many samples; drop oldest. */
+export const CALIBRATION_CAP = 20 as const;
+
+/**
+ * SPEC §11 blend formula hinge point: above this count the calibration
+ * is treated as dominant and the weight caps at 1.0.
+ */
+const BLEND_SATURATION = 10 as const;
+
+// ---------- zod schema ----------
+
+export const CalibrationSchema = z
+  .object({
+    sample_count: z.number().int().nonnegative(),
+    tokens_per_round: z.array(z.number()),
+    rounds_to_converge: z.array(z.number()),
+    cost_per_run_usd: z.array(z.number()),
+  })
+  .strict();
+
+export type Calibration = z.infer<typeof CalibrationSchema>;
+
+export interface CalibrationMeans {
+  readonly mean_tokens_per_round: number;
+  readonly mean_rounds_to_converge: number;
+  readonly mean_cost_per_run_usd: number;
+}
+
+export interface CalibrationSample {
+  readonly session_actual_tokens: number;
+  readonly session_actual_cost_usd: number;
+  readonly session_rounds: number;
+}
+
+// ---------- read ----------
+
+/**
+ * Read the `calibration` key off a loaded config object. Returns null
+ * when absent or malformed — a corrupted config entry must not crash
+ * preflight; we fall back to defaults.
+ */
+export function readCalibration(
+  config: Readonly<Record<string, unknown>>,
+): Calibration | null {
+  const raw = config["calibration"];
+  if (raw === undefined || raw === null) return null;
+  const parsed = CalibrationSchema.safeParse(raw);
+  if (!parsed.success) return null;
+  return parsed.data;
+}
+
+// ---------- blend weight ----------
+
+/**
+ * SPEC §11 formula. Below floor returns 0 (caller applies defaults).
+ * At or above saturation returns 1 (calibration dominates).
+ */
+export function blendWeight(sampleCount: number): number {
+  if (sampleCount < CALIBRATION_FLOOR) return 0;
+  const clamped = Math.min(sampleCount, BLEND_SATURATION);
+  return clamped / BLEND_SATURATION;
+}
+
+// ---------- means ----------
+
+export function meanCalibrated(cal: Calibration): CalibrationMeans {
+  return {
+    mean_tokens_per_round: arithmeticMean(cal.tokens_per_round),
+    mean_rounds_to_converge: arithmeticMean(cal.rounds_to_converge),
+    mean_cost_per_run_usd: arithmeticMean(cal.cost_per_run_usd),
+  };
+}
+
+function arithmeticMean(xs: readonly number[]): number {
+  if (xs.length === 0) return 0;
+  let s = 0;
+  for (const x of xs) s += x;
+  return s / xs.length;
+}
+
+// ---------- recordSession (pure; Issue #15 will wire this at session end) ----------
+
+/**
+ * Append a session's measured values to the calibration arrays.
+ *
+ * - Pure: does not mutate the input.
+ * - Cap: if any array exceeds `CALIBRATION_CAP`, the *oldest* (front)
+ *   entry is dropped.
+ * - `sample_count` after the call equals the length of the three
+ *   arrays (always kept in lockstep).
+ */
+export function recordSession(
+  current: Calibration,
+  sample: CalibrationSample,
+): Calibration {
+  const next: Calibration = {
+    sample_count: 0, // set below
+    tokens_per_round: append(
+      current.tokens_per_round,
+      sample.session_actual_tokens,
+    ),
+    rounds_to_converge: append(
+      current.rounds_to_converge,
+      sample.session_rounds,
+    ),
+    cost_per_run_usd: append(
+      current.cost_per_run_usd,
+      sample.session_actual_cost_usd,
+    ),
+  };
+  // Keep the three arrays in lockstep length.
+  // (All three appended exactly one entry; safety invariant below.)
+  return { ...next, sample_count: next.tokens_per_round.length };
+}
+
+function append(xs: readonly number[], v: number): number[] {
+  const out = xs.concat([v]);
+  while (out.length > CALIBRATION_CAP) {
+    out.shift();
+  }
+  return out;
+}

--- a/src/policy/consent.ts
+++ b/src/policy/consent.ts
@@ -1,0 +1,97 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §5 Phase 1 + §11 preflight consent gate.
+//
+// Fires when:
+//   - `preflight.likelyUsd > budget.preflight_confirm_usd`, OR
+//   - any adapter returned `usage: null` (preflight can't actually
+//     price it — spec explicitly widens the gate here).
+//
+// Three outcomes:
+//   - accept     -> proceed.
+//   - downshift  -> run one session at effort=high (not persisted).
+//   - abort      -> exit 5 per SPEC §10 (consent refused).
+//
+// Testable without a TTY: callers pass `opts.answer`. Sprint 3 will
+// wire the real prompt via the CLI.
+
+/** SPEC §10 exit-code table: consent refused -> 5. */
+export const CONSENT_ABORT_EXIT_CODE = 5 as const;
+
+export interface PreflightForConsent {
+  /** The preflight P50 in USD (priced adapters only). */
+  readonly likelyUsd: number;
+  /**
+   * True when any adapter's preflight could not be priced
+   * (usage: null — subscription auth or buggy adapter).
+   */
+  readonly anyUsageNull: boolean;
+}
+
+export type ConsentAnswer = "accept" | "downshift" | "abort";
+
+export interface PromptConsentOpts {
+  readonly preflight: PreflightForConsent;
+  readonly thresholdUsd: number;
+  /**
+   * Injected answer for tests / scripted flows. When the gate fires
+   * and no answer is supplied, `promptConsent` throws — Sprint 3 wires
+   * a real stdin/prompt adapter behind this.
+   */
+  readonly answer?: ConsentAnswer;
+}
+
+export interface ConsentResult {
+  readonly decision: ConsentAnswer;
+  /** Effort level to clamp this session to on `downshift`. */
+  readonly sessionEffort?: "high";
+  /** True if this decision mutates `.samospec/config.json`. */
+  readonly persist?: boolean;
+  /** Process exit code when `decision === 'abort'`. */
+  readonly exitCode?: number;
+}
+
+/**
+ * Rule: threshold is a strict > check (equal means "at the limit, fine"),
+ * and any usage-null adapter also trips the gate regardless of price.
+ */
+export function shouldPromptConsent(
+  p: PreflightForConsent,
+  thresholdUsd: number,
+): boolean {
+  if (p.anyUsageNull) return true;
+  return p.likelyUsd > thresholdUsd;
+}
+
+export function promptConsent(opts: PromptConsentOpts): ConsentResult {
+  const { preflight, thresholdUsd, answer } = opts;
+  if (!shouldPromptConsent(preflight, thresholdUsd)) {
+    return { decision: "accept" };
+  }
+  if (answer === undefined) {
+    throw new Error(
+      "consent gate fired but no answer was supplied — wire a " +
+        "prompt or inject opts.answer",
+    );
+  }
+  return decide(answer);
+}
+
+function decide(answer: ConsentAnswer): ConsentResult {
+  switch (answer) {
+    case "accept":
+      return { decision: "accept" };
+    case "downshift":
+      return {
+        decision: "downshift",
+        sessionEffort: "high",
+        persist: false,
+      };
+    case "abort":
+      return { decision: "abort", exitCode: CONSENT_ABORT_EXIT_CODE };
+    default:
+      // Any unknown string (including typos) falls through to a
+      // fail-safe abort so we never accidentally proceed.
+      return { decision: "abort", exitCode: CONSENT_ABORT_EXIT_CODE };
+  }
+}

--- a/src/policy/preflight.ts
+++ b/src/policy/preflight.ts
@@ -1,0 +1,306 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §5 Phase 1 + §11 preflight cost estimate.
+//
+// Runs at the END of Phase 1 — before persona, interview, context
+// discovery (before any paid lead call). Inputs are scaffold-only:
+//
+//   - iteration cap `M` (config.budget.max_iterations)
+//   - per-phase context budgets × phase count
+//   - per-round token shares split between lead revision + reviewer pair
+//   - calibration (if any) + per-vendor release-metadata coefficients
+//
+// Output: `PreflightEstimate` with:
+//
+//   - rangeLowUsd  — one-round scenario
+//   - rangeHighUsd — M-round scenario
+//   - likelyUsd    — P50 at M_likely, NOT arithmetic midpoint
+//   - perAdapter   — { id: { tokens, usd | "unknown — subscription auth" } }
+//   - warnings     — subscription-auth notices, usage-null, etc.
+//   - belowFloor   — true when calibration sample_count < 3 (inline
+//                    "first runs; estimate is approximate" printed)
+//   - blendWeight  — 0 below floor; min(count, 10)/10 otherwise
+//   - sampleCount  — calibration.sample_count if present, else 0
+//
+// The pretty-printer formats all this into the three-line `samospec`
+// CLI summary. The consent gate reads `likelyUsd` to decide whether
+// to prompt.
+
+import {
+  blendWeight,
+  CALIBRATION_FLOOR,
+  meanCalibrated,
+  readCalibration,
+  type Calibration,
+} from "./calibration.ts";
+
+// ---------- config surface ----------
+
+export interface PreflightAdapterConfig {
+  readonly adapter: string;
+  readonly model_id: string;
+  readonly effort: string;
+  readonly fallback_chain: readonly string[];
+}
+
+export interface PreflightBudget {
+  readonly max_iterations: number;
+  readonly max_reviewers: number;
+  readonly max_tokens_per_round: number;
+  readonly max_total_tokens_per_session: number;
+  readonly max_wall_clock_minutes: number;
+  readonly preflight_confirm_usd: number;
+}
+
+export interface PreflightConfig {
+  readonly adapters: {
+    readonly lead: PreflightAdapterConfig;
+    readonly reviewer_a: PreflightAdapterConfig;
+    readonly reviewer_b: PreflightAdapterConfig;
+  };
+  readonly budget: PreflightBudget;
+  readonly calibration: Calibration | null;
+}
+
+// ---------- adapter surface ----------
+
+export interface PreflightAdapter {
+  readonly id: string;
+  readonly vendor: string;
+  readonly role: "lead" | "reviewer_a" | "reviewer_b";
+  readonly subscription_auth: boolean;
+}
+
+// ---------- result ----------
+
+export interface PreflightPerAdapter {
+  readonly tokens: number;
+  readonly usd: number | "unknown — subscription auth";
+}
+
+export interface PreflightEstimate {
+  readonly rangeLowUsd: number;
+  readonly rangeHighUsd: number;
+  readonly likelyUsd: number;
+  readonly perAdapter: Readonly<Record<string, PreflightPerAdapter>>;
+  readonly warnings: readonly string[];
+  readonly belowFloor: boolean;
+  readonly blendWeight: number;
+  readonly sampleCount: number;
+  readonly mLikely: number;
+  readonly mMax: number;
+}
+
+// ---------- scaffold coefficients ----------
+//
+// SPEC §7 context budgets — fixed per-phase token costs used as
+// "release-metadata coefficients" until the first three sessions
+// have calibrated against real usage.
+//
+// Per-phase budgets: interview 5K, draft 30K, revision 20K.
+// Context overhead (once, passed to lead at draft time): 55K total.
+
+const CONTEXT_TOKENS_TOTAL = 5_000 + 30_000 + 20_000;
+const DRAFT_TOKENS = 30_000; // one-shot v0.1 lead write
+const REVISION_TOKENS_PER_ROUND = 20_000; // lead revision each round
+const CRITIQUE_TOKENS_PER_ROUND = 15_000; // reviewer critique each round
+
+// Per-vendor blended $/1M token coefficient. These are deliberate
+// order-of-magnitude estimates — SPEC §11 calls them out as
+// "approximate" until 3+ sessions have been calibrated against.
+const VENDOR_USD_PER_M_TOKENS: Readonly<Record<string, number>> = {
+  claude: 40,
+  codex: 25,
+};
+
+const FALLBACK_VENDOR_USD_PER_M_TOKENS = 40;
+
+function vendorUsdPerMTokens(vendor: string): number {
+  return VENDOR_USD_PER_M_TOKENS[vendor] ?? FALLBACK_VENDOR_USD_PER_M_TOKENS;
+}
+
+// ---------- internal scaling ----------
+
+interface CostScales {
+  /** Fractional multiplier applied to per-round token figures. */
+  readonly perRoundScale: number;
+}
+
+/**
+ * When calibration is present and the blend weight > 0, mix the
+ * calibrated per-round token observation with the default. The same
+ * scale applies to every seat — the 50/70/100% blend in SPEC §11 is
+ * about how much calibration data we trust, not about which seat it
+ * came from.
+ */
+function computeScales(cal: Calibration | null, weight: number): CostScales {
+  if (cal === null || weight === 0) return { perRoundScale: 1 };
+  const means = meanCalibrated(cal);
+  const defaultBase = REVISION_TOKENS_PER_ROUND + 2 * CRITIQUE_TOKENS_PER_ROUND;
+  // Guard against meaningless calibration (0 mean) so we don't collapse.
+  const calibratedBase =
+    means.mean_tokens_per_round > 0 ? means.mean_tokens_per_round : defaultBase;
+  const blended = weight * calibratedBase + (1 - weight) * defaultBase;
+  return { perRoundScale: blended / defaultBase };
+}
+
+/** Tokens consumed by one adapter across `m` rounds under the scale. */
+function tokensForAdapter(
+  role: PreflightAdapter["role"],
+  m: number,
+  scale: CostScales,
+): number {
+  if (role === "lead") {
+    const perRound = REVISION_TOKENS_PER_ROUND * scale.perRoundScale;
+    return CONTEXT_TOKENS_TOTAL + DRAFT_TOKENS + m * perRound;
+  }
+  // reviewer_a / reviewer_b
+  const perRound = CRITIQUE_TOKENS_PER_ROUND * scale.perRoundScale;
+  return m * perRound;
+}
+
+function adapterUsd(tokens: number, vendor: string): number {
+  const rate = vendorUsdPerMTokens(vendor);
+  return (tokens / 1_000_000) * rate;
+}
+
+// ---------- public API ----------
+
+export function computePreflight(
+  config: PreflightConfig,
+  adapters: readonly PreflightAdapter[],
+): PreflightEstimate {
+  const mMax = Math.max(1, config.budget.max_iterations);
+  const cal = config.calibration;
+  const sampleCount = cal?.sample_count ?? 0;
+  const belowFloor = sampleCount < CALIBRATION_FLOOR;
+  const weight = blendWeight(sampleCount);
+  const scale = computeScales(cal, weight);
+  const mLikely = computeMLikely(cal, weight, mMax);
+
+  const perAdapter: Record<string, PreflightPerAdapter> = {};
+  const warnings: string[] = [];
+
+  let likelyTotalPriced = 0;
+  let rangeLowTotalPriced = 0;
+  let rangeHighTotalPriced = 0;
+  let subscriptionAuthCount = 0;
+
+  for (const ad of adapters) {
+    // Tokens at M_likely used for per-adapter summary + total price.
+    const tokensLikely = tokensForAdapter(ad.role, mLikely, scale);
+    if (ad.subscription_auth) {
+      perAdapter[ad.id] = {
+        tokens: tokensLikely,
+        usd: "unknown — subscription auth",
+      };
+      subscriptionAuthCount += 1;
+      continue;
+    }
+    const usdLikely = adapterUsd(tokensLikely, ad.vendor);
+    perAdapter[ad.id] = { tokens: tokensLikely, usd: usdLikely };
+
+    const tokensLow = tokensForAdapter(ad.role, 1, scale);
+    const tokensHigh = tokensForAdapter(ad.role, mMax, scale);
+    likelyTotalPriced += usdLikely;
+    rangeLowTotalPriced += adapterUsd(tokensLow, ad.vendor);
+    rangeHighTotalPriced += adapterUsd(tokensHigh, ad.vendor);
+  }
+
+  if (subscriptionAuthCount > 0) {
+    warnings.push(
+      `${String(subscriptionAuthCount)} adapter(s) under ` +
+        `subscription-auth; total cost incomplete`,
+    );
+  }
+
+  return {
+    rangeLowUsd: rangeLowTotalPriced,
+    rangeHighUsd: rangeHighTotalPriced,
+    likelyUsd: likelyTotalPriced,
+    perAdapter,
+    warnings,
+    belowFloor,
+    blendWeight: weight,
+    sampleCount,
+    mLikely,
+    mMax,
+  };
+}
+
+/**
+ * `M_likely` is `mean_rounds_to_converge` when above the calibration
+ * floor (blended with the default `M/2` by `weight`); below the floor
+ * it is simply `M/2`. SPEC §11.
+ */
+function computeMLikely(
+  cal: Calibration | null,
+  weight: number,
+  mMax: number,
+): number {
+  const defaultM = mMax / 2;
+  if (cal === null || weight === 0) return defaultM;
+  const means = meanCalibrated(cal);
+  if (means.mean_rounds_to_converge <= 0) return defaultM;
+  return weight * means.mean_rounds_to_converge + (1 - weight) * defaultM;
+}
+
+// ---------- load from parsed config ----------
+
+/**
+ * Convenience: build a `PreflightConfig` from an already-parsed JSON
+ * config object (i.e. the contents of `.samospec/config.json`). Missing
+ * keys throw — callers should ensure `runInit` has been run.
+ */
+export function preflightConfigFromParsed(
+  raw: Readonly<Record<string, unknown>>,
+): PreflightConfig {
+  const adapters = raw["adapters"] as PreflightConfig["adapters"] | undefined;
+  const budget = raw["budget"] as PreflightBudget | undefined;
+  if (!adapters || !budget) {
+    throw new Error(
+      "preflight config must have adapters + budget; run samospec init first",
+    );
+  }
+  return {
+    adapters,
+    budget,
+    calibration: readCalibration(raw),
+  };
+}
+
+// ---------- pretty-printer ----------
+
+export function formatPreflight(e: PreflightEstimate): string {
+  const lines: string[] = [];
+  const headline = `estimated range: $${formatUsd(e.rangeLowUsd)}–$${formatUsd(
+    e.rangeHighUsd,
+  )}, likely $${formatUsd(e.likelyUsd)}`;
+  const tail = e.belowFloor ? " (first runs; estimate is approximate)" : "";
+  lines.push(headline + tail);
+
+  lines.push("per-adapter:");
+  for (const [id, entry] of Object.entries(e.perAdapter)) {
+    const price =
+      typeof entry.usd === "number" ? `$${formatUsd(entry.usd)}` : entry.usd;
+    lines.push(`  ${id}: ~${formatTokens(entry.tokens)} tokens, ${price}`);
+  }
+
+  if (e.warnings.length > 0) {
+    lines.push("warnings:");
+    for (const w of e.warnings) lines.push(`  ${w}`);
+  }
+
+  return lines.join("\n");
+}
+
+function formatUsd(v: number): string {
+  // 2 decimal places; no thousands separator for CLI brevity.
+  return v.toFixed(2);
+}
+
+function formatTokens(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(0)}K`;
+  return String(Math.round(v));
+}

--- a/src/policy/wallclock.ts
+++ b/src/policy/wallclock.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §11 wall-clock overrun rule.
+//
+// At each round boundary, compare remaining wall-clock against the
+// worst-case duration of one more round. If `remaining < worst_case`,
+// halt the loop with reason `wall-clock` (exit 4 per SPEC §10) rather
+// than starting a round that will blow the budget during its retry
+// tail.
+//
+// Worst-case per call (SPEC §7 capped retry):
+//   base + 1.5 * base + base = 3.5 * base
+//
+// Reviewer pair is parallel (SPEC §7 "Reviewers in parallel"), so
+// their worst case is dominated by `max(critiqueA, critiqueB)`.
+// Revise is sequential after reviewers.
+//
+// This module is helper-only — no loop orchestration. Sprint 3
+// Issue #15 wires it into the actual round boundary check.
+
+/** SPEC §7: capped retry worst case `base + 1.5*base + base = 3.5*base`. */
+export const CAPPED_RETRY_MULTIPLIER = 3.5 as const;
+
+export interface CallTimeoutsMs {
+  /** `critique` timeout for reviewer A (ms). SPEC §7 default 300s. */
+  readonly criticA_ms: number;
+  /** `critique` timeout for reviewer B (ms). */
+  readonly criticB_ms: number;
+  /** `revise` timeout for the lead (ms). SPEC §7 default 600s. */
+  readonly revise_ms: number;
+}
+
+export interface WallclockBudget {
+  /** `budget.max_wall_clock_minutes` expressed as ms. */
+  readonly max_wall_clock_ms: number;
+  readonly call_timeouts_ms: CallTimeoutsMs;
+}
+
+export interface WallclockState {
+  readonly session_started_at_ms: number;
+  readonly now_ms: number;
+}
+
+/** Worst-case duration of a single adapter call under capped retry. */
+export function worstCaseCallDurationMs(baseTimeoutMs: number): number {
+  return baseTimeoutMs * CAPPED_RETRY_MULTIPLIER;
+}
+
+/**
+ * Worst-case duration of one more review round (SPEC §11):
+ *
+ *   reviewer_pair (parallel) -> dominated by max(a, b)
+ *   + revise (sequential)
+ *   each scaled by the 3.5x capped-retry multiplier.
+ */
+export function worstCaseRoundDuration(t: CallTimeoutsMs): number {
+  const reviewerPairBase = Math.max(t.criticA_ms, t.criticB_ms);
+  const roundBase = reviewerPairBase + t.revise_ms;
+  return roundBase * CAPPED_RETRY_MULTIPLIER;
+}
+
+/**
+ * Returns true when there is enough wall-clock remaining to safely run
+ * one more worst-case round. Returns false at the boundary where
+ * remaining < worst-case (the loop should halt with `wall-clock`).
+ *
+ * Equality: exactly matching remaining and worst-case is treated as
+ * enough (inclusive boundary). The gate is `remaining < worst_case`.
+ */
+export function shouldStartNextRound(
+  state: WallclockState,
+  budget: WallclockBudget,
+): boolean {
+  const elapsed = Math.max(0, state.now_ms - state.session_started_at_ms);
+  const remaining = budget.max_wall_clock_ms - elapsed;
+  if (remaining <= 0) return false;
+  const worst = worstCaseRoundDuration(budget.call_timeouts_ms);
+  return remaining >= worst;
+}

--- a/tests/policy/calibration.test.ts
+++ b/tests/policy/calibration.test.ts
@@ -1,0 +1,228 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §11 calibration storage: `.samospec/config.json` gains a
+// `calibration` object with `sample_count`, `tokens_per_round[]`,
+// `rounds_to_converge[]`, `cost_per_run_usd[]`.
+//
+// Red-first contract:
+//   1. `readCalibration(config)` returns a valid `Calibration` or null.
+//   2. `recordSession(calibration, sample)` appends and caps at 20
+//      (drops oldest).
+//   3. `blendWeight(sample_count)` implements the SPEC §11 formula:
+//      min(sample_count, 10) / 10.
+//   4. `meanCalibrated(calibration)` averages the three arrays.
+//   5. Invalid arrays parse as null (defensive: corrupted config is
+//      treated as "no calibration", not as a crash).
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  blendWeight,
+  CALIBRATION_CAP,
+  CALIBRATION_FLOOR,
+  meanCalibrated,
+  readCalibration,
+  recordSession,
+  type Calibration,
+  type CalibrationSample,
+} from "../../src/policy/calibration.ts";
+
+// ---------- readCalibration ----------
+
+describe("readCalibration", () => {
+  test("returns null when config.calibration is absent", () => {
+    expect(readCalibration({})).toBeNull();
+  });
+
+  test("returns null when calibration is a non-object", () => {
+    expect(readCalibration({ calibration: 123 })).toBeNull();
+  });
+
+  test("returns null on array/type mismatches", () => {
+    expect(
+      readCalibration({
+        calibration: {
+          sample_count: 0,
+          tokens_per_round: "not-an-array",
+          rounds_to_converge: [],
+          cost_per_run_usd: [],
+        },
+      }),
+    ).toBeNull();
+  });
+
+  test("returns a valid Calibration when well-formed", () => {
+    const cal = readCalibration({
+      calibration: {
+        sample_count: 3,
+        tokens_per_round: [100, 200, 300],
+        rounds_to_converge: [5, 6, 7],
+        cost_per_run_usd: [1, 2, 3],
+      },
+    });
+    expect(cal).not.toBeNull();
+    expect(cal?.sample_count).toBe(3);
+    expect(cal?.tokens_per_round).toEqual([100, 200, 300]);
+  });
+});
+
+// ---------- blendWeight ----------
+
+describe("blendWeight (SPEC §11 formula)", () => {
+  test("0 samples -> 0", () => {
+    expect(blendWeight(0)).toBe(0);
+  });
+
+  test("below floor (1, 2) -> 0 (caller should not apply calibration)", () => {
+    expect(blendWeight(1)).toBe(0);
+    expect(blendWeight(2)).toBe(0);
+  });
+
+  test("exactly at floor (3) -> 0.3", () => {
+    expect(blendWeight(3)).toBeCloseTo(0.3, 5);
+  });
+
+  test("7 samples -> 0.7", () => {
+    expect(blendWeight(7)).toBeCloseTo(0.7, 5);
+  });
+
+  test("10 samples -> 1.0 (calibration dominates)", () => {
+    expect(blendWeight(10)).toBe(1.0);
+  });
+
+  test("20 samples -> clamps to 1.0", () => {
+    expect(blendWeight(20)).toBe(1.0);
+  });
+
+  test("100 samples -> 1.0", () => {
+    expect(blendWeight(100)).toBe(1.0);
+  });
+});
+
+// ---------- CALIBRATION_FLOOR / CAP constants ----------
+
+describe("calibration constants", () => {
+  test("floor is 3 per SPEC §11", () => {
+    expect(CALIBRATION_FLOOR).toBe(3);
+  });
+
+  test("cap is 20 per SPEC §11", () => {
+    expect(CALIBRATION_CAP).toBe(20);
+  });
+});
+
+// ---------- meanCalibrated ----------
+
+describe("meanCalibrated", () => {
+  test("returns arithmetic mean of each array", () => {
+    const cal: Calibration = {
+      sample_count: 3,
+      tokens_per_round: [100, 200, 300],
+      rounds_to_converge: [2, 4, 6],
+      cost_per_run_usd: [1, 2, 3],
+    };
+    const mean = meanCalibrated(cal);
+    expect(mean.mean_tokens_per_round).toBe(200);
+    expect(mean.mean_rounds_to_converge).toBe(4);
+    expect(mean.mean_cost_per_run_usd).toBe(2);
+  });
+
+  test("empty arrays yield 0s (used when sample_count is 0)", () => {
+    const cal: Calibration = {
+      sample_count: 0,
+      tokens_per_round: [],
+      rounds_to_converge: [],
+      cost_per_run_usd: [],
+    };
+    const mean = meanCalibrated(cal);
+    expect(mean.mean_tokens_per_round).toBe(0);
+    expect(mean.mean_rounds_to_converge).toBe(0);
+    expect(mean.mean_cost_per_run_usd).toBe(0);
+  });
+});
+
+// ---------- recordSession ----------
+
+describe("recordSession", () => {
+  const seed: Calibration = {
+    sample_count: 0,
+    tokens_per_round: [],
+    rounds_to_converge: [],
+    cost_per_run_usd: [],
+  };
+
+  test("appends a fresh sample to each array", () => {
+    const sample: CalibrationSample = {
+      session_actual_tokens: 150_000,
+      session_actual_cost_usd: 3.25,
+      session_rounds: 4,
+    };
+    const next = recordSession(seed, sample);
+    expect(next.sample_count).toBe(1);
+    expect(next.tokens_per_round).toEqual([150_000]);
+    expect(next.rounds_to_converge).toEqual([4]);
+    expect(next.cost_per_run_usd).toEqual([3.25]);
+  });
+
+  test("does not mutate the input (pure function)", () => {
+    recordSession(seed, {
+      session_actual_tokens: 1,
+      session_actual_cost_usd: 1,
+      session_rounds: 1,
+    });
+    expect(seed.sample_count).toBe(0);
+    expect(seed.tokens_per_round).toEqual([]);
+  });
+
+  test("sample_count equals length of each array across N writes", () => {
+    let cur = seed;
+    for (let i = 1; i <= 5; i += 1) {
+      cur = recordSession(cur, {
+        session_actual_tokens: i * 100,
+        session_actual_cost_usd: i,
+        session_rounds: i,
+      });
+    }
+    expect(cur.sample_count).toBe(5);
+    expect(cur.tokens_per_round).toHaveLength(5);
+    expect(cur.rounds_to_converge).toHaveLength(5);
+    expect(cur.cost_per_run_usd).toHaveLength(5);
+  });
+
+  test("caps at 20 samples and drops the oldest", () => {
+    let cur = seed;
+    for (let i = 1; i <= 25; i += 1) {
+      cur = recordSession(cur, {
+        session_actual_tokens: i,
+        session_actual_cost_usd: i,
+        session_rounds: i,
+      });
+    }
+    expect(cur.sample_count).toBe(20);
+    expect(cur.tokens_per_round).toHaveLength(20);
+    // Oldest dropped: first retained should be sample 6 (dropped 1..5).
+    expect(cur.tokens_per_round[0]).toBe(6);
+    expect(cur.tokens_per_round[19]).toBe(25);
+    expect(cur.rounds_to_converge[0]).toBe(6);
+    expect(cur.cost_per_run_usd[19]).toBe(25);
+  });
+
+  test("from a non-empty seed: trim drops oldest entries, not the new one", () => {
+    // Pre-fill with 20 samples numbered 1..20.
+    let cur: Calibration = {
+      sample_count: 20,
+      tokens_per_round: Array.from({ length: 20 }, (_v, i) => i + 1),
+      rounds_to_converge: Array.from({ length: 20 }, (_v, i) => i + 1),
+      cost_per_run_usd: Array.from({ length: 20 }, (_v, i) => i + 1),
+    };
+    cur = recordSession(cur, {
+      session_actual_tokens: 99,
+      session_actual_cost_usd: 99,
+      session_rounds: 99,
+    });
+    expect(cur.sample_count).toBe(20);
+    // Dropped the first (= 1), appended 99 at the tail.
+    expect(cur.tokens_per_round[0]).toBe(2);
+    expect(cur.tokens_per_round[19]).toBe(99);
+  });
+});

--- a/tests/policy/consent.test.ts
+++ b/tests/policy/consent.test.ts
@@ -1,0 +1,131 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §5 Phase 1 + §11 preflight consent gate.
+//
+// Red-first contract:
+//   1. When `likelyUsd <= preflight_confirm_usd` AND no adapter has
+//      `usage: null` risk -> no prompt needed (auto-accept).
+//   2. When `likelyUsd > preflight_confirm_usd` -> prompt; caller's
+//      `answer` is one of accept / downshift / abort.
+//   3. When any adapter has `usage_unknown` flag (usage: null) ->
+//      prompt fires even below the dollar threshold.
+//   4. `accept` decision: sessionEffort undefined.
+//   5. `abort` decision: exit 5 per SPEC §10.
+//   6. `downshift` decision: sessionEffort === 'high' (SPEC §11 effort
+//      ladder; 'high' is the first step down from 'max').
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  promptConsent,
+  shouldPromptConsent,
+  CONSENT_ABORT_EXIT_CODE,
+  type PreflightForConsent,
+} from "../../src/policy/consent.ts";
+
+// ---------- shouldPromptConsent ----------
+
+describe("shouldPromptConsent", () => {
+  const base: PreflightForConsent = {
+    likelyUsd: 5,
+    anyUsageNull: false,
+  };
+
+  test("auto-accepts when likely cost <= threshold and no usage-null risk", () => {
+    expect(shouldPromptConsent(base, 20)).toBe(false);
+  });
+
+  test("prompts when likely cost exceeds threshold", () => {
+    const over: PreflightForConsent = { likelyUsd: 25, anyUsageNull: false };
+    expect(shouldPromptConsent(over, 20)).toBe(true);
+  });
+
+  test("prompts when any adapter returned usage: null (price not measurable)", () => {
+    const risky: PreflightForConsent = { likelyUsd: 1, anyUsageNull: true };
+    expect(shouldPromptConsent(risky, 20)).toBe(true);
+  });
+
+  test("boundary: exactly equal to threshold does NOT prompt", () => {
+    const eq: PreflightForConsent = { likelyUsd: 20, anyUsageNull: false };
+    expect(shouldPromptConsent(eq, 20)).toBe(false);
+  });
+});
+
+// ---------- promptConsent with injected answer ----------
+
+describe("promptConsent — injected answer (no TTY required)", () => {
+  const preflight: PreflightForConsent = { likelyUsd: 25, anyUsageNull: false };
+
+  test("'accept' returns a decision with no session effort change", () => {
+    const r = promptConsent({
+      preflight,
+      thresholdUsd: 20,
+      answer: "accept",
+    });
+    expect(r.decision).toBe("accept");
+    expect(r.exitCode).toBeUndefined();
+    expect(r.sessionEffort).toBeUndefined();
+  });
+
+  test("'downshift' sets sessionEffort=high (not persisted)", () => {
+    const r = promptConsent({
+      preflight,
+      thresholdUsd: 20,
+      answer: "downshift",
+    });
+    expect(r.decision).toBe("downshift");
+    expect(r.sessionEffort).toBe("high");
+    expect(r.persist).toBe(false);
+  });
+
+  test("'abort' returns exit code 5 per SPEC §10", () => {
+    const r = promptConsent({
+      preflight,
+      thresholdUsd: 20,
+      answer: "abort",
+    });
+    expect(r.decision).toBe("abort");
+    expect(r.exitCode).toBe(5);
+    expect(CONSENT_ABORT_EXIT_CODE).toBe(5);
+  });
+
+  test("unknown answer string is treated as abort for safety", () => {
+    const r = promptConsent({
+      preflight,
+      thresholdUsd: 20,
+      answer: "banana" as unknown as "accept",
+    });
+    expect(r.decision).toBe("abort");
+  });
+});
+
+// ---------- auto-path when no prompt is required ----------
+
+describe("promptConsent — auto path (below threshold, no usage-null)", () => {
+  test("returns accept without asking when no prompt is warranted", () => {
+    const cheap: PreflightForConsent = {
+      likelyUsd: 5,
+      anyUsageNull: false,
+    };
+    const r = promptConsent({
+      preflight: cheap,
+      thresholdUsd: 20,
+      // No answer supplied; function should auto-accept and not throw.
+    });
+    expect(r.decision).toBe("accept");
+  });
+});
+
+// ---------- missing-answer path when prompt is warranted ----------
+
+describe("promptConsent — missing answer but prompt required", () => {
+  test("throws an explicit error so callers hook up an answerer", () => {
+    const pricey: PreflightForConsent = {
+      likelyUsd: 50,
+      anyUsageNull: false,
+    };
+    expect(() =>
+      promptConsent({ preflight: pricey, thresholdUsd: 20 }),
+    ).toThrow();
+  });
+});

--- a/tests/policy/preflight.test.ts
+++ b/tests/policy/preflight.test.ts
@@ -1,0 +1,324 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §5 Phase 1 + §11 preflight cost estimate.
+//
+// Red-first contract tests for `computePreflight` + its pretty-printer.
+// These exercise:
+//   1. Below calibration floor (sample_count < 3) -> defaults + "first
+//      runs" inline annotation.
+//   2. Blended band (3 <= sample_count < 10) -> weighted mix with defaults.
+//   3. Calibrated band (sample_count >= 10) -> calibration dominates.
+//   4. `likelyUsd` is the P50 AT `M_likely` rounds, NOT the midpoint of
+//      `rangeLow..rangeHigh`. Skewed range case asserts the P50 value
+//      sits where `M_likely` says it does.
+//   5. Subscription-auth: per-adapter cost string + warning + `likelyUsd`
+//      excludes unpriced adapter.
+//   6. Pretty-printer includes range, likely, per-adapter, warnings,
+//      and the "first runs" inline when below-floor.
+
+import { describe, expect, test } from "bun:test";
+
+import { DEFAULT_CONFIG } from "../../src/cli/init.ts";
+import {
+  computePreflight,
+  formatPreflight,
+  type PreflightAdapter,
+  type PreflightConfig,
+} from "../../src/policy/preflight.ts";
+
+// ---------- helpers ----------
+
+function mkConfig(overrides: Partial<PreflightConfig> = {}): PreflightConfig {
+  // Use the init defaults as our baseline then layer test-specific overrides.
+  const baseline: PreflightConfig = {
+    adapters: {
+      lead: { ...DEFAULT_CONFIG.adapters.lead },
+      reviewer_a: { ...DEFAULT_CONFIG.adapters.reviewer_a },
+      reviewer_b: { ...DEFAULT_CONFIG.adapters.reviewer_b },
+    },
+    budget: { ...DEFAULT_CONFIG.budget },
+    calibration: null,
+  };
+  return { ...baseline, ...overrides };
+}
+
+function mkAdapter(
+  id: string,
+  vendor: string,
+  subscription_auth: boolean,
+  role: "lead" | "reviewer_a" | "reviewer_b",
+): PreflightAdapter {
+  return { id, vendor, role, subscription_auth };
+}
+
+// A three-seat default fleet matching the spec's pinned defaults.
+const LEAD = mkAdapter("lead", "claude", false, "lead");
+const REVA = mkAdapter("reviewer_a", "codex", false, "reviewer_a");
+const REVB = mkAdapter("reviewer_b", "claude", false, "reviewer_b");
+const FLEET = [LEAD, REVA, REVB];
+
+// ---------- below floor ----------
+
+describe("computePreflight — below calibration floor (sample_count < 3)", () => {
+  test("returns estimate with `belowFloor: true` and no calibration used", () => {
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, FLEET);
+    expect(r.belowFloor).toBe(true);
+    expect(r.sampleCount).toBe(0);
+  });
+
+  test("at 2 samples: still below floor", () => {
+    const cfg = mkConfig({
+      calibration: {
+        sample_count: 2,
+        tokens_per_round: [100_000, 120_000],
+        rounds_to_converge: [5, 6],
+        cost_per_run_usd: [3, 4],
+      },
+    });
+    const r = computePreflight(cfg, FLEET);
+    expect(r.belowFloor).toBe(true);
+  });
+
+  test("pretty-printer emits 'first runs; estimate is approximate' inline", () => {
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, FLEET);
+    const text = formatPreflight(r);
+    expect(text).toContain("first runs; estimate is approximate");
+  });
+
+  test("pretty-printer includes range + likely line + per-adapter list", () => {
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, FLEET);
+    const text = formatPreflight(r);
+    expect(text).toMatch(/estimated range: \$[\d.]+–\$[\d.]+, likely \$[\d.]+/);
+    expect(text).toContain("lead");
+    expect(text).toContain("reviewer_a");
+    expect(text).toContain("reviewer_b");
+  });
+
+  test("rangeLow < likely < rangeHigh and all positive", () => {
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, FLEET);
+    expect(r.rangeLowUsd).toBeGreaterThan(0);
+    expect(r.rangeHighUsd).toBeGreaterThan(r.rangeLowUsd);
+    expect(r.likelyUsd).toBeGreaterThan(r.rangeLowUsd);
+    expect(r.likelyUsd).toBeLessThan(r.rangeHighUsd);
+  });
+});
+
+// ---------- likelyUsd is P50 at M_likely, not midpoint of range ----------
+
+describe("computePreflight — likelyUsd is P50 at M_likely", () => {
+  test("below floor with default M=10: M_likely=5, NOT midpoint of range", () => {
+    // rangeLow = 1 round, rangeHigh = M rounds. Arithmetic midpoint
+    // would be (low + high) / 2 = ~5.5 rounds if linearly scaled.
+    // M_likely = M/2 = 5 rounds — so likely < arithmetic midpoint
+    // because the per-round scaling is not perfectly linear (draft is
+    // a one-time lead cost).
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, FLEET);
+    const midpoint = (r.rangeLowUsd + r.rangeHighUsd) / 2;
+    // Assert NOT equal, with a meaningful delta.
+    expect(Math.abs(r.likelyUsd - midpoint)).toBeGreaterThan(0.01);
+  });
+
+  test("with 10+ samples and a mean_rounds_to_converge well below M/2, likely < arithmetic midpoint", () => {
+    const cfg = mkConfig({
+      calibration: {
+        // 10 samples, every one converged in 3 rounds.
+        sample_count: 10,
+        tokens_per_round: new Array<number>(10).fill(100_000),
+        rounds_to_converge: new Array<number>(10).fill(3),
+        cost_per_run_usd: new Array<number>(10).fill(2.5),
+      },
+    });
+    const r = computePreflight(cfg, FLEET);
+    const midpoint = (r.rangeLowUsd + r.rangeHighUsd) / 2;
+    expect(r.likelyUsd).toBeLessThan(midpoint);
+  });
+});
+
+// ---------- blended (3..9 samples) ----------
+
+describe("computePreflight — blended band (3..9 samples)", () => {
+  test("at 3 samples: effective = 30% calibration + 70% defaults", () => {
+    // Use a calibration strongly different from defaults so the blend
+    // is observable in the output.
+    const heavyCal = mkConfig({
+      calibration: {
+        sample_count: 3,
+        tokens_per_round: [1_000_000, 1_000_000, 1_000_000], // high
+        rounds_to_converge: [3, 3, 3], // few rounds
+        cost_per_run_usd: [100, 100, 100],
+      },
+    });
+    const r3 = computePreflight(heavyCal, FLEET);
+    expect(r3.belowFloor).toBe(false);
+    expect(r3.sampleCount).toBe(3);
+    expect(r3.blendWeight).toBeCloseTo(0.3, 5);
+  });
+
+  test("at 7 samples: effective = 70% calibration + 30% defaults", () => {
+    const cfg = mkConfig({
+      calibration: {
+        sample_count: 7,
+        tokens_per_round: new Array<number>(7).fill(500_000),
+        rounds_to_converge: new Array<number>(7).fill(4),
+        cost_per_run_usd: new Array<number>(7).fill(10),
+      },
+    });
+    const r = computePreflight(cfg, FLEET);
+    expect(r.blendWeight).toBeCloseTo(0.7, 5);
+  });
+
+  test("pretty-printer for blended band OMITS 'first runs; estimate is approximate'", () => {
+    const cfg = mkConfig({
+      calibration: {
+        sample_count: 5,
+        tokens_per_round: new Array<number>(5).fill(100_000),
+        rounds_to_converge: new Array<number>(5).fill(4),
+        cost_per_run_usd: new Array<number>(5).fill(3),
+      },
+    });
+    const r = computePreflight(cfg, FLEET);
+    const text = formatPreflight(r);
+    expect(text).not.toContain("first runs; estimate is approximate");
+  });
+});
+
+// ---------- calibrated (>=10 samples) ----------
+
+describe("computePreflight — calibrated (sample_count >= 10)", () => {
+  test("at 10 samples: calibration dominates (weight=1.0)", () => {
+    const cfg = mkConfig({
+      calibration: {
+        sample_count: 10,
+        tokens_per_round: new Array<number>(10).fill(200_000),
+        rounds_to_converge: new Array<number>(10).fill(5),
+        cost_per_run_usd: new Array<number>(10).fill(5),
+      },
+    });
+    const r = computePreflight(cfg, FLEET);
+    expect(r.blendWeight).toBeCloseTo(1.0, 5);
+  });
+
+  test("at 20 samples: still clamps to weight=1.0", () => {
+    const cfg = mkConfig({
+      calibration: {
+        sample_count: 20,
+        tokens_per_round: new Array<number>(20).fill(200_000),
+        rounds_to_converge: new Array<number>(20).fill(5),
+        cost_per_run_usd: new Array<number>(20).fill(5),
+      },
+    });
+    const r = computePreflight(cfg, FLEET);
+    expect(r.blendWeight).toBeCloseTo(1.0, 5);
+  });
+
+  test("calibration mean_rounds_to_converge drives M_likely", () => {
+    const fastCal = mkConfig({
+      calibration: {
+        sample_count: 10,
+        tokens_per_round: new Array<number>(10).fill(100_000),
+        rounds_to_converge: new Array<number>(10).fill(2), // very fast
+        cost_per_run_usd: new Array<number>(10).fill(1.5),
+      },
+    });
+    const slowCal = mkConfig({
+      calibration: {
+        sample_count: 10,
+        tokens_per_round: new Array<number>(10).fill(100_000),
+        rounds_to_converge: new Array<number>(10).fill(9), // slow
+        cost_per_run_usd: new Array<number>(10).fill(5),
+      },
+    });
+    const rFast = computePreflight(fastCal, FLEET);
+    const rSlow = computePreflight(slowCal, FLEET);
+    // Slower convergence → higher likely.
+    expect(rSlow.likelyUsd).toBeGreaterThan(rFast.likelyUsd);
+  });
+});
+
+// ---------- subscription-auth escape ----------
+
+describe("computePreflight — subscription-auth escape", () => {
+  test("per-adapter cost is the 'unknown — subscription auth' string", () => {
+    const subLead = mkAdapter("lead", "claude", true, "lead");
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, [subLead, REVA, REVB]);
+    const perLead = r.perAdapter["lead"];
+    expect(perLead).toBeDefined();
+    expect(perLead?.usd).toBe("unknown — subscription auth");
+  });
+
+  test("warning lists how many adapters are under subscription-auth", () => {
+    const subLead = mkAdapter("lead", "claude", true, "lead");
+    const subRevB = mkAdapter("reviewer_b", "claude", true, "reviewer_b");
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, [subLead, REVA, subRevB]);
+    expect(r.warnings.some((w) => w.includes("subscription"))).toBe(true);
+    expect(
+      r.warnings.some(
+        (w) => w.includes("2") && /subscription/i.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  test("likelyUsd reflects only priced adapters (excludes subscription-auth)", () => {
+    const allPriced = [LEAD, REVA, REVB];
+    const rAll = computePreflight(mkConfig(), allPriced);
+
+    const subLead = mkAdapter("lead", "claude", true, "lead");
+    const oneSub = [subLead, REVA, REVB];
+    const rSub = computePreflight(mkConfig(), oneSub);
+
+    // Dropping the lead's priced contribution must shrink the likely.
+    expect(rSub.likelyUsd).toBeLessThan(rAll.likelyUsd);
+  });
+
+  test("pretty-printer renders 'unknown — subscription auth' for the subbed adapter line", () => {
+    const subLead = mkAdapter("lead", "claude", true, "lead");
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, [subLead, REVA, REVB]);
+    const text = formatPreflight(r);
+    expect(text).toContain("unknown — subscription auth");
+  });
+});
+
+// ---------- per-adapter breakdown + tokens ----------
+
+describe("computePreflight — per-adapter breakdown", () => {
+  test("each adapter entry reports a positive token estimate", () => {
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, FLEET);
+    for (const id of ["lead", "reviewer_a", "reviewer_b"] as const) {
+      const entry = r.perAdapter[id];
+      expect(entry).toBeDefined();
+      expect(entry?.tokens).toBeGreaterThan(0);
+    }
+  });
+
+  test("lead spend > reviewer spend (lead carries draft + revision per round)", () => {
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, FLEET);
+    const lead = r.perAdapter["lead"]!;
+    const revA = r.perAdapter["reviewer_a"]!;
+    expect(lead.tokens).toBeGreaterThan(revA.tokens);
+  });
+});
+
+// ---------- shape / types ----------
+
+describe("computePreflight — return shape", () => {
+  test("has the required top-level keys", () => {
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, FLEET);
+    expect(r).toHaveProperty("rangeLowUsd");
+    expect(r).toHaveProperty("rangeHighUsd");
+    expect(r).toHaveProperty("likelyUsd");
+    expect(r).toHaveProperty("perAdapter");
+    expect(r).toHaveProperty("warnings");
+    expect(Array.isArray(r.warnings)).toBe(true);
+  });
+});

--- a/tests/policy/preflight.test.ts
+++ b/tests/policy/preflight.test.ts
@@ -259,9 +259,7 @@ describe("computePreflight — subscription-auth escape", () => {
     const r = computePreflight(cfg, [subLead, REVA, subRevB]);
     expect(r.warnings.some((w) => w.includes("subscription"))).toBe(true);
     expect(
-      r.warnings.some(
-        (w) => w.includes("2") && /subscription/i.test(w),
-      ),
+      r.warnings.some((w) => w.includes("2") && /subscription/i.test(w)),
     ).toBe(true);
   });
 
@@ -302,9 +300,11 @@ describe("computePreflight — per-adapter breakdown", () => {
   test("lead spend > reviewer spend (lead carries draft + revision per round)", () => {
     const cfg = mkConfig();
     const r = computePreflight(cfg, FLEET);
-    const lead = r.perAdapter["lead"]!;
-    const revA = r.perAdapter["reviewer_a"]!;
-    expect(lead.tokens).toBeGreaterThan(revA.tokens);
+    const lead = r.perAdapter["lead"];
+    const revA = r.perAdapter["reviewer_a"];
+    expect(lead).toBeDefined();
+    expect(revA).toBeDefined();
+    expect(lead?.tokens).toBeGreaterThan(revA?.tokens ?? Infinity);
   });
 });
 

--- a/tests/policy/wallclock.test.ts
+++ b/tests/policy/wallclock.test.ts
@@ -1,0 +1,165 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §11 wall-clock overrun rule.
+//
+// At each round boundary, compare remaining wall-clock against the
+// worst-case duration of one more round. If remaining < worst-case,
+// the loop halts with reason `wall-clock` (exit 4 per SPEC §10) —
+// don't start another round just to timeout during the retry tail.
+//
+// Worst-case per call (SPEC §7 capped retry: base + 1.5*base + base
+// = 3.5*base). Reviewer pair is parallel — dominated by max(a, b).
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  CAPPED_RETRY_MULTIPLIER,
+  shouldStartNextRound,
+  worstCaseCallDurationMs,
+  worstCaseRoundDuration,
+  type WallclockBudget,
+  type WallclockState,
+} from "../../src/policy/wallclock.ts";
+
+// Three-pinned seats at their SPEC §7 default timeouts (ms):
+// ask 120s / critique 300s / revise 600s.
+const SECONDS = 1_000;
+const DEFAULT_TIMEOUTS = {
+  criticA_ms: 300 * SECONDS,
+  criticB_ms: 300 * SECONDS,
+  revise_ms: 600 * SECONDS,
+};
+
+// ---------- capped-retry constant ----------
+
+describe("CAPPED_RETRY_MULTIPLIER (SPEC §7)", () => {
+  test("base + 1.5*base + base = 3.5x", () => {
+    expect(CAPPED_RETRY_MULTIPLIER).toBe(3.5);
+  });
+});
+
+// ---------- worstCaseCallDurationMs ----------
+
+describe("worstCaseCallDurationMs", () => {
+  test("scales the base timeout by 3.5x", () => {
+    expect(worstCaseCallDurationMs(1000)).toBe(3500);
+  });
+
+  test("0 base => 0", () => {
+    expect(worstCaseCallDurationMs(0)).toBe(0);
+  });
+});
+
+// ---------- worstCaseRoundDuration ----------
+
+describe("worstCaseRoundDuration (SPEC §11)", () => {
+  test("reviewer pair is parallel -> dominated by max; revise sequential", () => {
+    const r = worstCaseRoundDuration({
+      criticA_ms: 100,
+      criticB_ms: 200,
+      revise_ms: 500,
+    });
+    // (max(100, 200) * 3.5) + (500 * 3.5) = 700 + 1750 = 2450.
+    expect(r).toBe(2450);
+  });
+
+  test("real defaults produce ~70min worst case", () => {
+    const r = worstCaseRoundDuration(DEFAULT_TIMEOUTS);
+    // (300 * 3.5) + (600 * 3.5) = 1050 + 2100 = 3150s => ~52.5 min.
+    expect(r).toBe(3150 * 1000);
+  });
+
+  test("equal critic timeouts still use max(a, a) = a", () => {
+    const r = worstCaseRoundDuration({
+      criticA_ms: 300,
+      criticB_ms: 300,
+      revise_ms: 600,
+    });
+    expect(r).toBe((300 + 600) * 3.5);
+  });
+});
+
+// ---------- shouldStartNextRound ----------
+
+describe("shouldStartNextRound (SPEC §11 overrun rule)", () => {
+  const budget: WallclockBudget = {
+    max_wall_clock_ms: 60 * 60 * 1000, // 1h
+    call_timeouts_ms: DEFAULT_TIMEOUTS,
+  };
+
+  test("plenty of time remaining -> true", () => {
+    const state: WallclockState = {
+      session_started_at_ms: 0,
+      now_ms: 0,
+    };
+    expect(shouldStartNextRound(state, budget)).toBe(true);
+  });
+
+  test("5 minutes remaining, worst-case round is 52.5 min -> false", () => {
+    const state: WallclockState = {
+      session_started_at_ms: 0,
+      // Elapsed = 55min -> 5min remaining.
+      now_ms: 55 * 60 * 1000,
+    };
+    expect(shouldStartNextRound(state, budget)).toBe(false);
+  });
+
+  test("exactly worst-case remaining -> true (boundary includes equal)", () => {
+    const worst = worstCaseRoundDuration(DEFAULT_TIMEOUTS);
+    const state: WallclockState = {
+      session_started_at_ms: 0,
+      now_ms: budget.max_wall_clock_ms - worst,
+    };
+    expect(shouldStartNextRound(state, budget)).toBe(true);
+  });
+
+  test("1 ms less than worst-case remaining -> false", () => {
+    const worst = worstCaseRoundDuration(DEFAULT_TIMEOUTS);
+    const state: WallclockState = {
+      session_started_at_ms: 0,
+      now_ms: budget.max_wall_clock_ms - worst + 1,
+    };
+    expect(shouldStartNextRound(state, budget)).toBe(false);
+  });
+
+  test("already over budget -> false", () => {
+    const state: WallclockState = {
+      session_started_at_ms: 0,
+      now_ms: budget.max_wall_clock_ms + 1000,
+    };
+    expect(shouldStartNextRound(state, budget)).toBe(false);
+  });
+
+  test("crafted 15 minute budget / worst-case 10 min -> true", () => {
+    const smallBudget: WallclockBudget = {
+      max_wall_clock_ms: 15 * 60 * 1000,
+      call_timeouts_ms: {
+        // Tuned so worst-case is exactly 10 min:
+        // (max(a, b) + revise) * 3.5 = 600s => (a + revise) = 171.428s
+        // Simpler: max=60s, revise=111.428s => 60*3.5+111.428*3.5 ≈ 600s.
+        // Cleanest: a=b=60s, revise=60s => worst = (60+60)*3.5 = 420s = 7min.
+        // Try a=b=80, revise=80 => (80+80)*3.5 = 560s ~ 9.33min. Still < 10.
+        // Use a=b=100, revise=71.42 => not clean integers. Use exact 10-min:
+        // (100 + 71_428/1000) * 3.5 = 600? Too fiddly.
+        // Pick (a=b)=40_000ms, revise=131_429ms: (40+131.429)*3.5 = 600.
+        // Simpler: directly test with the helper, avoid magic numbers.
+        criticA_ms: 60_000,
+        criticB_ms: 60_000,
+        revise_ms: 60_000,
+      },
+    };
+    // worst = (60 + 60) * 3.5 * 1000 = 420_000ms = 7min.
+    const state: WallclockState = {
+      session_started_at_ms: 0,
+      now_ms: 0, // full 15min remaining, worst=7min -> true.
+    };
+    expect(shouldStartNextRound(state, smallBudget)).toBe(true);
+
+    // Now consume 9min; 6min remaining < 7min worst -> false.
+    const state2: WallclockState = {
+      session_started_at_ms: 0,
+      now_ms: 9 * 60 * 1000,
+    };
+    expect(shouldStartNextRound(state2, smallBudget)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #14

## Summary

Ships the Sprint 2 budget-enforcement skeleton (policy layer) with four new modules under `src/policy/`, all red-first TDD, no loop execution (Sprint 3 wires them).

- `preflight.ts` — `computePreflight(config, adapters)` + `formatPreflight` pretty-printer. Range (M=1), high (M=`max_iterations`), likely (**P50 at `M_likely`**, NOT arithmetic midpoint). Per-adapter breakdown with `"unknown — subscription auth"` for subbed adapters, warnings, `belowFloor` flag, `blendWeight` + `sampleCount`.
- `calibration.ts` — `.samospec/config.json` `calibration` schema, `readCalibration`, `blendWeight = min(count, 10) / 10`, floor=3 / cap=20 constants, `meanCalibrated`, pure `recordSession(cur, sample)` (20-sample cap, drops oldest; Issue #15 wires it at session end).
- `consent.ts` — `shouldPromptConsent` gate (threshold OR `anyUsageNull`), `promptConsent({ preflight, thresholdUsd, answer? })` returning `accept` / `downshift` (`sessionEffort=high`, not persisted) / `abort` (exit 5). TTY-less: `answer` is injected for tests.
- `wallclock.ts` — `shouldStartNextRound(state, budget)` + `worstCaseRoundDuration` using SPEC §7 capped-retry `3.5x` multiplier. Reviewer pair parallel -> `max(a, b)` + revise, each scaled by `3.5`.

## Checklist

- [x] `computePreflight` returns `{ rangeLowUsd, rangeHighUsd, likelyUsd, perAdapter, warnings, belowFloor, blendWeight, sampleCount, mLikely, mMax }`
- [x] Runs at end of Phase 1; scaffold-only inputs (iteration cap, per-phase budgets, reviewer pair × critique × M)
- [x] `likelyUsd` is P50 at `M_likely`, NOT arithmetic midpoint
- [x] Subscription-auth per-adapter cost is `"unknown — subscription auth"`; warning added; `likelyUsd` excludes unpriced adapter
- [x] Pretty-printer with `estimated range: \$X–\$Y, likely \$Z` + per-adapter breakdown + warnings + "first runs; estimate is approximate" inline below floor
- [x] Calibration floor = 3 samples; below = defaults; 3..9 blended; 10+ dominates
- [x] Blend formula `effective = min(count, 10) / 10 * calibration + (1 - min(count, 10) / 10) * defaults`
- [x] 20-sample cap, drops oldest
- [x] Consent-gate `[accept / downshift / abort]`; abort = exit 5; downshift = session-only effort=high
- [x] `shouldStartNextRound` implements the SPEC §11 wall-clock overrun rule
- [x] Capped-retry `3.5x` multiplier per call; reviewer pair dominated by `max(a, b)`
- [x] Copyright banners, `- ` markdown lists
- [x] Lint + format + typecheck green; 584 tests (522 prior + 62 new) all pass

## Test plan

- [x] Red-first commits: `9ed6f63` (RED) -> `e198408` (GREEN)
- [x] \`bun test tests/policy/\` -> 62 pass / 0 fail
- [x] \`bun test\` (all) -> 584 pass / 0 fail
- [x] \`bun run lint\` / \`format:check\` / \`typecheck\` -> clean

### Captured demo (below-floor / blended / calibrated / subscription-auth)

\`\`\`
=== (a) below-floor ===
estimated range: \$5.17–\$21.15, likely \$12.28 (first runs; estimate is approximate)
per-adapter:
  lead: ~185K tokens, \$7.40
  reviewer_a: ~75K tokens, \$1.88
  reviewer_b: ~75K tokens, \$3.00

=== (b) blended (5 samples, 50/50) ===
estimated range: \$6.42–\$33.58, likely \$16.98
per-adapter:
  lead: ~238K tokens, \$9.52
  reviewer_a: ~115K tokens, \$2.87
  reviewer_b: ~115K tokens, \$4.59

=== (c) calibrated (12 samples; calibration dominates) ===
estimated range: \$9.79–\$67.30, likely \$41.74
per-adapter:
  lead: ~517K tokens, \$20.68
  reviewer_a: ~324K tokens, \$8.10
  reviewer_b: ~324K tokens, \$12.96

=== (d) subscription-auth (lead + reviewer_b subbed) ===
estimated range: \$0.38–\$3.75, likely \$1.88 (first runs; estimate is approximate)
per-adapter:
  lead: ~185K tokens, unknown — subscription auth
  reviewer_a: ~75K tokens, \$1.88
  reviewer_b: ~75K tokens, unknown — subscription auth
warnings:
  2 adapter(s) under subscription-auth; total cost incomplete
\`\`\`

## Scope guardrails observed

- No loop execution (Sprint 3).
- No real \`samospec status\` command; helpers exported for Issue #15 to wire.
- No real calibration writes; \`recordSession\` shipped as pure API only.
- Existing \`src/adapter/*\` / \`src/state/*\` untouched.