### PR TITLE
feat: Sprint 2 #13 — persona proposal + 5-question interview

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,21 @@
 // Copyright 2026 Nikolay Samokhvalov.
 
 import { homedir } from "node:os";
+import * as readline from "node:readline/promises";
 
+import { ClaudeAdapter } from "./adapter/claude.ts";
 import { createFakeAdapter } from "./adapter/fake-adapter.ts";
+import type { Adapter } from "./adapter/types.ts";
 import { runInit } from "./cli/init.ts";
 import { runDoctor, type DoctorAdapterBinding } from "./cli/doctor.ts";
+import { runNew, type ChoiceResolvers } from "./cli/new.ts";
+import {
+  PERSONA_FORM_RE,
+  extractSkill,
+  type PersonaChoice,
+  type PersonaProposal,
+} from "./cli/persona.ts";
+import { runResume } from "./cli/resume.ts";
 import packageJson from "../package.json" with { type: "json" };
 
 export interface CliResult {
@@ -22,9 +33,11 @@ const VERSION_FLAGS: ReadonlySet<string> = new Set([
 const USAGE =
   "Usage: samospec <command>\n\n" +
   "Commands:\n" +
-  "  init       Create or refresh .samospec/ in the current repo.\n" +
-  "  doctor     Diagnose CLI availability, auth, git, lock, and config.\n" +
-  "  version    Print the samospec version and exit.\n";
+  "  init                        Create or refresh .samospec/ in the current repo.\n" +
+  "  doctor                      Diagnose CLI availability, auth, git, lock, and config.\n" +
+  "  new <slug> [--idea ...]     Start a new spec (persona + 5-question interview).\n" +
+  "  resume [<slug>]             Resume an in-progress spec from state.json.\n" +
+  "  version                     Print the samospec version and exit.\n";
 
 /**
  * Default adapter bindings for `samospec doctor`. Sprint 1 only ships
@@ -74,9 +87,193 @@ export async function runCli(argv: readonly string[]): Promise<CliResult> {
     });
   }
 
+  if (command === "new") {
+    return runNewCommand(rest);
+  }
+
+  if (command === "resume") {
+    return runResumeCommand(rest);
+  }
+
   return {
     exitCode: 1,
     stdout: "",
     stderr: `samospec: unknown command '${command}'\n\n${USAGE}`,
   };
+}
+
+// ---------- command parsers ----------
+
+interface NewArgs {
+  readonly slug: string;
+  readonly idea: string;
+  readonly explain: boolean;
+}
+
+interface ResumeArgs {
+  readonly slug: string;
+  readonly explain: boolean;
+}
+
+function parseNewArgs(argv: readonly string[]): NewArgs | string {
+  let slug: string | null = null;
+  let idea: string | null = null;
+  let explain = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === undefined) continue;
+    if (token === "--explain") {
+      explain = true;
+      continue;
+    }
+    if (token === "--idea") {
+      idea = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (token.startsWith("--idea=")) {
+      idea = token.slice("--idea=".length);
+      continue;
+    }
+    if (token.startsWith("--")) {
+      // Unknown flags ignored in this skeleton; #15 expands flag set.
+      continue;
+    }
+    if (slug === null) {
+      slug = token;
+      continue;
+    }
+  }
+  if (slug === null || slug.length === 0) {
+    return "samospec new: missing <slug>";
+  }
+  return {
+    slug,
+    idea: idea ?? slug,
+    explain,
+  };
+}
+
+function parseResumeArgs(argv: readonly string[]): ResumeArgs | string {
+  let slug: string | null = null;
+  let explain = false;
+  for (const token of argv) {
+    if (token === "--explain") {
+      explain = true;
+      continue;
+    }
+    if (token.startsWith("--")) continue;
+    slug ??= token;
+  }
+  if (slug === null || slug.length === 0) {
+    return "samospec resume: missing <slug> (v1 does not auto-select)";
+  }
+  return { slug, explain };
+}
+
+// ---------- adapter + resolver wiring ----------
+
+function leadAdapter(): Adapter {
+  return new ClaudeAdapter();
+}
+
+/**
+ * Interactive resolvers: prompt via stdin/stdout. When stdin is not a
+ * TTY (piped / CI), defaults to accepting the proposal and choosing
+ * the first option. Tests drive `runNew` / `runResume` directly with
+ * deterministic resolvers, so this path is exercised only from a real
+ * terminal invocation.
+ */
+function interactiveResolvers(): ChoiceResolvers {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return {
+    persona: async (p: PersonaProposal): Promise<PersonaChoice> => {
+      process.stdout.write(`\nPersona proposal: ${p.persona}\n`);
+      process.stdout.write(`Rationale: ${p.rationale}\n`);
+      const ans = (
+        await rl.question(
+          "[A]ccept / [E]dit skill / [R]eplace / [Enter=accept]: ",
+        )
+      )
+        .trim()
+        .toLowerCase();
+      if (ans === "" || ans === "a" || ans === "accept") {
+        return { kind: "accept" };
+      }
+      if (ans === "e" || ans === "edit") {
+        const skill = (await rl.question("New skill: ")).trim();
+        return { kind: "edit", skill };
+      }
+      if (ans === "r" || ans === "replace") {
+        const persona = (
+          await rl.question(
+            'Full persona (must match Veteran "<skill>" expert): ',
+          )
+        ).trim();
+        if (!PERSONA_FORM_RE.test(persona)) {
+          return { kind: "accept" };
+        }
+        const skill = extractSkill(persona);
+        if (skill === null) return { kind: "accept" };
+        return { kind: "replace", persona };
+      }
+      return { kind: "accept" };
+    },
+    question: async (q) => {
+      process.stdout.write(`\n${q.text}\n`);
+      q.options.forEach((opt, idx) => {
+        process.stdout.write(`  ${String(idx + 1)}. ${opt}\n`);
+      });
+      const pick = (
+        await rl.question(`Pick 1-${String(q.options.length)} [1]: `)
+      ).trim();
+      const idx = pick === "" ? 0 : Number.parseInt(pick, 10) - 1;
+      const chosen = q.options[idx] ?? q.options[0] ?? "decide for me";
+      if (chosen === "custom") {
+        const custom = (await rl.question("Custom answer: ")).trim();
+        return { choice: "custom", custom };
+      }
+      return { choice: chosen };
+    },
+  };
+}
+
+async function runNewCommand(rest: readonly string[]) {
+  const parsed = parseNewArgs(rest);
+  if (typeof parsed === "string") {
+    return { exitCode: 1, stdout: "", stderr: `${parsed}\n\n${USAGE}` };
+  }
+  const adapter = leadAdapter();
+  return runNew(
+    {
+      cwd: process.cwd(),
+      slug: parsed.slug,
+      idea: parsed.idea,
+      explain: parsed.explain,
+      resolvers: interactiveResolvers(),
+      now: new Date().toISOString(),
+    },
+    adapter,
+  );
+}
+
+async function runResumeCommand(rest: readonly string[]) {
+  const parsed = parseResumeArgs(rest);
+  if (typeof parsed === "string") {
+    return { exitCode: 1, stdout: "", stderr: `${parsed}\n\n${USAGE}` };
+  }
+  const adapter = leadAdapter();
+  return runResume(
+    {
+      cwd: process.cwd(),
+      slug: parsed.slug,
+      now: new Date().toISOString(),
+      resolvers: interactiveResolvers(),
+      explain: parsed.explain,
+    },
+    adapter,
+  );
 }

--- a/src/cli/interview.ts
+++ b/src/cli/interview.ts
@@ -1,0 +1,383 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §5 Phase 4 — 5-question strategic interview.
+//
+// Contract:
+//   - runInterview(input, adapter) asks the lead for up to
+//     INTERVIEW_MAX_QUESTIONS strategic questions about the idea,
+//     each with options. Extras beyond 5 are DROPPED (hard cap).
+//   - Every question is wrapped so its user-facing option list
+//     ALWAYS includes the three universal escape hatches:
+//     `decide for me`, `not sure — defer`, `custom`.
+//   - The caller owns interactive prompt UI via `onQuestion`. The
+//     callback resolves one of: { choice: "<option>" } or
+//     { choice: "custom", custom: "<free text>" }.
+//   - interview.json schema is zod-validated on both write and read.
+//
+// Scope guard: this module does NOT commit to git and does NOT move
+// phase. The caller (new/resume) owns those seams.
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import path from "node:path";
+
+import { z } from "zod";
+
+import { preParseJson } from "../adapter/json-parse.ts";
+import type { Adapter, AskInput, EffortLevel } from "../adapter/types.ts";
+import { PERSONA_FORM_RE } from "./persona.ts";
+
+// ---------- constants ----------
+
+export const INTERVIEW_MAX_QUESTIONS = 5 as const;
+
+export const INTERVIEW_ESCAPE_HATCHES: readonly string[] = [
+  "decide for me",
+  "not sure — defer",
+  "custom",
+] as const;
+
+const ISO_TS_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/;
+
+// ---------- zod schemas ----------
+
+const QuestionSchema = z
+  .object({
+    id: z.string().min(1),
+    text: z.string().min(1),
+    options: z.array(z.string().min(1)),
+  })
+  .strict();
+
+const AnswerSchema = z
+  .object({
+    id: z.string().min(1),
+    choice: z.string().min(1),
+    custom: z.string().min(1).optional(),
+  })
+  .strict()
+  .refine(
+    (a) => a.choice !== "custom" || typeof a.custom === "string",
+    "choice=custom requires a non-empty `custom` free-text field",
+  );
+
+export const InterviewFileSchema = z
+  .object({
+    slug: z.string().min(1),
+    persona: z.string().regex(PERSONA_FORM_RE),
+    generated_at: z.string().regex(ISO_TS_RE),
+    questions: z.array(QuestionSchema),
+    answers: z.array(AnswerSchema),
+  })
+  .strict();
+
+export type InterviewFile = z.infer<typeof InterviewFileSchema>;
+export type InterviewQuestion = z.infer<typeof QuestionSchema>;
+export type InterviewAnswer = z.infer<typeof AnswerSchema>;
+
+// The shape the lead returns. `options` is optional so we tolerate
+// bare-question responses (we always splice in escape hatches).
+const LeadQuestionSchema = z
+  .object({
+    id: z.string().min(1),
+    text: z.string().min(1),
+    options: z.array(z.string().min(1)).optional(),
+  })
+  .passthrough();
+
+const LeadResponseSchema = z
+  .object({
+    questions: z.array(LeadQuestionSchema),
+  })
+  .passthrough();
+
+// ---------- public types ----------
+
+export type OnQuestionCallback = (q: {
+  readonly id: string;
+  readonly text: string;
+  readonly options: readonly string[];
+}) => Promise<{
+  readonly choice: string;
+  readonly custom?: string;
+}>;
+
+export interface RunInterviewInput {
+  readonly slug: string;
+  readonly persona: string;
+  readonly explain: boolean;
+  readonly subscriptionAuth: boolean;
+  readonly onQuestion: OnQuestionCallback;
+  /** Sink for surface messages. */
+  readonly onNotice?: (line: string) => void;
+  /** Optional path for interview.json; nothing written when omitted. */
+  readonly outputPath?: string;
+  /** Override timestamp for deterministic tests; defaults to now(). */
+  readonly now?: string;
+  readonly effort?: EffortLevel;
+  readonly timeoutMs?: number;
+}
+
+export interface InterviewResult {
+  readonly slug: string;
+  readonly persona: string;
+  readonly generated_at: string;
+  readonly questions: readonly InterviewQuestion[];
+  readonly answers: readonly InterviewAnswer[];
+}
+
+// ---------- errors ----------
+
+export class InterviewTerminalError extends Error {
+  constructor(detail: string) {
+    super(`interview lead_terminal: ${detail}`);
+    this.name = "InterviewTerminalError";
+  }
+}
+
+// ---------- prompt builders ----------
+
+function buildInterviewPrompt(input: {
+  persona: string;
+  explain: boolean;
+}): string {
+  const explainPreamble = input.explain
+    ? "Use plain English for any user-facing copy. Avoid engineer-terse " +
+      "jargon in prose fields. (Non-technical ICP.)\n\n"
+    : "";
+  return (
+    explainPreamble +
+    `You are the samospec lead, playing the persona: ${input.persona}. ` +
+    "Propose up to FIVE (5) high-signal strategic questions that the " +
+    "user must answer to produce a v0.1 spec. Fewer is fine; more than 5 " +
+    "will be truncated by the tool. Each question has an `id` (slug), " +
+    "`text` (one sentence), and `options` (2-6 concrete choices the " +
+    "persona thinks are the most likely answers).\n\n" +
+    "Respond ONLY with a JSON object:\n" +
+    '  { "questions": [ { "id": "...", "text": "...", "options": ' +
+    '["...", "..."] }, ... ] }\n' +
+    "Do not wrap in code fences.\n"
+  );
+}
+
+// ---------- runInterview ----------
+
+/**
+ * SPEC §5 Phase 4 — ask the lead for up to 5 questions, then drive the
+ * user through them. Extras past 5 are dropped (hard cap); fewer than 5
+ * are proceed-with-fewer.
+ *
+ * The `onQuestion` callback is the UI seam — callers wire interactive
+ * numbered-menu prompts around it. Tests pass a deterministic auto-
+ * responder.
+ */
+export async function runInterview(
+  input: RunInterviewInput,
+  adapter: Adapter,
+): Promise<InterviewResult> {
+  if (!PERSONA_FORM_RE.test(input.persona)) {
+    throw new InterviewTerminalError(
+      `persona is not in canonical form: ${input.persona}`,
+    );
+  }
+
+  const effort: EffortLevel = input.effort ?? "max";
+  const timeoutMs = input.timeoutMs ?? 120_000;
+  const prompt = buildInterviewPrompt({
+    persona: input.persona,
+    explain: input.explain,
+  });
+
+  const askInput: AskInput = {
+    prompt,
+    context: "",
+    opts: { effort, timeout: timeoutMs },
+  };
+
+  let askOut;
+  try {
+    askOut = await adapter.ask(askInput);
+  } catch (err) {
+    throw new InterviewTerminalError(
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  const parsed = preParseJson(askOut.answer);
+  if (!parsed.ok) {
+    throw new InterviewTerminalError(
+      `lead response was not valid JSON: ${parsed.error.message}`,
+    );
+  }
+  const validated = LeadResponseSchema.safeParse(parsed.value);
+  if (!validated.success) {
+    throw new InterviewTerminalError(
+      `lead response did not match schema: ${validated.error.message}`,
+    );
+  }
+
+  // Hard cap at 5. Truncate extras silently; caller may log the drop.
+  const leadQuestions = validated.data.questions.slice(
+    0,
+    INTERVIEW_MAX_QUESTIONS,
+  );
+
+  // Compose each question with guaranteed escape hatches, preserving
+  // whatever the lead returned first.
+  const questions: InterviewQuestion[] = leadQuestions.map((q) => {
+    const leadOptions = q.options ?? [];
+    const composed: string[] = [];
+    const seen = new Set<string>();
+    for (const opt of leadOptions) {
+      if (!seen.has(opt)) {
+        composed.push(opt);
+        seen.add(opt);
+      }
+    }
+    for (const hatch of INTERVIEW_ESCAPE_HATCHES) {
+      if (!seen.has(hatch)) {
+        composed.push(hatch);
+        seen.add(hatch);
+      }
+    }
+    return {
+      id: q.id,
+      text: q.text,
+      options: composed,
+    };
+  });
+
+  const answers: InterviewAnswer[] = [];
+  for (const q of questions) {
+    const resp = await input.onQuestion({
+      id: q.id,
+      text: q.text,
+      options: q.options,
+    });
+    if (resp.choice === "custom") {
+      if (typeof resp.custom !== "string" || resp.custom.trim().length === 0) {
+        throw new InterviewTerminalError(
+          `answer to ${q.id} picked 'custom' but supplied no custom text`,
+        );
+      }
+      answers.push({ id: q.id, choice: "custom", custom: resp.custom });
+    } else {
+      answers.push({ id: q.id, choice: resp.choice });
+    }
+  }
+
+  const now = input.now ?? new Date().toISOString();
+  const result: InterviewResult = {
+    slug: input.slug,
+    persona: input.persona,
+    generated_at: now,
+    questions,
+    answers,
+  };
+
+  if (input.outputPath !== undefined) {
+    writeInterview(input.outputPath, {
+      slug: result.slug,
+      persona: result.persona,
+      generated_at: result.generated_at,
+      questions: [...result.questions],
+      answers: [...result.answers],
+    });
+  }
+
+  return result;
+}
+
+// ---------- file I/O ----------
+
+/**
+ * Atomic write of interview.json — zod-validates the payload first, then
+ * uses temp-file + fsync + rename for crash safety (matches
+ * src/state/store.ts pattern).
+ */
+export function writeInterview(file: string, payload: InterviewFile): void {
+  const validated = InterviewFileSchema.safeParse(payload);
+  if (!validated.success) {
+    throw new Error(
+      `refusing to write invalid interview.json to ${file}: ${validated.error.message}`,
+    );
+  }
+  const dir = path.dirname(file);
+  mkdirSync(dir, { recursive: true });
+
+  const tmp = path.join(dir, `.${path.basename(file)}.tmp.${process.pid}`);
+  const json = `${JSON.stringify(validated.data, null, 2)}\n`;
+
+  const fd = openSync(tmp, "w", 0o644);
+  try {
+    writeSync(fd, json, 0, "utf8");
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+
+  try {
+    renameSync(tmp, file);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+
+  // Best-effort directory fsync for durability.
+  try {
+    const dfd = openSync(dir, "r");
+    try {
+      fsyncSync(dfd);
+    } finally {
+      closeSync(dfd);
+    }
+  } catch {
+    // Some platforms do not allow fsync on a dir fd.
+  }
+}
+
+/**
+ * Read + validate interview.json. Returns null if the file is absent.
+ * Throws a contextual Error if the file is present but malformed.
+ */
+export function readInterview(file: string): InterviewFile | null {
+  if (!existsSync(file)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch (err) {
+    throw new Error(
+      `interview.json at ${file} could not be read: ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `interview.json at ${file} is not valid JSON: ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+  const result = InterviewFileSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `interview.json at ${file} failed schema validation: ${result.error.message}`,
+    );
+  }
+  return result.data;
+}

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -1,0 +1,419 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §5 Phases 1-4 skeleton for `samospec new <slug>`.
+// Wires:
+//   - lockfile acquisition (src/state/lock.ts)
+//   - branch creation stub (src/git/branch.ts — guarded by flag, SPEC §15
+//     Sprint 3 task #15 will wire real invocation)
+//   - persona proposal (src/cli/persona.ts)
+//   - interview (src/cli/interview.ts)
+//   - TODO markers for context / preflight / draft (issues #11 / #14 /
+//     #15 to follow)
+//
+// Scope guard (SPEC §13 test 3 persona + test 2 interview):
+//   - No context discovery; no preflight cost estimate; no v0.1 draft.
+//   - Branch creation is behind enableBranchCreation flag so #15 can
+//     wire the real call without touching this file's tests.
+
+import { existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+
+import type { Adapter } from "../adapter/types.ts";
+import {
+  LockContendedError,
+  acquireLock,
+  releaseLock,
+  type LockHandle,
+} from "../state/lock.ts";
+import { advancePhase } from "../state/phase.ts";
+import { newState, readState, writeState } from "../state/store.ts";
+import type { State } from "../state/types.ts";
+import {
+  PersonaTerminalError,
+  extractSkill,
+  proposePersona,
+  type PersonaChoice,
+  type PersonaProposal,
+} from "./persona.ts";
+import {
+  InterviewTerminalError,
+  readInterview,
+  runInterview,
+  type InterviewResult,
+  type OnQuestionCallback,
+} from "./interview.ts";
+
+const DEFAULT_MAX_WALL_CLOCK_MIN = 240;
+
+export interface RunNewResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface ChoiceResolvers {
+  readonly persona: (p: PersonaProposal) => Promise<PersonaChoice>;
+  readonly question: OnQuestionCallback;
+}
+
+export interface RunNewInput {
+  readonly cwd: string;
+  readonly slug: string;
+  readonly idea: string;
+  readonly explain: boolean;
+  readonly resolvers: ChoiceResolvers;
+  readonly now: string;
+  /** Test seam: inject a non-process pid when probing lock contention. */
+  readonly pid?: number;
+  /** Opt-in git branch creation (SPEC #15 Sprint 3). Default: false. */
+  readonly enableBranchCreation?: boolean;
+  /**
+   * Injected branch-creator seam. Default resolves to a no-op when
+   * enableBranchCreation is false. When true, invoked exactly once
+   * after lock acquisition.
+   */
+  readonly createBranch?: (slug: string) => string;
+  /** Override for max wall-clock minutes (lock staleness cutoff). */
+  readonly maxWallClockMinutes?: number;
+}
+
+// ---------- CLI entry ----------
+
+export async function runNew(
+  input: RunNewInput,
+  adapter: Adapter,
+): Promise<RunNewResult> {
+  const lines: string[] = [];
+  const errors: string[] = [];
+  const notice = (line: string): void => {
+    lines.push(line);
+  };
+
+  const samoDir = path.join(input.cwd, ".samospec");
+  const specsDir = path.join(samoDir, "spec");
+  const slugDir = path.join(specsDir, input.slug);
+  const lockPath = path.join(samoDir, ".lock");
+
+  // Slug collision guard (SPEC §10): refuse any pre-existing slug
+  // directory and suggest resume / --force.
+  if (existsSync(slugDir)) {
+    errors.push(
+      `samospec: .samospec/spec/${input.slug}/ already exists. ` +
+        `Try \`samospec resume ${input.slug}\` or ` +
+        `\`samospec new ${input.slug} --force\` to archive the old run.`,
+    );
+    return {
+      exitCode: 1,
+      stdout: lines.join("\n"),
+      stderr: `${errors.join("\n")}\n`,
+    };
+  }
+
+  // Lockfile acquisition (SPEC §5 Phase 1).
+  let handle: LockHandle;
+  try {
+    handle = acquireLock({
+      lockPath,
+      slug: input.slug,
+      now: Date.parse(input.now),
+      maxWallClockMinutes:
+        input.maxWallClockMinutes ?? DEFAULT_MAX_WALL_CLOCK_MIN,
+      pid: input.pid ?? process.pid,
+    });
+  } catch (err) {
+    if (err instanceof LockContendedError) {
+      errors.push(
+        `samospec: another samospec run holds the repo lock (pid ${err.holderPid}). ` +
+          `Wait for it to exit or remove ${err.lockPath} if stale.`,
+      );
+      return {
+        exitCode: 2,
+        stdout: lines.join("\n"),
+        stderr: `${errors.join("\n")}\n`,
+      };
+    }
+    throw err;
+  }
+
+  try {
+    // Branch creation seam (SPEC §5 Phase 1 + SPEC §15 task #15).
+    if (input.enableBranchCreation === true) {
+      const createBranch = input.createBranch;
+      if (createBranch !== undefined) {
+        createBranch(input.slug);
+      }
+      notice(`TODO #15: branch 'samospec/${input.slug}' created (stub).`);
+    } else {
+      notice(
+        `TODO #15: branch creation deferred (set enableBranchCreation=true to opt in).`,
+      );
+    }
+
+    // Materialize the slug directory.
+    mkdirSync(slugDir, { recursive: true });
+
+    // Initial state.json. Starts at phase 'detect' and advances as we
+    // make progress so a crash leaves a truthful state record.
+    let state = newState({ slug: input.slug, now: input.now });
+    const statePath = path.join(slugDir, "state.json");
+    writeState(statePath, state);
+
+    // Phase-advance seam: each phase we enter bumps the phase pointer
+    // and re-persists so resume starts from the right place.
+    state = advancePhase(state, "branch_lock_preflight", { now: input.now });
+    writeState(statePath, state);
+
+    // TODO markers (#14 preflight cost, #11 context discovery).
+    notice(
+      `TODO #14: preflight cost estimate deferred (no paid lead calls before preflight land).`,
+    );
+
+    // Phase 2 — persona.
+    state = advancePhase(state, "persona", { now: input.now });
+    writeState(statePath, state);
+
+    const subAuth = await resolveSubscriptionAuth(adapter);
+    let persona: PersonaProposal;
+    try {
+      persona = await proposePersonaInteractive(
+        {
+          idea: input.idea,
+          explain: input.explain,
+          subscriptionAuth: subAuth,
+          onNotice: notice,
+          resolver: input.resolvers.persona,
+        },
+        adapter,
+      );
+    } catch (err) {
+      if (err instanceof PersonaTerminalError) {
+        state = { ...state, round_state: "lead_terminal" };
+        state.updated_at = input.now;
+        writeState(statePath, state);
+        errors.push(
+          `samospec: lead_terminal at persona — ${err.detail}. ` +
+            `Edit .samospec/spec/${input.slug}/ manually or restart with --force.`,
+        );
+        return {
+          exitCode: 4,
+          stdout: lines.join("\n"),
+          stderr: `${errors.join("\n")}\n`,
+        };
+      }
+      throw err;
+    }
+
+    state = {
+      ...state,
+      persona: { skill: persona.skill, accepted: persona.accepted },
+      updated_at: input.now,
+    };
+    writeState(statePath, state);
+    notice(`persona accepted: ${persona.persona}`);
+
+    // Phase 3 — context discovery (TODO #11).
+    state = advancePhase(state, "context", { now: input.now });
+    writeState(statePath, state);
+    notice(
+      `TODO #11: context discovery deferred (interview uses idea-only context for now).`,
+    );
+
+    // Phase 4 — interview.
+    state = advancePhase(state, "interview", { now: input.now });
+    writeState(statePath, state);
+
+    const interviewPath = path.join(slugDir, "interview.json");
+    let interview: InterviewResult;
+    try {
+      interview = await runInterview(
+        {
+          slug: input.slug,
+          persona: persona.persona,
+          explain: input.explain,
+          subscriptionAuth: subAuth,
+          onQuestion: input.resolvers.question,
+          onNotice: notice,
+          outputPath: interviewPath,
+          now: input.now,
+        },
+        adapter,
+      );
+    } catch (err) {
+      if (err instanceof InterviewTerminalError) {
+        state = { ...state, round_state: "lead_terminal" };
+        state.updated_at = input.now;
+        writeState(statePath, state);
+        errors.push(
+          `samospec: lead_terminal at interview — ${err.message}. ` +
+            `Edit .samospec/spec/${input.slug}/ manually or restart with --force.`,
+        );
+        return {
+          exitCode: 4,
+          stdout: lines.join("\n"),
+          stderr: `${errors.join("\n")}\n`,
+        };
+      }
+      // Any other error (e.g. question-callback reject, simulating a
+      // user Ctrl-C) is classified as interrupted (SPEC §10 exit 3).
+      errors.push(
+        `samospec: interview interrupted — ${
+          err instanceof Error ? err.message : String(err)
+        }.\n` +
+          `State persisted; run \`samospec resume ${input.slug}\` to continue.`,
+      );
+      return {
+        exitCode: 3,
+        stdout: lines.join("\n"),
+        stderr: `${errors.join("\n")}\n`,
+      };
+    }
+
+    notice(
+      `interview complete: ${String(interview.answers.length)} answer(s) recorded.`,
+    );
+
+    // TODO markers for the next unimplemented phases.
+    notice(
+      `TODO #15: v0.1 draft deferred. Next phase: context / draft — not implemented yet.`,
+    );
+
+    // Final state: phase remains `interview` until #15 advances us.
+    state.updated_at = input.now;
+    writeState(statePath, state);
+
+    return {
+      exitCode: 0,
+      stdout: lines.length === 0 ? "" : `${lines.join("\n")}\n`,
+      stderr: "",
+    };
+  } finally {
+    releaseLock(handle);
+  }
+}
+
+// ---------- helpers ----------
+
+async function resolveSubscriptionAuth(adapter: Adapter): Promise<boolean> {
+  try {
+    const auth = await adapter.auth_status();
+    return auth.subscription_auth === true;
+  } catch {
+    return false;
+  }
+}
+
+interface PersonaInteractiveInput {
+  readonly idea: string;
+  readonly explain: boolean;
+  readonly subscriptionAuth: boolean;
+  readonly onNotice: (line: string) => void;
+  readonly resolver: (p: PersonaProposal) => Promise<PersonaChoice>;
+}
+
+/**
+ * Two-step persona flow: first call proposePersona in "accept" mode
+ * just to surface the proposal; then ask the resolver for the real
+ * choice; if the resolver returns anything other than accept, invoke
+ * proposePersona again with the real choice (edit/replace short-
+ * circuits the ask path because the persona string is already valid).
+ *
+ * We rely on proposePersona's pure applyChoice on the first result:
+ * we pass through the PersonaProposal returned in step 1 and re-
+ * invoke only for edit/replace so the caller sees a single "call the
+ * lead once" happy path for accept.
+ */
+async function proposePersonaInteractive(
+  input: PersonaInteractiveInput,
+  adapter: Adapter,
+): Promise<PersonaProposal> {
+  // The first invocation is a dry-run to surface the proposal to the
+  // user via the resolver. We still want subscription-auth copy + the
+  // lead call to happen exactly once. proposePersona only makes the
+  // call on the first attempt; edit/replace do NOT re-ask. To support
+  // this, we call once with kind=accept, then apply the resolver's
+  // final choice locally via a second invocation (which re-uses the
+  // validated persona form, so won't re-hit the lead).
+  //
+  // Implementation detail: proposePersona always hits the lead once
+  // regardless of choice, so we drive two invocations naturally and
+  // cache the first proposal.
+
+  const draft = await proposePersona(
+    {
+      idea: input.idea,
+      explain: input.explain,
+      subscriptionAuth: input.subscriptionAuth,
+      onNotice: input.onNotice,
+      choice: { kind: "accept" },
+    },
+    adapter,
+  );
+
+  // Surface the draft to the user; SPEC §11 message was printed if
+  // applicable inside the first call.
+  input.onNotice(`proposed persona: ${draft.persona}`);
+  input.onNotice(`rationale: ${draft.rationale}`);
+
+  const choice = await input.resolver(draft);
+
+  if (choice.kind === "accept") {
+    return draft;
+  }
+
+  // For edit/replace, reuse applyChoice via a second proposePersona
+  // call path. We want no second lead call — but proposePersona always
+  // hits the lead, so we synthesize the result manually.
+  if (choice.kind === "edit") {
+    return {
+      persona: `Veteran "${choice.skill}" expert`,
+      skill: choice.skill,
+      rationale: draft.rationale,
+      accepted: true,
+    };
+  }
+  // kind === "replace"
+  const skill = extractSkill(choice.persona);
+  if (skill === null) {
+    throw new PersonaTerminalError(
+      "schema_violation",
+      `replacement persona did not match Veteran "<skill>" expert: ${choice.persona}`,
+    );
+  }
+  return {
+    persona: choice.persona,
+    skill,
+    rationale: draft.rationale,
+    accepted: true,
+  };
+}
+
+// ---------- diagnostic readers (used by resume) ----------
+
+export interface SpecPaths {
+  readonly slugDir: string;
+  readonly statePath: string;
+  readonly interviewPath: string;
+  readonly lockPath: string;
+}
+
+export function specPaths(cwd: string, slug: string): SpecPaths {
+  const slugDir = path.join(cwd, ".samospec", "spec", slug);
+  return {
+    slugDir,
+    statePath: path.join(slugDir, "state.json"),
+    interviewPath: path.join(slugDir, "interview.json"),
+    lockPath: path.join(cwd, ".samospec", ".lock"),
+  };
+}
+
+export interface SpecInspection {
+  readonly state: State | null;
+  readonly hasInterview: boolean;
+}
+
+export function inspectSpec(cwd: string, slug: string): SpecInspection {
+  const paths = specPaths(cwd, slug);
+  const state = readState(paths.statePath);
+  const hasInterview = readInterview(paths.interviewPath) !== null;
+  return { state, hasInterview };
+}

--- a/src/cli/persona.ts
+++ b/src/cli/persona.ts
@@ -1,0 +1,286 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §5 Phase 2 + §7 lead persona wiring + §11 subscription-auth UX.
+//
+// Contract:
+//   - proposePersona(input, adapter) asks the lead for a persona in the
+//     canonical form `Veteran "<skill>" expert`.
+//   - On schema violation, ONE repair retry (matching §7 adapter
+//     semantics). Second failure throws PersonaTerminalError.
+//   - User choice is one of: { accept } | { edit, skill } | { replace,
+//     persona }.
+//   - When subscriptionAuth=true, emits the SPEC §11 UX message via
+//     onNotice BEFORE the lead call.
+//   - When explain=true, the system prompt adds a plain-English
+//     preamble (SPEC §4 secondary ICP).
+//
+// No lead_terminal state mutation happens here — the caller (new/resume)
+// owns state.json; this module throws a typed error the caller routes.
+
+import { z } from "zod";
+
+import { preParseJson } from "../adapter/json-parse.ts";
+import type { Adapter, AskInput, EffortLevel } from "../adapter/types.ts";
+
+// SPEC §5 Phase 2 canonical form. Matches:
+//   Veteran "<non-empty skill>" expert
+// Skill allows any character except unescaped double quotes.
+export const PERSONA_FORM_RE = /^Veteran "([^"]+)" expert$/;
+
+export function formatPersonaString(skill: string): string {
+  return `Veteran "${skill}" expert`;
+}
+
+export function extractSkill(persona: string): string | null {
+  const m = PERSONA_FORM_RE.exec(persona);
+  return m !== null ? (m[1] ?? null) : null;
+}
+
+// SPEC §11 UX copy printed before the first paid lead call under
+// subscription-auth. Exported so `doctor` and tests can compare against
+// the canonical string.
+export const SUBSCRIPTION_AUTH_MESSAGE =
+  "Claude adapter is in subscription-auth mode. Token cost is not " +
+  "visible; wall-clock/iteration caps enforced instead.";
+
+// ---------- LLM JSON schema ----------
+
+const personaAskSchema = z
+  .object({
+    persona: z.string().min(1),
+    rationale: z.string(),
+  })
+  .passthrough();
+
+// ---------- public types ----------
+
+export interface PersonaProposal {
+  readonly persona: string;
+  readonly skill: string;
+  readonly rationale: string;
+  /** Whether the user accepted / edited / replaced to arrive at this. */
+  readonly accepted: boolean;
+}
+
+export type PersonaChoice =
+  | { readonly kind: "accept" }
+  | { readonly kind: "edit"; readonly skill: string }
+  | { readonly kind: "replace"; readonly persona: string };
+
+export interface ProposePersonaInput {
+  readonly idea: string;
+  readonly explain: boolean;
+  readonly subscriptionAuth: boolean;
+  readonly choice: PersonaChoice;
+  /** Sink for surface messages (subscription-auth copy etc.). */
+  readonly onNotice?: (line: string) => void;
+  /** Effort override; defaults to `max`. */
+  readonly effort?: EffortLevel;
+  /** Timeout override in ms; defaults to 120_000 (AskInput default). */
+  readonly timeoutMs?: number;
+}
+
+// ---------- errors ----------
+
+export class PersonaTerminalError extends Error {
+  public readonly reason: "schema_violation" | "adapter_error";
+  public readonly detail: string;
+
+  constructor(reason: "schema_violation" | "adapter_error", detail: string) {
+    super(`persona lead_terminal: ${reason}: ${detail}`);
+    this.name = "PersonaTerminalError";
+    this.reason = reason;
+    this.detail = detail;
+  }
+}
+
+export class PersonaChoiceError extends Error {
+  constructor(detail: string) {
+    super(`persona choice invalid: ${detail}`);
+    this.name = "PersonaChoiceError";
+  }
+}
+
+// ---------- implementation ----------
+
+function buildPersonaPrompt(input: { idea: string; explain: boolean }): string {
+  const explainPreamble = input.explain
+    ? "Use plain English for any user-facing copy. Avoid engineer-terse " +
+      "jargon in prose fields. (Non-technical ICP.)\n\n"
+    : "";
+  return (
+    explainPreamble +
+    "You are the samospec lead. Given a rough idea, propose a single " +
+    'expert persona in the EXACT form `Veteran "<skill>" expert`. ' +
+    "Examples:\n" +
+    '  - Veteran "CLI software engineer" expert\n' +
+    '  - Veteran "distributed systems / SRE specialist" expert\n\n' +
+    "Respond ONLY with a JSON object:\n" +
+    '  { "persona": "Veteran \\"<skill>\\" expert", "rationale": "..." }\n' +
+    "Do not wrap in code fences. The skill must be non-empty and must " +
+    "not contain unescaped double quotes. One and only one persona.\n\n" +
+    `Idea:\n${input.idea}\n`
+  );
+}
+
+function buildRepairPrompt(original: string, badAnswer: string): string {
+  return (
+    "Your previous response did not match the required schema. Re-emit " +
+    'ONLY a JSON object of shape { "persona": "Veteran \\"<skill>\\" ' +
+    'expert", "rationale": "..." }. No prose, no code fences. The ' +
+    '`persona` field MUST match the regex ^Veteran "[^"]+" expert$.\n\n' +
+    "Previous invalid output was:\n" +
+    badAnswer +
+    "\n\nRe-attempt the original request:\n" +
+    original
+  );
+}
+
+function parsePersonaAnswer(raw: string): {
+  persona: string;
+  rationale: string;
+} | null {
+  const parsed = preParseJson(raw);
+  if (!parsed.ok) return null;
+  const validated = personaAskSchema.safeParse(parsed.value);
+  if (!validated.success) return null;
+  const { persona, rationale } = validated.data;
+  if (!PERSONA_FORM_RE.test(persona)) return null;
+  return { persona, rationale };
+}
+
+async function askForPersona(
+  adapter: Adapter,
+  prompt: string,
+  effort: EffortLevel,
+  timeoutMs: number,
+): Promise<string> {
+  const askInput: AskInput = {
+    prompt,
+    context: "",
+    opts: { effort, timeout: timeoutMs },
+  };
+  let output;
+  try {
+    output = await adapter.ask(askInput);
+  } catch (err) {
+    throw new PersonaTerminalError(
+      "adapter_error",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+  return output.answer;
+}
+
+/**
+ * Propose + confirm a persona per SPEC §5 Phase 2.
+ *
+ * The `choice` field is a pre-resolved user decision — callers wire
+ * interactive prompt UI around this function and pass the resolved
+ * action. This keeps proposePersona deterministic and test-harnessable
+ * without having to mock stdin/stdout.
+ */
+export async function proposePersona(
+  input: ProposePersonaInput,
+  adapter: Adapter,
+): Promise<PersonaProposal> {
+  const notice = input.onNotice ?? (() => undefined);
+
+  // SPEC §11: subscription-auth surface message before first paid call.
+  if (input.subscriptionAuth) {
+    notice(SUBSCRIPTION_AUTH_MESSAGE);
+  }
+
+  const effort: EffortLevel = input.effort ?? "max";
+  const timeoutMs = input.timeoutMs ?? 120_000;
+  const prompt = buildPersonaPrompt({
+    idea: input.idea,
+    explain: input.explain,
+  });
+
+  // First attempt.
+  const rawFirst = await askForPersona(adapter, prompt, effort, timeoutMs);
+  let validated = parsePersonaAnswer(rawFirst);
+
+  // One repair retry if the first attempt failed the schema.
+  if (validated === null) {
+    const repairPrompt = buildRepairPrompt(prompt, rawFirst);
+    const rawSecond = await askForPersona(
+      adapter,
+      repairPrompt,
+      effort,
+      timeoutMs,
+    );
+    validated = parsePersonaAnswer(rawSecond);
+  }
+
+  if (validated === null) {
+    throw new PersonaTerminalError(
+      "schema_violation",
+      "persona did not match schema after one repair retry",
+    );
+  }
+
+  const rationale = validated.rationale;
+
+  // Apply user choice.
+  const applied = applyChoice(validated.persona, rationale, input.choice);
+  return applied;
+}
+
+function applyChoice(
+  proposedPersona: string,
+  rationale: string,
+  choice: PersonaChoice,
+): PersonaProposal {
+  switch (choice.kind) {
+    case "accept": {
+      const skill = extractSkill(proposedPersona);
+      if (skill === null) {
+        throw new PersonaTerminalError(
+          "schema_violation",
+          "proposed persona failed form match post-validation (impossible)",
+        );
+      }
+      return {
+        persona: proposedPersona,
+        skill,
+        rationale,
+        accepted: true,
+      };
+    }
+    case "edit": {
+      if (choice.skill.trim().length === 0) {
+        throw new PersonaChoiceError("edited skill must be non-empty");
+      }
+      if (choice.skill.includes('"')) {
+        throw new PersonaChoiceError(
+          "edited skill must not contain unescaped double quotes",
+        );
+      }
+      const persona = formatPersonaString(choice.skill);
+      return {
+        persona,
+        skill: choice.skill,
+        rationale,
+        accepted: true,
+      };
+    }
+    case "replace": {
+      const m = PERSONA_FORM_RE.exec(choice.persona);
+      if (m === null) {
+        throw new PersonaChoiceError(
+          `replacement persona must match ` +
+            `Veteran "<skill>" expert, got: ${choice.persona}`,
+        );
+      }
+      const skill = m[1] ?? "";
+      return {
+        persona: choice.persona,
+        skill,
+        rationale,
+        accepted: true,
+      };
+    }
+  }
+}

--- a/src/cli/resume.ts
+++ b/src/cli/resume.ts
@@ -1,0 +1,262 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §5 + §7 — `samospec resume [<slug>]`.
+// Phase-based resumption:
+//   - no state.json => exit 1 with remediation.
+//   - round_state === lead_terminal => exit 4 (immutable absorbing
+//     state per SPEC §7).
+//   - persona persisted but interview.json missing => re-enter the
+//     interview phase (re-asks the lead for questions; the caller
+//     is expected to re-answer via the resolver).
+//   - interview.json present AND phase complete => emit the "next
+//     phase: context / draft (not implemented yet)" message and
+//     exit 0 (Issue #15 completes this).
+//
+// Scope guard: no context discovery, no v0.1 draft, no review loop.
+
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import type { Adapter } from "../adapter/types.ts";
+import {
+  LockContendedError,
+  acquireLock,
+  releaseLock,
+  type LockHandle,
+} from "../state/lock.ts";
+import { advancePhase } from "../state/phase.ts";
+import { writeState } from "../state/store.ts";
+import type { State } from "../state/types.ts";
+import { PERSONA_FORM_RE, formatPersonaString } from "./persona.ts";
+import {
+  InterviewTerminalError,
+  readInterview,
+  runInterview,
+} from "./interview.ts";
+import { inspectSpec, specPaths, type ChoiceResolvers } from "./new.ts";
+
+const DEFAULT_MAX_WALL_CLOCK_MIN = 240;
+
+export interface RunResumeInput {
+  readonly cwd: string;
+  readonly slug: string;
+  readonly now: string;
+  readonly resolvers: ChoiceResolvers;
+  readonly pid?: number;
+  readonly maxWallClockMinutes?: number;
+  readonly explain?: boolean;
+}
+
+export interface RunResumeResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export async function runResume(
+  input: RunResumeInput,
+  adapter: Adapter,
+): Promise<RunResumeResult> {
+  const lines: string[] = [];
+  const errors: string[] = [];
+  const notice = (line: string): void => {
+    lines.push(line);
+  };
+
+  const paths = specPaths(input.cwd, input.slug);
+
+  if (!existsSync(paths.statePath)) {
+    errors.push(
+      `samospec: no spec found for slug '${input.slug}'. ` +
+        `Run \`samospec new ${input.slug}\` to start one.`,
+    );
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `${errors.join("\n")}\n`,
+    };
+  }
+
+  const inspected = inspectSpec(input.cwd, input.slug);
+  const state = inspected.state;
+  if (state === null) {
+    // readState threw upstream of inspectSpec would have surfaced —
+    // reaching here means the file existed but parsed to null (which
+    // readState does not do; safeguard only).
+    errors.push(
+      `samospec: state.json for '${input.slug}' is missing or invalid.`,
+    );
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `${errors.join("\n")}\n`,
+    };
+  }
+
+  // lead_terminal is absorbing (SPEC §7). Exit 4 with context.
+  if (state.round_state === "lead_terminal") {
+    errors.push(
+      `samospec: spec '${input.slug}' is at lead_terminal. ` +
+        `Edit .samospec/spec/${input.slug}/ manually or rerun with --force.`,
+    );
+    return {
+      exitCode: 4,
+      stdout: "",
+      stderr: `${errors.join("\n")}\n`,
+    };
+  }
+
+  // Acquire the repo lock for the resume window.
+  let handle: LockHandle;
+  try {
+    handle = acquireLock({
+      lockPath: paths.lockPath,
+      slug: input.slug,
+      now: Date.parse(input.now),
+      maxWallClockMinutes:
+        input.maxWallClockMinutes ?? DEFAULT_MAX_WALL_CLOCK_MIN,
+      pid: input.pid ?? process.pid,
+    });
+  } catch (err) {
+    if (err instanceof LockContendedError) {
+      errors.push(
+        `samospec: another samospec run holds the repo lock (pid ${err.holderPid}). ` +
+          `Wait for it to exit or remove ${err.lockPath} if stale.`,
+      );
+      return {
+        exitCode: 2,
+        stdout: "",
+        stderr: `${errors.join("\n")}\n`,
+      };
+    }
+    throw err;
+  }
+
+  try {
+    // Case A: persona present, interview missing -> re-enter interview.
+    if (
+      state.persona !== null &&
+      state.persona.accepted &&
+      !inspected.hasInterview
+    ) {
+      const personaStr = formatPersonaString(state.persona.skill);
+      if (!PERSONA_FORM_RE.test(personaStr)) {
+        errors.push(
+          `samospec: state.persona.skill is malformed for '${input.slug}'.`,
+        );
+        return {
+          exitCode: 1,
+          stdout: "",
+          stderr: `${errors.join("\n")}\n`,
+        };
+      }
+      notice(`resuming interview for '${input.slug}' (persona: ${personaStr})`);
+
+      let nextState: State = advancePhase(state, "interview", {
+        now: input.now,
+      });
+      // advancePhase only moves forward; interview -> interview is a
+      // no-op pass. If state.phase was already interview, this returns
+      // the same state; otherwise we step once.
+      if (nextState === state && state.phase !== "interview") {
+        // Shouldn't happen; advancePhase throws on illegal moves.
+        nextState = { ...state, phase: "interview", updated_at: input.now };
+      }
+      writeState(paths.statePath, nextState);
+
+      try {
+        await runInterview(
+          {
+            slug: input.slug,
+            persona: personaStr,
+            explain: input.explain ?? false,
+            subscriptionAuth: await isSubscriptionAuth(adapter),
+            onQuestion: input.resolvers.question,
+            onNotice: notice,
+            outputPath: paths.interviewPath,
+            now: input.now,
+          },
+          adapter,
+        );
+      } catch (err) {
+        if (err instanceof InterviewTerminalError) {
+          const terminal: State = {
+            ...nextState,
+            round_state: "lead_terminal",
+            updated_at: input.now,
+          };
+          writeState(paths.statePath, terminal);
+          errors.push(`samospec: lead_terminal at interview — ${err.message}.`);
+          return {
+            exitCode: 4,
+            stdout: lines.join("\n"),
+            stderr: `${errors.join("\n")}\n`,
+          };
+        }
+        errors.push(
+          `samospec: interview interrupted — ${
+            err instanceof Error ? err.message : String(err)
+          }.`,
+        );
+        return {
+          exitCode: 3,
+          stdout: lines.join("\n"),
+          stderr: `${errors.join("\n")}\n`,
+        };
+      }
+
+      notice(
+        `interview complete: written to ${path.basename(paths.interviewPath)}.`,
+      );
+      notice(`TODO #15: next phase — context / draft — not implemented yet.`);
+      return {
+        exitCode: 0,
+        stdout: `${lines.join("\n")}\n`,
+        stderr: "",
+      };
+    }
+
+    // Case B: interview done.
+    if (inspected.hasInterview) {
+      const iv = readInterview(paths.interviewPath);
+      notice(
+        `resume: persona + interview already persisted for '${input.slug}'.`,
+      );
+      if (iv !== null) {
+        notice(
+          `persona: ${iv.persona}; answers recorded: ${String(iv.answers.length)}.`,
+        );
+      }
+      notice(
+        `next phase: context / draft (not implemented yet). See issues #11 / #15.`,
+      );
+      return {
+        exitCode: 0,
+        stdout: `${lines.join("\n")}\n`,
+        stderr: "",
+      };
+    }
+
+    // Case C: persona not yet written. Tell the caller to re-run new.
+    errors.push(
+      `samospec: spec '${input.slug}' has no persona yet. ` +
+        `Re-run \`samospec new ${input.slug}\` to start over.`,
+    );
+    return {
+      exitCode: 1,
+      stdout: lines.join("\n"),
+      stderr: `${errors.join("\n")}\n`,
+    };
+  } finally {
+    releaseLock(handle);
+  }
+}
+
+async function isSubscriptionAuth(adapter: Adapter): Promise<boolean> {
+  try {
+    const auth = await adapter.auth_status();
+    return auth.subscription_auth === true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/cli/interview.test.ts
+++ b/tests/cli/interview.test.ts
@@ -1,0 +1,402 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Tests for `samospec new` Phase 4 — 5-question strategic interview
+// (SPEC §5 Phase 4).
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+} from "../../src/adapter/types.ts";
+import {
+  INTERVIEW_MAX_QUESTIONS,
+  INTERVIEW_ESCAPE_HATCHES,
+  InterviewFileSchema,
+  readInterview,
+  runInterview,
+  writeInterview,
+} from "../../src/cli/interview.ts";
+
+function askOutputWithAnswer(answer: string): AskOutput {
+  return { answer, usage: null, effort_used: "max" };
+}
+
+interface ScriptedAskAdapter extends Adapter {
+  readonly asks: readonly AskInput[];
+}
+
+function makeScriptedAskAdapter(
+  answers: readonly string[],
+): ScriptedAskAdapter {
+  const base = createFakeAdapter();
+  const asks: AskInput[] = [];
+  let call = 0;
+  const scripted: Adapter = {
+    ...base,
+    ask: (input: AskInput): Promise<AskOutput> => {
+      asks.push(input);
+      const answer = answers[call] ?? answers[answers.length - 1] ?? "";
+      call += 1;
+      return Promise.resolve(askOutputWithAnswer(answer));
+    },
+  };
+  const result = Object.assign(scripted, { asks }) as ScriptedAskAdapter;
+  return result;
+}
+
+// A deterministic autoresponder: resolves every question to the first
+// listed option (or "decide for me" if none provided). Captures the
+// questions for assertions.
+function autoAnswerFirst(): {
+  answer: (q: {
+    readonly id: string;
+    readonly text: string;
+    readonly options: readonly string[];
+  }) => Promise<{ readonly choice: string; readonly custom?: string }>;
+  saw: { id: string; text: string }[];
+} {
+  const saw: { id: string; text: string }[] = [];
+  return {
+    saw,
+    answer: async (q) => {
+      saw.push({ id: q.id, text: q.text });
+      const first = q.options[0] ?? "decide for me";
+      await Promise.resolve();
+      return { choice: first };
+    },
+  };
+}
+
+function makeQuestionsJson(
+  items: readonly { readonly id: string; readonly text: string }[],
+): string {
+  return JSON.stringify({
+    questions: items.map((it) => ({
+      id: it.id,
+      text: it.text,
+      options: [`option A for ${it.id}`, `option B for ${it.id}`],
+    })),
+  });
+}
+
+// ---------- escape hatches / constants ----------
+
+describe("interview constants (SPEC §5 Phase 4)", () => {
+  test("INTERVIEW_MAX_QUESTIONS is 5", () => {
+    expect(INTERVIEW_MAX_QUESTIONS).toBe(5);
+  });
+
+  test("INTERVIEW_ESCAPE_HATCHES contains exactly the three universal options", () => {
+    expect(INTERVIEW_ESCAPE_HATCHES).toEqual([
+      "decide for me",
+      "not sure — defer",
+      "custom",
+    ]);
+  });
+});
+
+// ---------- hard cap 5 ----------
+
+describe("runInterview — hard cap at 5 (SPEC §5 Phase 4)", () => {
+  test("lead returns 7 questions -> only first 5 are asked, extras dropped", async () => {
+    const sevenQs = Array.from({ length: 7 }, (_, i) => ({
+      id: `q${String(i + 1)}`,
+      text: `question ${String(i + 1)}?`,
+    }));
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(sevenQs)]);
+    const auto = autoAnswerFirst();
+
+    const answers = await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        onQuestion: auto.answer,
+      },
+      adapter,
+    );
+
+    expect(auto.saw.length).toBe(5);
+    expect(answers.answers.length).toBe(5);
+    expect(auto.saw.map((s) => s.id)).toEqual(["q1", "q2", "q3", "q4", "q5"]);
+  });
+
+  test("lead returns 3 questions -> proceeds with 3", async () => {
+    const threeQs = Array.from({ length: 3 }, (_, i) => ({
+      id: `q${String(i + 1)}`,
+      text: `question ${String(i + 1)}?`,
+    }));
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(threeQs)]);
+    const auto = autoAnswerFirst();
+    const answers = await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        onQuestion: auto.answer,
+      },
+      adapter,
+    );
+    expect(answers.answers.length).toBe(3);
+  });
+
+  test("lead returns 0 questions -> empty interview result", async () => {
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson([])]);
+    const auto = autoAnswerFirst();
+    const answers = await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        onQuestion: auto.answer,
+      },
+      adapter,
+    );
+    expect(answers.answers.length).toBe(0);
+  });
+});
+
+// ---------- escape hatches ----------
+
+describe("runInterview — escape hatches always present (SPEC §5 Phase 4)", () => {
+  test("each question's options includes `decide for me`, `not sure — defer`, `custom`", async () => {
+    const qs = Array.from({ length: 3 }, (_, i) => ({
+      id: `q${String(i + 1)}`,
+      text: `question ${String(i + 1)}?`,
+    }));
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
+    const seenOptions: readonly string[][] = [];
+    await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        onQuestion: (q) => {
+          (seenOptions as string[][]).push([...q.options]);
+          return Promise.resolve({ choice: "decide for me" });
+        },
+      },
+      adapter,
+    );
+    for (const opts of seenOptions) {
+      expect(opts).toContain("decide for me");
+      expect(opts).toContain("not sure — defer");
+      expect(opts).toContain("custom");
+    }
+  });
+
+  test("choice = custom + custom text is captured into the answer record", async () => {
+    const qs = [{ id: "q1", text: "what framework?" }];
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
+    const out = await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        onQuestion: (_q) =>
+          Promise.resolve({ choice: "custom", custom: "Bun + TypeScript" }),
+      },
+      adapter,
+    );
+    expect(out.answers.length).toBe(1);
+    const a = out.answers[0]!;
+    expect(a.choice).toBe("custom");
+    expect(a.custom).toBe("Bun + TypeScript");
+  });
+
+  test("choice = decide for me is persisted verbatim", async () => {
+    const qs = [{ id: "q1", text: "which database?" }];
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
+    const out = await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        onQuestion: (_q) => Promise.resolve({ choice: "decide for me" }),
+      },
+      adapter,
+    );
+    expect(out.answers.length).toBe(1);
+    expect(out.answers[0]!.choice).toBe("decide for me");
+  });
+
+  test("choice = not sure — defer is persisted verbatim", async () => {
+    const qs = [{ id: "q1", text: "target platform?" }];
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
+    const out = await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        onQuestion: (_q) => Promise.resolve({ choice: "not sure — defer" }),
+      },
+      adapter,
+    );
+    expect(out.answers[0]!.choice).toBe("not sure — defer");
+  });
+});
+
+// ---------- persona + explain wiring ----------
+
+describe("runInterview — persona + explain wiring (SPEC §7)", () => {
+  test("system prompt contains the persona string", async () => {
+    const qs = [{ id: "q1", text: "something?" }];
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
+    await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI software engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        onQuestion: (_q) => Promise.resolve({ choice: "decide for me" }),
+      },
+      adapter,
+    );
+    const first = adapter.asks[0]!;
+    expect(first.prompt).toContain('Veteran "CLI software engineer" expert');
+  });
+
+  test("explain=true adds a plain-English preamble to the prompt", async () => {
+    const qs = [{ id: "q1", text: "something?" }];
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
+    await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: true,
+        subscriptionAuth: false,
+        onQuestion: (_q) => Promise.resolve({ choice: "decide for me" }),
+      },
+      adapter,
+    );
+    const first = adapter.asks[0]!;
+    expect(first.prompt.toLowerCase()).toMatch(
+      /plain english|plain-english|non-technical|everyday/,
+    );
+  });
+});
+
+// ---------- interview.json schema + round-trip ----------
+
+describe("interview.json schema (SPEC §5 Phase 4)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(tmpdir(), "samospec-interview-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("round-trip: write -> read -> validate", () => {
+    const file = path.join(tmp, "interview.json");
+    const payload = InterviewFileSchema.parse({
+      slug: "demo",
+      persona: 'Veteran "CLI engineer" expert',
+      generated_at: "2026-04-19T10:00:00Z",
+      questions: [
+        {
+          id: "q1",
+          text: "What framework?",
+          options: [
+            "Bun + TypeScript",
+            "Node + TS",
+            "decide for me",
+            "not sure — defer",
+            "custom",
+          ],
+        },
+      ],
+      answers: [{ id: "q1", choice: "custom", custom: "Deno + TS" }],
+    });
+    writeInterview(file, payload);
+    const raw = readFileSync(file, "utf8");
+    expect(raw).toContain("Deno + TS");
+    const reloaded = readInterview(file);
+    expect(reloaded).not.toBeNull();
+    expect(reloaded!.answers[0]!.custom).toBe("Deno + TS");
+    expect(reloaded!.persona).toBe('Veteran "CLI engineer" expert');
+    expect(reloaded!.questions[0]!.options).toContain("decide for me");
+  });
+
+  test("invalid JSON structure is rejected", () => {
+    expect(() =>
+      InterviewFileSchema.parse({
+        slug: "demo",
+        persona: "not canonical form",
+        generated_at: "2026-04-19T10:00:00Z",
+        questions: [],
+        answers: [],
+      }),
+    ).toThrow();
+  });
+
+  test("writeInterview refuses to write a malformed payload", () => {
+    const file = path.join(tmp, "interview.json");
+    expect(() =>
+      // Deliberate type assertion to bypass TS: runtime validation must catch.
+      writeInterview(file, {
+        slug: "",
+        persona: 'Veteran "CLI engineer" expert',
+        generated_at: "bad",
+        questions: [],
+        answers: [],
+      } as unknown as Parameters<typeof writeInterview>[1]),
+    ).toThrow();
+  });
+});
+
+// ---------- runInterview writes interview.json when a path is given ----------
+
+describe("runInterview — interview.json write", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(tmpdir(), "samospec-interview-run-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("writes a validated interview.json at the given path", async () => {
+    const qs = [
+      { id: "q1", text: "what framework?" },
+      { id: "q2", text: "what db?" },
+    ];
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
+    const file = path.join(tmp, "interview.json");
+    const out = await runInterview(
+      {
+        slug: "demo",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        outputPath: file,
+        now: "2026-04-19T10:00:00Z",
+        onQuestion: (q) => {
+          if (q.id === "q1")
+            return Promise.resolve({ choice: "custom", custom: "Bun" });
+          return Promise.resolve({ choice: "decide for me" });
+        },
+      },
+      adapter,
+    );
+    expect(out.answers.length).toBe(2);
+    const reloaded = readInterview(file);
+    expect(reloaded).not.toBeNull();
+    expect(reloaded!.answers[0]!.custom).toBe("Bun");
+  });
+});

--- a/tests/cli/interview.test.ts
+++ b/tests/cli/interview.test.ts
@@ -9,11 +9,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
-import type {
-  Adapter,
-  AskInput,
-  AskOutput,
-} from "../../src/adapter/types.ts";
+import type { Adapter, AskInput, AskOutput } from "../../src/adapter/types.ts";
 import {
   INTERVIEW_MAX_QUESTIONS,
   INTERVIEW_ESCAPE_HATCHES,
@@ -210,7 +206,7 @@ describe("runInterview — escape hatches always present (SPEC §5 Phase 4)", ()
       adapter,
     );
     expect(out.answers.length).toBe(1);
-    const a = out.answers[0]!;
+    const a = out.answers[0];
     expect(a.choice).toBe("custom");
     expect(a.custom).toBe("Bun + TypeScript");
   });
@@ -229,7 +225,7 @@ describe("runInterview — escape hatches always present (SPEC §5 Phase 4)", ()
       adapter,
     );
     expect(out.answers.length).toBe(1);
-    expect(out.answers[0]!.choice).toBe("decide for me");
+    expect(out.answers[0].choice).toBe("decide for me");
   });
 
   test("choice = not sure — defer is persisted verbatim", async () => {
@@ -245,7 +241,7 @@ describe("runInterview — escape hatches always present (SPEC §5 Phase 4)", ()
       },
       adapter,
     );
-    expect(out.answers[0]!.choice).toBe("not sure — defer");
+    expect(out.answers[0].choice).toBe("not sure — defer");
   });
 });
 
@@ -265,7 +261,7 @@ describe("runInterview — persona + explain wiring (SPEC §7)", () => {
       },
       adapter,
     );
-    const first = adapter.asks[0]!;
+    const first = adapter.asks[0];
     expect(first.prompt).toContain('Veteran "CLI software engineer" expert');
   });
 
@@ -282,7 +278,7 @@ describe("runInterview — persona + explain wiring (SPEC §7)", () => {
       },
       adapter,
     );
-    const first = adapter.asks[0]!;
+    const first = adapter.asks[0];
     expect(first.prompt.toLowerCase()).toMatch(
       /plain english|plain-english|non-technical|everyday/,
     );
@@ -327,9 +323,9 @@ describe("interview.json schema (SPEC §5 Phase 4)", () => {
     expect(raw).toContain("Deno + TS");
     const reloaded = readInterview(file);
     expect(reloaded).not.toBeNull();
-    expect(reloaded!.answers[0]!.custom).toBe("Deno + TS");
+    expect(reloaded!.answers[0].custom).toBe("Deno + TS");
     expect(reloaded!.persona).toBe('Veteran "CLI engineer" expert');
-    expect(reloaded!.questions[0]!.options).toContain("decide for me");
+    expect(reloaded!.questions[0].options).toContain("decide for me");
   });
 
   test("invalid JSON structure is rejected", () => {
@@ -397,6 +393,6 @@ describe("runInterview — interview.json write", () => {
     expect(out.answers.length).toBe(2);
     const reloaded = readInterview(file);
     expect(reloaded).not.toBeNull();
-    expect(reloaded!.answers[0]!.custom).toBe("Bun");
+    expect(reloaded!.answers[0].custom).toBe("Bun");
   });
 });

--- a/tests/cli/new.test.ts
+++ b/tests/cli/new.test.ts
@@ -1,0 +1,383 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Tests for `samospec new <slug>` (SPEC §5 Phases 1-4 skeleton +
+// §7 state persistence + §11 subscription-auth + §10 exit codes).
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  AuthStatus,
+} from "../../src/adapter/types.ts";
+import { readInterview } from "../../src/cli/interview.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+import { readState } from "../../src/state/store.ts";
+import { runInit } from "../../src/cli/init.ts";
+
+function askOut(answer: string): AskOutput {
+  return { answer, usage: null, effort_used: "max" };
+}
+
+function makeLeadAdapter(
+  answers: readonly string[],
+  authOverride?: AuthStatus,
+): { adapter: Adapter; asks: AskInput[] } {
+  const base = createFakeAdapter(
+    authOverride !== undefined ? { auth: authOverride } : {},
+  );
+  const asks: AskInput[] = [];
+  let call = 0;
+  const adapter: Adapter = {
+    ...base,
+    ask: (input: AskInput): Promise<AskOutput> => {
+      asks.push(input);
+      const a = answers[call] ?? answers[answers.length - 1] ?? "";
+      call += 1;
+      return Promise.resolve(askOut(a));
+    },
+  };
+  return { adapter, asks };
+}
+
+const personaJson = (skill: string): string =>
+  JSON.stringify({
+    persona: `Veteran "${skill}" expert`,
+    rationale: "pragmatic choice",
+  });
+
+const questionsJson = (
+  items: readonly { id: string; text: string }[],
+): string =>
+  JSON.stringify({
+    questions: items.map((q) => ({
+      id: q.id,
+      text: q.text,
+      options: ["opt A", "opt B"],
+    })),
+  });
+
+function acceptResolver(): ChoiceResolvers {
+  return {
+    persona: () => Promise.resolve({ kind: "accept" }),
+    question: (_q) => Promise.resolve({ choice: "decide for me" }),
+  };
+}
+
+// ---------- sandbox ----------
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-new-"));
+  // A fresh .samospec/ is a precondition (SPEC §5 Phase 1).
+  runInit({ cwd: tmp });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+// ---------- happy path ----------
+
+describe("samospec new <slug> — happy path (SPEC §5 Phases 1-4)", () => {
+  test("writes state.json + interview.json and exits 0", async () => {
+    const { adapter } = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([
+        { id: "q1", text: "framework?" },
+        { id: "q2", text: "db?" },
+      ]),
+    ]);
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "a CLI for turning ideas into specs",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+      },
+      adapter,
+    );
+    expect(result.exitCode).toBe(0);
+
+    const slugDir = path.join(tmp, ".samospec", "spec", "demo");
+    expect(existsSync(slugDir)).toBe(true);
+    expect(existsSync(path.join(slugDir, "state.json"))).toBe(true);
+    expect(existsSync(path.join(slugDir, "interview.json"))).toBe(true);
+
+    const st = readState(path.join(slugDir, "state.json"));
+    expect(st).not.toBeNull();
+    expect(st!.slug).toBe("demo");
+    expect(st!.persona).toEqual({
+      skill: "CLI engineer",
+      accepted: true,
+    });
+    // Phase should have advanced through persona -> context -> interview.
+    // Post-interview, scope guard says next phase is `draft` (not
+    // implemented yet). The CLI wiring leaves phase at `interview` with
+    // state persisted; resume decides the next-step messaging.
+    expect(st!.phase).toBe("interview");
+
+    const iv = readInterview(path.join(slugDir, "interview.json"));
+    expect(iv).not.toBeNull();
+    expect(iv!.slug).toBe("demo");
+    expect(iv!.persona).toBe('Veteran "CLI engineer" expert');
+    expect(iv!.answers.length).toBe(2);
+  });
+
+  test("stdout announces TODO markers for context/preflight/draft phases", async () => {
+    const { adapter } = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([{ id: "q1", text: "framework?" }]),
+    ]);
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+      },
+      adapter,
+    );
+    // TODO markers surfaced per the issue scope — don't block execution.
+    expect(result.stdout.toLowerCase()).toMatch(/context discovery/);
+    expect(result.stdout.toLowerCase()).toMatch(/preflight/);
+    expect(result.stdout.toLowerCase()).toMatch(/draft/);
+  });
+});
+
+// ---------- subscription-auth copy ----------
+
+describe("samospec new — subscription-auth UX message (SPEC §11)", () => {
+  test("subscription_auth=true => SPEC §11 copy printed BEFORE first lead call", async () => {
+    const { adapter } = makeLeadAdapter(
+      [
+        personaJson("CLI engineer"),
+        questionsJson([{ id: "q1", text: "framework?" }]),
+      ],
+      {
+        authenticated: true,
+        subscription_auth: true,
+      },
+    );
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+      },
+      adapter,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("subscription-auth mode");
+    expect(result.stdout).toContain("wall-clock/iteration caps");
+  });
+
+  test("subscription_auth=false => message suppressed", async () => {
+    const { adapter } = makeLeadAdapter(
+      [
+        personaJson("CLI engineer"),
+        questionsJson([{ id: "q1", text: "framework?" }]),
+      ],
+      {
+        authenticated: true,
+        subscription_auth: false,
+      },
+    );
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+      },
+      adapter,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain("subscription-auth mode");
+  });
+});
+
+// ---------- --explain flag ----------
+
+describe("samospec new --explain (SPEC §4 secondary ICP)", () => {
+  test("explain=true reaches the persona AND interview prompts", async () => {
+    const { adapter, asks } = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([{ id: "q1", text: "framework?" }]),
+    ]);
+    await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: true,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+      },
+      adapter,
+    );
+    // First call (persona) + second call (interview) both carry the
+    // plain-English preamble.
+    expect(asks.length).toBeGreaterThanOrEqual(2);
+    expect(asks[0]!.prompt.toLowerCase()).toMatch(/plain english/);
+    expect(asks[1]!.prompt.toLowerCase()).toMatch(/plain english/);
+  });
+});
+
+// ---------- lead_terminal / exit 4 ----------
+
+describe("samospec new — lead_terminal path (SPEC §10 exit codes)", () => {
+  test("persona lead_terminal => exit 4 + state.round_state = lead_terminal", async () => {
+    // Two malformed persona responses in a row => PersonaTerminalError.
+    const { adapter } = makeLeadAdapter([
+      JSON.stringify({ persona: "no quotes here", rationale: "" }),
+      JSON.stringify({ persona: "still bad", rationale: "" }),
+    ]);
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+      },
+      adapter,
+    );
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr.toLowerCase()).toMatch(/lead_terminal|persona/);
+
+    const st = readState(path.join(tmp, ".samospec", "spec", "demo", "state.json"));
+    expect(st).not.toBeNull();
+    expect(st!.round_state).toBe("lead_terminal");
+  });
+});
+
+// ---------- slug collision ----------
+
+describe("samospec new — slug collision (SPEC §10)", () => {
+  test("existing .samospec/spec/<slug>/ => exit 1 suggesting resume", async () => {
+    mkdirSync(path.join(tmp, ".samospec", "spec", "demo"), {
+      recursive: true,
+    });
+    const { adapter } = makeLeadAdapter([personaJson("CLI engineer")]);
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+      },
+      adapter,
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toLowerCase()).toMatch(/resume|already exists/);
+  });
+});
+
+// ---------- lock contention ----------
+
+describe("samospec new — repo lock (SPEC §7 lockfile)", () => {
+  test("pre-existing live lock => exit 2", async () => {
+    const lockPath = path.join(tmp, ".samospec", ".lock");
+    const fakeLock = {
+      pid: process.pid,
+      started_at: "2026-04-19T10:00:00Z",
+      slug: "other",
+    };
+    // Write a lock that points at our own pid (so isPidAlive=true).
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+    writeFileSync(lockPath, JSON.stringify(fakeLock), "utf8");
+    const { adapter } = makeLeadAdapter([personaJson("CLI engineer")]);
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+        // Force a different pid so the lock is "someone else's".
+        pid: process.pid + 1,
+      },
+      adapter,
+    );
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toLowerCase()).toMatch(/lock|concurrent|another/);
+  });
+});
+
+// ---------- state.json has slug branch not yet created ----------
+
+describe("samospec new — branch creation guarded by flag (scope guard)", () => {
+  test("default createBranch=false => does NOT invoke git checkout", async () => {
+    const { adapter } = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([{ id: "q1", text: "framework?" }]),
+    ]);
+    let invoked = 0;
+    await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+        createBranch: () => {
+          invoked += 1;
+          return "samospec/demo";
+        },
+      },
+      adapter,
+    );
+    expect(invoked).toBe(0);
+  });
+
+  test("opt-in createBranch=true => stub is invoked exactly once", async () => {
+    const { adapter } = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([{ id: "q1", text: "framework?" }]),
+    ]);
+    let invoked = 0;
+    await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+        enableBranchCreation: true,
+        createBranch: () => {
+          invoked += 1;
+          return "samospec/demo";
+        },
+      },
+      adapter,
+    );
+    expect(invoked).toBe(1);
+  });
+});
+

--- a/tests/cli/new.test.ts
+++ b/tests/cli/new.test.ts
@@ -238,8 +238,8 @@ describe("samospec new --explain (SPEC §4 secondary ICP)", () => {
     // First call (persona) + second call (interview) both carry the
     // plain-English preamble.
     expect(asks.length).toBeGreaterThanOrEqual(2);
-    expect(asks[0]!.prompt.toLowerCase()).toMatch(/plain english/);
-    expect(asks[1]!.prompt.toLowerCase()).toMatch(/plain english/);
+    expect(asks[0].prompt.toLowerCase()).toMatch(/plain english/);
+    expect(asks[1].prompt.toLowerCase()).toMatch(/plain english/);
   });
 });
 
@@ -266,7 +266,9 @@ describe("samospec new — lead_terminal path (SPEC §10 exit codes)", () => {
     expect(result.exitCode).toBe(4);
     expect(result.stderr.toLowerCase()).toMatch(/lead_terminal|persona/);
 
-    const st = readState(path.join(tmp, ".samospec", "spec", "demo", "state.json"));
+    const st = readState(
+      path.join(tmp, ".samospec", "spec", "demo", "state.json"),
+    );
     expect(st).not.toBeNull();
     expect(st!.round_state).toBe("lead_terminal");
   });
@@ -380,4 +382,3 @@ describe("samospec new — branch creation guarded by flag (scope guard)", () =>
     expect(invoked).toBe(1);
   });
 });
-

--- a/tests/cli/persona.test.ts
+++ b/tests/cli/persona.test.ts
@@ -55,7 +55,7 @@ function makeScriptedAskAdapter(
 // ---------- persona form regex ----------
 
 describe("persona form regex (SPEC §5 Phase 2)", () => {
-  test("accepts canonical `Veteran \"<skill>\" expert`", () => {
+  test('accepts canonical `Veteran "<skill>" expert`', () => {
     expect(PERSONA_FORM_RE.test('Veteran "CLI software engineer" expert')).toBe(
       true,
     );
@@ -109,12 +109,15 @@ describe("proposePersona — happy path", () => {
           "The idea is a command-line tool; this persona covers design and UX.",
       }),
     ]);
-    const result = await proposePersona({
-      idea: "a CLI for turning ideas into specs",
-      explain: false,
-      subscriptionAuth: false,
-      choice: { kind: "accept" },
-    }, adapter);
+    const result = await proposePersona(
+      {
+        idea: "a CLI for turning ideas into specs",
+        explain: false,
+        subscriptionAuth: false,
+        choice: { kind: "accept" },
+      },
+      adapter,
+    );
 
     expect(result.persona).toBe('Veteran "CLI software engineer" expert');
     expect(result.rationale.length).toBeGreaterThan(0);
@@ -129,15 +132,18 @@ describe("proposePersona — happy path", () => {
         rationale: "ok",
       }),
     ]);
-    await proposePersona({
-      idea: "some idea",
-      explain: false,
-      subscriptionAuth: false,
-      choice: { kind: "accept" },
-    }, adapter);
+    await proposePersona(
+      {
+        idea: "some idea",
+        explain: false,
+        subscriptionAuth: false,
+        choice: { kind: "accept" },
+      },
+      adapter,
+    );
 
     expect(adapter.asks.length).toBeGreaterThan(0);
-    const first = adapter.asks[0]!;
+    const first = adapter.asks[0];
     expect(first.prompt).toContain("Veteran");
     expect(first.prompt).toContain("expert");
     expect(first.opts.effort).toBe("max");
@@ -154,12 +160,15 @@ describe("proposePersona — confirm / edit / replace", () => {
         rationale: "reasoning",
       }),
     ]);
-    const result = await proposePersona({
-      idea: "idea",
-      explain: false,
-      subscriptionAuth: false,
-      choice: { kind: "edit", skill: "distributed systems engineer" },
-    }, adapter);
+    const result = await proposePersona(
+      {
+        idea: "idea",
+        explain: false,
+        subscriptionAuth: false,
+        choice: { kind: "edit", skill: "distributed systems engineer" },
+      },
+      adapter,
+    );
     expect(result.skill).toBe("distributed systems engineer");
     expect(result.persona).toBe(
       'Veteran "distributed systems engineer" expert',
@@ -174,15 +183,18 @@ describe("proposePersona — confirm / edit / replace", () => {
         rationale: "reasoning",
       }),
     ]);
-    const result = await proposePersona({
-      idea: "idea",
-      explain: false,
-      subscriptionAuth: false,
-      choice: {
-        kind: "replace",
-        persona: 'Veteran "staff-level platform engineer" expert',
+    const result = await proposePersona(
+      {
+        idea: "idea",
+        explain: false,
+        subscriptionAuth: false,
+        choice: {
+          kind: "replace",
+          persona: 'Veteran "staff-level platform engineer" expert',
+        },
       },
-    }, adapter);
+      adapter,
+    );
     expect(result.persona).toBe(
       'Veteran "staff-level platform engineer" expert',
     );
@@ -197,8 +209,9 @@ describe("proposePersona — confirm / edit / replace", () => {
         rationale: "reasoning",
       }),
     ]);
-    await expect(
-      proposePersona(
+    let caught: unknown = null;
+    try {
+      await proposePersona(
         {
           idea: "idea",
           explain: false,
@@ -206,8 +219,12 @@ describe("proposePersona — confirm / edit / replace", () => {
           choice: { kind: "replace", persona: "CLI engineer" },
         },
         adapter,
-      ),
-    ).rejects.toBeDefined();
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught).toBeInstanceOf(Error);
   });
 });
 
@@ -227,12 +244,15 @@ describe("proposePersona — schema repair + lead_terminal", () => {
         rationale: "r2",
       }),
     ]);
-    const result = await proposePersona({
-      idea: "idea",
-      explain: false,
-      subscriptionAuth: false,
-      choice: { kind: "accept" },
-    }, adapter);
+    const result = await proposePersona(
+      {
+        idea: "idea",
+        explain: false,
+        subscriptionAuth: false,
+        choice: { kind: "accept" },
+      },
+      adapter,
+    );
     expect(result.persona).toBe('Veteran "CLI software engineer" expert');
     // Exactly one repair attempt was made (so 2 total ask calls).
     expect(adapter.asks.length).toBe(2);
@@ -243,8 +263,9 @@ describe("proposePersona — schema repair + lead_terminal", () => {
       JSON.stringify({ persona: "nope", rationale: "bad" }),
       JSON.stringify({ persona: "still bad", rationale: "worse" }),
     ]);
-    await expect(
-      proposePersona(
+    let caught: unknown = null;
+    try {
+      await proposePersona(
         {
           idea: "idea",
           explain: false,
@@ -252,8 +273,12 @@ describe("proposePersona — schema repair + lead_terminal", () => {
           choice: { kind: "accept" },
         },
         adapter,
-      ),
-    ).rejects.toThrow(/lead_terminal|schema|persona/i);
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/lead_terminal|schema|persona/i);
   });
 
   test("non-JSON response => throws PersonaTerminalError", async () => {
@@ -261,8 +286,9 @@ describe("proposePersona — schema repair + lead_terminal", () => {
       "this is not JSON at all",
       "still not JSON",
     ]);
-    await expect(
-      proposePersona(
+    let caught: unknown = null;
+    try {
+      await proposePersona(
         {
           idea: "idea",
           explain: false,
@@ -270,8 +296,12 @@ describe("proposePersona — schema repair + lead_terminal", () => {
           choice: { kind: "accept" },
         },
         adapter,
-      ),
-    ).rejects.toThrow(/lead_terminal|schema|persona/i);
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/lead_terminal|schema|persona/i);
   });
 });
 
@@ -341,7 +371,7 @@ describe("proposePersona — --explain flag (SPEC §4 secondary ICP)", () => {
       },
       adapter,
     );
-    const first = adapter.asks[0]!;
+    const first = adapter.asks[0];
     expect(first.prompt.toLowerCase()).toMatch(
       /plain english|plain-english|non-technical|everyday/,
     );
@@ -363,7 +393,7 @@ describe("proposePersona — --explain flag (SPEC §4 secondary ICP)", () => {
       },
       adapter,
     );
-    const first = adapter.asks[0]!;
+    const first = adapter.asks[0];
     expect(first.prompt.toLowerCase()).not.toMatch(
       /plain english preamble|non-technical/,
     );
@@ -388,6 +418,6 @@ describe("proposePersona — lead effort policy (SPEC §11)", () => {
       effort: "high" as EffortLevel,
     };
     await proposePersona(opts, adapter);
-    expect(adapter.asks[0]!.opts.effort).toBe("high");
+    expect(adapter.asks[0].opts.effort).toBe("high");
   });
 });

--- a/tests/cli/persona.test.ts
+++ b/tests/cli/persona.test.ts
@@ -1,0 +1,393 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Tests for `samospec new` Phase 2 — persona proposal (SPEC §5 Phase 2,
+// §7 lead adapter persona wiring, §11 subscription-auth UX copy).
+
+import { describe, expect, test } from "bun:test";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  AuthStatus,
+  EffortLevel,
+} from "../../src/adapter/types.ts";
+import {
+  PERSONA_FORM_RE,
+  SUBSCRIPTION_AUTH_MESSAGE,
+  proposePersona,
+  formatPersonaString,
+} from "../../src/cli/persona.ts";
+
+function askOutputWithAnswer(answer: string): AskOutput {
+  return { answer, usage: null, effort_used: "max" };
+}
+
+interface ScriptedAskAdapter extends Adapter {
+  readonly asks: readonly AskInput[];
+}
+
+function makeScriptedAskAdapter(
+  answers: readonly string[],
+  overrides: Partial<{
+    auth: AuthStatus;
+  }> = {},
+): ScriptedAskAdapter {
+  const base = createFakeAdapter(
+    overrides.auth !== undefined ? { auth: overrides.auth } : {},
+  );
+  const asks: AskInput[] = [];
+  let call = 0;
+  const scripted: Adapter = {
+    ...base,
+    ask: (input: AskInput): Promise<AskOutput> => {
+      asks.push(input);
+      const answer = answers[call] ?? answers[answers.length - 1] ?? "";
+      call += 1;
+      return Promise.resolve(askOutputWithAnswer(answer));
+    },
+  };
+  const result = Object.assign(scripted, { asks }) as ScriptedAskAdapter;
+  return result;
+}
+
+// ---------- persona form regex ----------
+
+describe("persona form regex (SPEC §5 Phase 2)", () => {
+  test("accepts canonical `Veteran \"<skill>\" expert`", () => {
+    expect(PERSONA_FORM_RE.test('Veteran "CLI software engineer" expert')).toBe(
+      true,
+    );
+  });
+
+  test("accepts multi-word skills with punctuation", () => {
+    expect(
+      PERSONA_FORM_RE.test(
+        'Veteran "distributed systems / SRE specialist" expert',
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects missing quotes", () => {
+    expect(PERSONA_FORM_RE.test("Veteran CLI software engineer expert")).toBe(
+      false,
+    );
+  });
+
+  test("rejects wrong word order", () => {
+    expect(PERSONA_FORM_RE.test('Expert "CLI software engineer" veteran')).toBe(
+      false,
+    );
+  });
+
+  test("rejects empty skill", () => {
+    expect(PERSONA_FORM_RE.test('Veteran "" expert')).toBe(false);
+  });
+
+  test("rejects trailing garbage", () => {
+    expect(
+      PERSONA_FORM_RE.test('Veteran "CLI engineer" expert and also a sage'),
+    ).toBe(false);
+  });
+
+  test("formatPersonaString wraps the skill correctly", () => {
+    expect(formatPersonaString("CLI software engineer")).toBe(
+      'Veteran "CLI software engineer" expert',
+    );
+  });
+});
+
+// ---------- happy path ----------
+
+describe("proposePersona — happy path", () => {
+  test("returns { persona, rationale } when lead returns canonical form + rationale", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "CLI software engineer" expert',
+        rationale:
+          "The idea is a command-line tool; this persona covers design and UX.",
+      }),
+    ]);
+    const result = await proposePersona({
+      idea: "a CLI for turning ideas into specs",
+      explain: false,
+      subscriptionAuth: false,
+      choice: { kind: "accept" },
+    }, adapter);
+
+    expect(result.persona).toBe('Veteran "CLI software engineer" expert');
+    expect(result.rationale.length).toBeGreaterThan(0);
+    expect(result.accepted).toBe(true);
+    expect(result.skill).toBe("CLI software engineer");
+  });
+
+  test("ask() is invoked with a system prompt mentioning the persona form", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "platform engineer" expert',
+        rationale: "ok",
+      }),
+    ]);
+    await proposePersona({
+      idea: "some idea",
+      explain: false,
+      subscriptionAuth: false,
+      choice: { kind: "accept" },
+    }, adapter);
+
+    expect(adapter.asks.length).toBeGreaterThan(0);
+    const first = adapter.asks[0]!;
+    expect(first.prompt).toContain("Veteran");
+    expect(first.prompt).toContain("expert");
+    expect(first.opts.effort).toBe("max");
+  });
+});
+
+// ---------- confirm / edit / replace ----------
+
+describe("proposePersona — confirm / edit / replace", () => {
+  test("kind: edit overrides the skill and keeps the rationale", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "CLI software engineer" expert',
+        rationale: "reasoning",
+      }),
+    ]);
+    const result = await proposePersona({
+      idea: "idea",
+      explain: false,
+      subscriptionAuth: false,
+      choice: { kind: "edit", skill: "distributed systems engineer" },
+    }, adapter);
+    expect(result.skill).toBe("distributed systems engineer");
+    expect(result.persona).toBe(
+      'Veteran "distributed systems engineer" expert',
+    );
+    expect(result.accepted).toBe(true);
+  });
+
+  test("kind: replace overrides the entire persona string", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "CLI software engineer" expert',
+        rationale: "reasoning",
+      }),
+    ]);
+    const result = await proposePersona({
+      idea: "idea",
+      explain: false,
+      subscriptionAuth: false,
+      choice: {
+        kind: "replace",
+        persona: 'Veteran "staff-level platform engineer" expert',
+      },
+    }, adapter);
+    expect(result.persona).toBe(
+      'Veteran "staff-level platform engineer" expert',
+    );
+    expect(result.skill).toBe("staff-level platform engineer");
+    expect(result.accepted).toBe(true);
+  });
+
+  test("kind: replace rejects an ill-formed persona (throws)", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "CLI software engineer" expert',
+        rationale: "reasoning",
+      }),
+    ]);
+    await expect(
+      proposePersona(
+        {
+          idea: "idea",
+          explain: false,
+          subscriptionAuth: false,
+          choice: { kind: "replace", persona: "CLI engineer" },
+        },
+        adapter,
+      ),
+    ).rejects.toBeDefined();
+  });
+});
+
+// ---------- schema repair + terminal path ----------
+
+describe("proposePersona — schema repair + lead_terminal", () => {
+  test("first response malformed, second response valid: accepts second", async () => {
+    const adapter = makeScriptedAskAdapter([
+      // Malformed: missing quotes around skill.
+      JSON.stringify({
+        persona: "Veteran CLI software engineer expert",
+        rationale: "r",
+      }),
+      // Valid repair.
+      JSON.stringify({
+        persona: 'Veteran "CLI software engineer" expert',
+        rationale: "r2",
+      }),
+    ]);
+    const result = await proposePersona({
+      idea: "idea",
+      explain: false,
+      subscriptionAuth: false,
+      choice: { kind: "accept" },
+    }, adapter);
+    expect(result.persona).toBe('Veteran "CLI software engineer" expert');
+    // Exactly one repair attempt was made (so 2 total ask calls).
+    expect(adapter.asks.length).toBe(2);
+  });
+
+  test("two malformed responses in a row => throws PersonaTerminalError", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({ persona: "nope", rationale: "bad" }),
+      JSON.stringify({ persona: "still bad", rationale: "worse" }),
+    ]);
+    await expect(
+      proposePersona(
+        {
+          idea: "idea",
+          explain: false,
+          subscriptionAuth: false,
+          choice: { kind: "accept" },
+        },
+        adapter,
+      ),
+    ).rejects.toThrow(/lead_terminal|schema|persona/i);
+  });
+
+  test("non-JSON response => throws PersonaTerminalError", async () => {
+    const adapter = makeScriptedAskAdapter([
+      "this is not JSON at all",
+      "still not JSON",
+    ]);
+    await expect(
+      proposePersona(
+        {
+          idea: "idea",
+          explain: false,
+          subscriptionAuth: false,
+          choice: { kind: "accept" },
+        },
+        adapter,
+      ),
+    ).rejects.toThrow(/lead_terminal|schema|persona/i);
+  });
+});
+
+// ---------- subscription-auth copy ----------
+
+describe("proposePersona — subscription-auth UX copy (SPEC §11)", () => {
+  test("subscriptionAuth=true surfaces the explicit message via onNotice callback", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "CLI software engineer" expert',
+        rationale: "r",
+      }),
+    ]);
+    const notices: string[] = [];
+    await proposePersona(
+      {
+        idea: "idea",
+        explain: false,
+        subscriptionAuth: true,
+        choice: { kind: "accept" },
+        onNotice: (n) => notices.push(n),
+      },
+      adapter,
+    );
+    expect(notices.some((n) => n === SUBSCRIPTION_AUTH_MESSAGE)).toBe(true);
+    expect(SUBSCRIPTION_AUTH_MESSAGE).toContain("subscription-auth");
+  });
+
+  test("subscriptionAuth=false suppresses the message", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "CLI software engineer" expert',
+        rationale: "r",
+      }),
+    ]);
+    const notices: string[] = [];
+    await proposePersona(
+      {
+        idea: "idea",
+        explain: false,
+        subscriptionAuth: false,
+        choice: { kind: "accept" },
+        onNotice: (n) => notices.push(n),
+      },
+      adapter,
+    );
+    expect(notices.every((n) => n !== SUBSCRIPTION_AUTH_MESSAGE)).toBe(true);
+  });
+});
+
+// ---------- --explain flag ----------
+
+describe("proposePersona — --explain flag (SPEC §4 secondary ICP)", () => {
+  test("explain=true adds a plain-English preamble to the prompt", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "CLI software engineer" expert',
+        rationale: "r",
+      }),
+    ]);
+    await proposePersona(
+      {
+        idea: "idea",
+        explain: true,
+        subscriptionAuth: false,
+        choice: { kind: "accept" },
+      },
+      adapter,
+    );
+    const first = adapter.asks[0]!;
+    expect(first.prompt.toLowerCase()).toMatch(
+      /plain english|plain-english|non-technical|everyday/,
+    );
+  });
+
+  test("explain=false does NOT include the plain-English preamble", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "CLI software engineer" expert',
+        rationale: "r",
+      }),
+    ]);
+    await proposePersona(
+      {
+        idea: "idea",
+        explain: false,
+        subscriptionAuth: false,
+        choice: { kind: "accept" },
+      },
+      adapter,
+    );
+    const first = adapter.asks[0]!;
+    expect(first.prompt.toLowerCase()).not.toMatch(
+      /plain english preamble|non-technical/,
+    );
+  });
+});
+
+// ---------- effort max policy ----------
+
+describe("proposePersona — lead effort policy (SPEC §11)", () => {
+  test("defaults to effort=max, honors override", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "CLI software engineer" expert',
+        rationale: "r",
+      }),
+    ]);
+    const opts = {
+      idea: "idea",
+      explain: false,
+      subscriptionAuth: false,
+      choice: { kind: "accept" as const },
+      effort: "high" as EffortLevel,
+    };
+    await proposePersona(opts, adapter);
+    expect(adapter.asks[0]!.opts.effort).toBe("high");
+  });
+});

--- a/tests/cli/resume.test.ts
+++ b/tests/cli/resume.test.ts
@@ -12,11 +12,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
-import type {
-  Adapter,
-  AskInput,
-  AskOutput,
-} from "../../src/adapter/types.ts";
+import type { Adapter, AskInput, AskOutput } from "../../src/adapter/types.ts";
 import { runInit } from "../../src/cli/init.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { runResume } from "../../src/cli/resume.ts";
@@ -158,9 +154,7 @@ describe("samospec resume — kill after persona, before interview", () => {
       resumeAdapter,
     );
     expect(second.exitCode).toBe(0);
-    expect(
-      existsSync(path.join(slugDir, "interview.json")),
-    ).toBe(true);
+    expect(existsSync(path.join(slugDir, "interview.json"))).toBe(true);
 
     const iv = readInterview(path.join(slugDir, "interview.json"));
     expect(iv).not.toBeNull();

--- a/tests/cli/resume.test.ts
+++ b/tests/cli/resume.test.ts
@@ -1,0 +1,244 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Tests for `samospec resume [<slug>]` (SPEC §5 / §7).
+// Specific red target (SPEC §13 indirectly): state persistence across
+// kill + resume — persona written, interview unstarted -> resume re-
+// enters interview; interview done -> resume prints "next phase" and
+// exits 0.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+} from "../../src/adapter/types.ts";
+import { runInit } from "../../src/cli/init.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+import { runResume } from "../../src/cli/resume.ts";
+import { readState } from "../../src/state/store.ts";
+import { readInterview } from "../../src/cli/interview.ts";
+
+function askOut(answer: string): AskOutput {
+  return { answer, usage: null, effort_used: "max" };
+}
+
+function makeLeadAdapter(answers: readonly string[]): {
+  adapter: Adapter;
+  asks: AskInput[];
+} {
+  const base = createFakeAdapter();
+  const asks: AskInput[] = [];
+  let call = 0;
+  const adapter: Adapter = {
+    ...base,
+    ask: (input: AskInput): Promise<AskOutput> => {
+      asks.push(input);
+      const a = answers[call] ?? answers[answers.length - 1] ?? "";
+      call += 1;
+      return Promise.resolve(askOut(a));
+    },
+  };
+  return { adapter, asks };
+}
+
+const personaJson = (skill: string): string =>
+  JSON.stringify({
+    persona: `Veteran "${skill}" expert`,
+    rationale: "pragmatic",
+  });
+
+const questionsJson = (
+  items: readonly { id: string; text: string }[],
+): string =>
+  JSON.stringify({
+    questions: items.map((q) => ({
+      id: q.id,
+      text: q.text,
+      options: ["opt A", "opt B"],
+    })),
+  });
+
+function acceptResolver(): ChoiceResolvers {
+  return {
+    persona: () => Promise.resolve({ kind: "accept" }),
+    question: (_q) => Promise.resolve({ choice: "decide for me" }),
+  };
+}
+
+// ---------- sandbox ----------
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-resume-"));
+  runInit({ cwd: tmp });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+// ---------- no spec => exit 1 ----------
+
+describe("samospec resume — error cases", () => {
+  test("no spec directory at all => exit 1 with remediation hint", async () => {
+    const { adapter } = makeLeadAdapter([]);
+    const result = await runResume(
+      {
+        cwd: tmp,
+        slug: "demo",
+        now: "2026-04-19T11:00:00Z",
+        resolvers: acceptResolver(),
+      },
+      adapter,
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toLowerCase()).toMatch(/no spec|not found/);
+  });
+});
+
+// ---------- resume after persona, before interview ----------
+
+describe("samospec resume — kill after persona, before interview", () => {
+  test("resume picks up at the interview phase and completes the run", async () => {
+    // Simulate a run that writes state.json up to the persona phase
+    // and crashes before the interview starts. We reproduce this by
+    // driving runNew to fail at interview time (empty answers array +
+    // onQuestion that throws), then invoking runResume.
+    const { adapter: killAdapter } = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([{ id: "q1", text: "framework?" }]),
+    ]);
+    const killResolvers: ChoiceResolvers = {
+      persona: () => Promise.resolve({ kind: "accept" }),
+      question: (_q) => Promise.reject(new Error("simulated kill")),
+    };
+    const first = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: killResolvers,
+        now: "2026-04-19T10:00:00Z",
+      },
+      killAdapter,
+    );
+    // A kill mid-interview is a non-zero exit (interrupted, exit 3).
+    expect(first.exitCode).not.toBe(0);
+
+    const slugDir = path.join(tmp, ".samospec", "spec", "demo");
+    const st = readState(path.join(slugDir, "state.json"));
+    expect(st).not.toBeNull();
+    expect(st!.persona).not.toBeNull();
+
+    // interview.json should NOT be present yet.
+    expect(existsSync(path.join(slugDir, "interview.json"))).toBe(false);
+
+    // Now resume with a working question-answerer.
+    const { adapter: resumeAdapter } = makeLeadAdapter([
+      // The first ask on resume is the interview ask; persona is already
+      // written, so resume skips re-proposing.
+      questionsJson([
+        { id: "q1", text: "framework?" },
+        { id: "q2", text: "db?" },
+      ]),
+    ]);
+    const second = await runResume(
+      {
+        cwd: tmp,
+        slug: "demo",
+        now: "2026-04-19T11:00:00Z",
+        resolvers: acceptResolver(),
+      },
+      resumeAdapter,
+    );
+    expect(second.exitCode).toBe(0);
+    expect(
+      existsSync(path.join(slugDir, "interview.json")),
+    ).toBe(true);
+
+    const iv = readInterview(path.join(slugDir, "interview.json"));
+    expect(iv).not.toBeNull();
+    expect(iv!.answers.length).toBe(2);
+    expect(iv!.persona).toBe('Veteran "CLI engineer" expert');
+  });
+});
+
+// ---------- resume after interview ----------
+
+describe("samospec resume — interview already complete", () => {
+  test("prints next-phase notice and exits 0 (pre-#15)", async () => {
+    // Run a full new; then resume.
+    const { adapter: newAdapter } = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([{ id: "q1", text: "framework?" }]),
+    ]);
+    await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+      },
+      newAdapter,
+    );
+
+    const { adapter: resumeAdapter } = makeLeadAdapter([]);
+    const result = await runResume(
+      {
+        cwd: tmp,
+        slug: "demo",
+        now: "2026-04-19T11:00:00Z",
+        resolvers: acceptResolver(),
+      },
+      resumeAdapter,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toLowerCase()).toMatch(/next phase|not implemented/);
+    expect(result.stdout.toLowerCase()).toMatch(/context|draft/);
+  });
+});
+
+// ---------- resume at lead_terminal ----------
+
+describe("samospec resume — lead_terminal", () => {
+  test("resume at lead_terminal exits 4 and preserves state", async () => {
+    // Drive runNew into lead_terminal via two malformed persona outputs.
+    const { adapter: newAdapter } = makeLeadAdapter([
+      JSON.stringify({ persona: "no quotes", rationale: "" }),
+      JSON.stringify({ persona: "still bad", rationale: "" }),
+    ]);
+    const first = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T10:00:00Z",
+      },
+      newAdapter,
+    );
+    expect(first.exitCode).toBe(4);
+
+    const { adapter: resumeAdapter } = makeLeadAdapter([]);
+    const result = await runResume(
+      {
+        cwd: tmp,
+        slug: "demo",
+        now: "2026-04-19T11:00:00Z",
+        resolvers: acceptResolver(),
+      },
+      resumeAdapter,
+    );
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr.toLowerCase()).toMatch(/lead_terminal/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #13.

- Persona proposal (SPEC §5 Phase 2, §7 lead persona wiring) with canonical `Veteran "<skill>" expert` form, accept / edit-skill / replace-persona flow, one repair retry on schema violation, and `PersonaTerminalError` routed to exit 4 + `round_state: lead_terminal`.
- 5-question strategic interview (SPEC §5 Phase 4) with hard cap at 5 (extras dropped, fewer proceeds with fewer), three universal escape hatches (`decide for me`, `not sure — defer`, `custom`) spliced into every question regardless of what the lead proposes, and a zod-validated `interview.json` round-trip written atomically.
- `samospec new <slug>` and `samospec resume [<slug>]` CLI skeleton wiring lockfile, branch creation (guarded stub for #15), persona, interview, and TODO markers for #11 / #14 / #15.
- Subscription-auth UX copy (SPEC §11) surfaced via `onNotice` before the first paid lead call when `auth_status().subscription_auth === true`.
- `--explain` flag flips a plain-English preamble on both persona and interview prompts (SPEC §4 secondary ICP). Copy-layer only; does not rewrite every output string.

## Acceptance criteria (issue #13)

- [x] `src/cli/persona.ts` exposes `proposePersona(input, adapter)`; `Veteran "<skill>" expert`; accept / edit / replace; persisted to `state.json`; `lead_terminal` on schema fail after one repair.
- [x] `src/cli/interview.ts` exposes `runInterview(input, adapter, persona)`; hard cap 5; escape hatches universal; answers + questions in `interview.json` (zod validation).
- [x] `src/cli/new.ts` skeleton: lockfile, branch stub, persona, interview, TODO markers for #6/#11/#14/#15.
- [x] `samospec new <slug>` exits cleanly after persona + interview, writing `state.json` and `interview.json`.
- [x] `samospec resume [<slug>]` picks up from the recorded phase; prints `next phase: context / draft (not implemented yet)` and exits 0 when interview is done.
- [x] Subscription-auth surface message printed before the first paid lead call; suppressed when `false`.
- [x] `--explain` propagates into persona + interview prompts as a system-prompt preamble toggle only.

## Red-first TDD

Each deliverable landed as a RED commit then a GREEN commit (6 commits total):
- `ae6b8d1` RED persona -> `0efef07` GREEN persona.
- `e227317` RED interview -> `2396aa7` GREEN interview.
- `79c8d6a` RED new+resume -> `29b92dc` GREEN new+resume.

## Testing evidence

### `bun test --coverage`

```
 571 pass
 0 fail
 7125 expect() calls
Ran 571 tests across 37 files.
```

Representative coverage (new code):
- `src/cli/persona.ts` — 100% lines.
- `src/cli/interview.ts` — 85.4% lines.
- `src/cli/new.ts` — 84.3% lines.
- `src/cli/resume.ts` — 65.8% lines (error paths not all hit by tests — exit 2 lock contention on resume is covered; the rare Case C persona-missing branch is a safeguard).

### Scripted `samospec new test-idea` + kill + `samospec resume test-idea`

```
$ samospec init   [exit 0]
samospec: initialized .samospec/ in /tmp/samospec-demo-xxxx
created .samospec/.gitignore
created .samospec/config.json

$ samospec new test-idea   [exit 3]
TODO #15: branch creation deferred (set enableBranchCreation=true to opt in).
TODO #14: preflight cost estimate deferred (no paid lead calls before preflight land).
Claude adapter is in subscription-auth mode. Token cost is not visible; wall-clock/iteration caps enforced instead.
proposed persona: Veteran "CLI software engineer" expert
rationale: Idea is a CLI; this persona covers design and UX.
persona accepted: Veteran "CLI software engineer" expert
TODO #11: context discovery deferred (interview uses idea-only context for now).

STDERR:
samospec: interview interrupted — Ctrl-C (simulated).
State persisted; run `samospec resume test-idea` to continue.

$ samospec resume test-idea   [exit 0]
resuming interview for 'test-idea' (persona: Veteran "CLI software engineer" expert)
interview complete: written to interview.json.
TODO #15: next phase — context / draft — not implemented yet.

$ samospec resume test-idea   [exit 0]
resume: persona + interview already persisted for 'test-idea'.
persona: Veteran "CLI software engineer" expert; answers recorded: 3.
next phase: context / draft (not implemented yet). See issues #11 / #15.
```

Resulting `state.json` post-resume:

```json
{
  "slug": "test-idea",
  "phase": "interview",
  "round_index": 0,
  "version": "0.0.0",
  "persona": { "skill": "CLI software engineer", "accepted": true },
  "push_consent": null,
  "calibration": null,
  "remote_stale": false,
  "coupled_fallback": false,
  "round_state": "planned",
  "exit": null,
  "created_at": "2026-04-19T10:00:00Z",
  "updated_at": "2026-04-19T10:15:00Z"
}
```

Resulting `interview.json`:

```json
{
  "slug": "test-idea",
  "persona": "Veteran \"CLI software engineer\" expert",
  "generated_at": "2026-04-19T10:15:00Z",
  "questions": [
    { "id": "q1", "text": "Primary user persona?", "options": ["solo dev", "team", "decide for me", "not sure — defer", "custom"] },
    { "id": "q2", "text": "Persistence?", "options": ["file", "git", "sqlite", "decide for me", "not sure — defer", "custom"] },
    { "id": "q3", "text": "Distribution?", "options": ["npm", "homebrew", "decide for me", "not sure — defer", "custom"] }
  ],
  "answers": [
    { "id": "q1", "choice": "decide for me" },
    { "id": "q2", "choice": "decide for me" },
    { "id": "q3", "choice": "decide for me" }
  ]
}
```

## Test plan

- [x] `bun test` — 571/571 passing.
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — clean.
- [x] Scripted `samospec new test-idea` against fake adapter: shows subscription-auth copy, persona proposal/accept, interview, TODO markers. State + interview written.
- [x] Scripted kill mid-interview + `samospec resume test-idea`: picks up at interview phase, writes `interview.json`, exits 0.
- [x] Scripted `samospec resume test-idea` after interview done: prints `next phase: context / draft (not implemented yet)` and exits 0.
- [x] `lead_terminal` path: two malformed persona responses -> exit 4, `state.round_state = lead_terminal`.
- [x] Slug collision: pre-existing `.samospec/spec/<slug>/` -> exit 1 with resume/--force hint.
- [x] Lock contention: live lock held by different pid -> exit 2.

## Scope guardrails honored

- NO context discovery (Issue #11 / #15).
- NO preflight cost estimate (Issue #14).
- NO v0.1 draft (Issue #15).
- NO reviewer adapters.
- NO actual branch creation — `enableBranchCreation` flag with a `createBranch` seam so #15 can wire `src/git/branch.ts` without touching these tests.
- Real `ClaudeAdapter` from `src/adapter/claude.ts` is wired into the CLI router; tests inject scripted fake adapters so no network calls happen in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)