### PR TITLE
feat: Sprint 3 #23 — Codex adapter (Reviewer A)

### DIFF
--- a/src/adapter/auth-status.ts
+++ b/src/adapter/auth-status.ts
@@ -11,9 +11,10 @@
 //   - If the adapter is authenticated AND no vendor API-key env var
 //     carries a non-empty value, treat as subscription auth.
 //   - Non-authenticated -> subscription_auth is false (not meaningful).
-//   - Non-Claude vendors (Codex, etc.) do not currently offer
-//     subscription auth; we return false. When a new vendor ships
-//     subscription auth, add its keys here.
+//   - Codex CLI (since Sprint 3 #23) supports ChatGPT-subscription
+//     login in addition to OPENAI_API_KEY. When authenticated without
+//     an API key, the CLI is assumed to be using the subscription
+//     keychain and `subscription_auth=true` is surfaced.
 //
 // The real Claude adapter will layer additional checks in Sprint 2
 // (e.g. probing `claude auth status --json`); this module is the
@@ -28,8 +29,10 @@ export interface DetectSubscriptionAuthInput {
 const API_KEY_ENV_VARS_BY_VENDOR: Readonly<Record<string, readonly string[]>> =
   {
     claude: ["ANTHROPIC_API_KEY"],
-    // Codex / OpenAI: no subscription-auth path exists at time of writing.
-    codex: [],
+    // Codex CLI (as of Sprint 3 #23): supports both OPENAI_API_KEY
+    // (API-key auth) and ChatGPT-subscription login. Mirrors Claude's
+    // Max/Pro escape — CLI is authenticated but cannot report tokens.
+    codex: ["OPENAI_API_KEY"],
   };
 
 export function detectSubscriptionAuth(

--- a/src/adapter/codex.ts
+++ b/src/adapter/codex.ts
@@ -2,21 +2,66 @@
 
 // SPEC §7 + §11: the real Codex adapter (Reviewer A seat).
 //
-// Lifecycle skeleton only. Work calls (ask/critique/revise) and auth
-// probing are added in subsequent red-green commits.
+// - Spawns the `codex` CLI via Bun.spawn using the minimal-env +
+//   non-interactive flag helpers from `./spawn.ts`.
+// - Non-interactive flags: `codex exec ...` subcommand (CODEX_NON_INTERACTIVE_FLAGS
+//   in spawn.ts). `exec` is the installed Codex CLI's headless mode:
+//   it reads the prompt from stdin, does not spawn a TTY, and does not
+//   hang on a permission prompt. `doctor` additionally runs
+//   `codex --version` to verify a TTY-less spawn works.
+// - Minimal env: `HOME`, `PATH`, `TMPDIR`, plus `OPENAI_API_KEY`
+//   when present. Everything else is dropped.
+// - Structured output: stdout captured, passed through
+//   `preParseJson`, then zod-validated. ONE repair retry on schema
+//   violation per call; then terminal.
+// - Timeout: capped retry policy (base → +50% → base → terminal)
+//   via `runWithCappedRetry`.
+// - Persona system prompt on `critique()`: "paranoid security/ops
+//   engineer" with an explicit advisory weighting toward
+//   `missing-risk`, `weak-implementation`, `unnecessary-scope` (SPEC §7
+//   Model roles). Literal wording per issue #23.
+// - Effort mapping per SPEC §11: logical max/high → reasoning_effort
+//   high, medium → medium, low → low, off → minimal. Passed as a
+//   `--reasoning_effort <level>` flag on every work call.
+// - Pinned default model: `gpt-5.1-codex-max`. Fallback chain on
+//   model-unavailable failure: `gpt-5.1-codex-max → gpt-5.1-codex →
+//   terminal` (SPEC §11). Fallback is triggered by a stderr heuristic
+//   on non-zero exit; resolved model is preserved within a call but
+//   not across calls (callers observe via `state.json` at round start).
+// - `usage: null` path honored when CLI output doesn't report it or
+//   under subscription auth.
+// - Subscription-auth heuristic: ChatGPT-login (no OPENAI_API_KEY) →
+//   subscription_auth=true; API-key → false. Matches the Claude
+//   Max/Pro escape in auth-status.ts.
 //
-// Non-interactive flags: `codex exec` subcommand is the installed
-// target's headless mode (see src/adapter/spawn.ts CODEX_NON_INTERACTIVE_FLAGS).
-// Minimal env: HOME, PATH, TMPDIR, OPENAI_API_KEY (when present).
-// Structured output: stdout is captured, passed through the shared
-// pre-parser, then zod-validated.
-// Pinned default model: gpt-5.1-codex-max. Fallback chain:
-// gpt-5.1-codex-max -> gpt-5.1-codex -> terminal (SPEC §11).
+// Tests never shell out to the real `codex`. Work-call tests inject
+// the fake-CLI harness via the `spawn` dependency.
 
 import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-import { spawnCli } from "./spawn.ts";
+import { detectSubscriptionAuth } from "./auth-status.ts";
+import { preParseJson } from "./json-parse.ts";
+import {
+  CODEX_NON_INTERACTIVE_FLAGS,
+  spawnCli,
+  type SpawnCliInput,
+  type SpawnCliResult,
+} from "./spawn.ts";
+import { computeAttemptTimeouts } from "./timeout.ts";
+
+// Internal fail reason covering the Codex fallback sentinel plus the
+// standard failure classes. The adapter-level CodexAdapterError
+// surfaces every case (including `model_unavailable`) directly — the
+// public interface does not lose information.
+interface CodexAttemptFail {
+  readonly ok: false;
+  readonly reason: CodexAdapterErrorReason;
+  readonly detail?: string;
+}
+type CodexAttemptResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | CodexAttemptFail;
 import {
   type Adapter,
   type AskInput,
@@ -29,6 +74,12 @@ import {
   type ModelInfo,
   type ReviseInput,
   type ReviseOutput,
+  AskInputSchema,
+  AskOutputSchema,
+  CritiqueInputSchema,
+  CritiqueOutputSchema,
+  ReviseInputSchema,
+  ReviseOutputSchema,
 } from "./types.ts";
 
 // ---------- constants ----------
@@ -43,6 +94,25 @@ const DEFAULT_MODELS: readonly ModelInfo[] = [
   { id: "gpt-5.1-codex-max", family: "codex" },
   { id: "gpt-5.1-codex", family: "codex" },
 ];
+
+const DEFAULT_MODEL_ID = "gpt-5.1-codex-max";
+
+// SPEC §11 effort-level table (Codex / OpenAI-family column).
+const EFFORT_TO_REASONING: Readonly<Record<EffortLevel, string>> = {
+  max: "high",
+  high: "high",
+  medium: "medium",
+  low: "low",
+  off: "minimal",
+};
+
+// Persona + taxonomy weighting (SPEC §7 Model roles). Literal wording
+// is pinned by test; issue #23 forbids paraphrasing.
+const CODEX_CRITIQUE_PERSONA_PREFIX =
+  "You are a paranoid security/ops engineer reviewing this spec. " +
+  "Focus especially on missing-risk, weak-implementation, and " +
+  "unnecessary-scope. You may surface findings in other categories " +
+  "when warranted, but weight your effort toward these.";
 
 // ---------- adapter options / dependency injection ----------
 
@@ -61,9 +131,16 @@ export interface CodexAdapterOpts {
    */
   readonly spawn?: SpawnFn;
   /**
-   * Models override. Defaults to pinned `gpt-5.1-codex-max` + fallback.
+   * Models override. Defaults to pinned `gpt-5.1-codex-max` +
+   * `gpt-5.1-codex` fallback. Order matters: the first entry is the
+   * preferred model; subsequent entries are the fallback chain.
    */
   readonly models?: readonly ModelInfo[];
+  /**
+   * Default model id. Used as the first entry of the runtime fallback
+   * chain. Default `gpt-5.1-codex-max`.
+   */
+  readonly defaultModel?: string;
 }
 
 // ---------- binary discovery ----------
@@ -116,6 +193,7 @@ export class CodexAdapter implements Adapter {
   private readonly host: Readonly<Record<string, string | undefined>>;
   private readonly spawnFn: SpawnFn;
   private readonly modelList: readonly ModelInfo[];
+  private readonly defaultModel: string;
 
   constructor(opts: CodexAdapterOpts = {}) {
     this.binary = opts.binary ?? CODEX_BINARY_NAME;
@@ -123,6 +201,7 @@ export class CodexAdapter implements Adapter {
       opts.host ?? (process.env as Record<string, string | undefined>);
     this.spawnFn = opts.spawn ?? spawnCli;
     this.modelList = opts.models ?? DEFAULT_MODELS;
+    this.defaultModel = opts.defaultModel ?? DEFAULT_MODEL_ID;
   }
 
   // ---------- lifecycle ----------
@@ -158,10 +237,36 @@ export class CodexAdapter implements Adapter {
     };
   }
 
-  // ---------- auth (stub — expanded in later commit) ----------
+  // ---------- auth ----------
 
   auth_status(): Promise<AuthStatus> {
-    return Promise.resolve({ authenticated: false });
+    const authKey = CODEX_AUTH_ENV_KEYS[0];
+    const apiKey = authKey !== undefined ? this.host[authKey] : undefined;
+    const hasApiKey = typeof apiKey === "string" && apiKey.length > 0;
+
+    // If no binary on PATH, we cannot be authenticated.
+    const resolved = resolveBinaryPath(this.host, this.binary);
+    if (resolved === null) {
+      return Promise.resolve({ authenticated: false });
+    }
+
+    // Deterministic baseline: binary installed implies the CLI is in
+    // one of the two authenticated modes (API key or ChatGPT login).
+    // The real CLI will reject unauthenticated calls at runtime; the
+    // Sprint 3 heuristic mirrors the Claude adapter's env-var approach.
+    const authenticated = true;
+    const subscription_auth = detectSubscriptionAuth({
+      vendor: CODEX_VENDOR,
+      authenticated,
+      env: this.host,
+    });
+    if (hasApiKey) {
+      return Promise.resolve({
+        authenticated,
+        subscription_auth: false,
+      });
+    }
+    return Promise.resolve({ authenticated, subscription_auth });
   }
 
   supports_structured_output(): boolean {
@@ -176,21 +281,442 @@ export class CodexAdapter implements Adapter {
     return Promise.resolve(this.modelList);
   }
 
-  // ---------- work calls (stubs — expanded in later commit) ----------
+  // ---------- work calls ----------
 
-  ask(_input: AskInput): Promise<AskOutput> {
-    return Promise.reject(new Error("CodexAdapter.ask not yet implemented"));
+  async ask(input: AskInput): Promise<AskOutput> {
+    AskInputSchema.parse(input);
+    const prompt = buildAskPrompt(input);
+    const raw = await this.runWithRetries({
+      prompt,
+      timeoutMs: input.opts.timeout,
+      effort: input.opts.effort,
+      structured: true,
+    });
+    const parsed = parseStructuredJson(raw, input.opts.effort);
+    return AskOutputSchema.parse(parsed);
   }
 
-  critique(_input: CritiqueInput): Promise<CritiqueOutput> {
-    return Promise.reject(
-      new Error("CodexAdapter.critique not yet implemented"),
+  async critique(input: CritiqueInput): Promise<CritiqueOutput> {
+    CritiqueInputSchema.parse(input);
+    const prompt = buildCritiquePrompt(input);
+    const raw = await this.runWithRetries({
+      prompt,
+      timeoutMs: input.opts.timeout,
+      effort: input.opts.effort,
+      structured: true,
+    });
+    const parsed = parseStructuredJson(raw, input.opts.effort);
+    return CritiqueOutputSchema.parse(parsed);
+  }
+
+  async revise(input: ReviseInput): Promise<ReviseOutput> {
+    ReviseInputSchema.parse(input);
+    const prompt = buildRevisePrompt(input);
+    const raw = await this.runWithRetries({
+      prompt,
+      timeoutMs: input.opts.timeout,
+      effort: input.opts.effort,
+      structured: true,
+    });
+    const parsed = parseStructuredJson(raw, input.opts.effort);
+    return ReviseOutputSchema.parse(parsed);
+  }
+
+  // ---------- shared spawn + retry ----------
+
+  /**
+   * Run one work-call via the CLI. Enforces:
+   * - capped timeout retry (base → +50% → base → terminal)
+   * - ONE schema-violation repair retry per timeout-attempt
+   * - model fallback chain on "model not available" failure
+   * - non-interactive flags
+   * - minimal env
+   *
+   * Returns the raw stdout string for the caller to JSON-parse.
+   */
+  private async runWithRetries(args: {
+    prompt: string;
+    timeoutMs: number;
+    effort: EffortLevel;
+    structured: boolean;
+  }): Promise<string> {
+    const resolvedBinary =
+      resolveBinaryPath(this.host, this.binary) ?? this.binary;
+
+    // Runtime fallback chain: defaultModel first, then any other models
+    // not equal to the default (preserving list order, de-duped).
+    const chain = buildFallbackChain(this.modelList, this.defaultModel);
+
+    // Capped timeout retry (SPEC §7): base -> +50% -> base, then
+    // terminal. Timeouts are the only retryable class inside this
+    // sweep; `model_unavailable` is consumed by the model-fallback
+    // loop inside runSingleAttempt and bubbles up only when every
+    // model has been exhausted.
+    const timeouts = computeAttemptTimeouts(args.timeoutMs);
+    let lastFail: CodexAttemptFail | null = null;
+    let attemptCount = 0;
+    for (const timeout of timeouts) {
+      attemptCount += 1;
+      const r = await this.runSingleAttempt({
+        binary: resolvedBinary,
+        prompt: args.prompt,
+        timeoutMs: timeout,
+        effort: args.effort,
+        structured: args.structured,
+        models: chain,
+      });
+      if (r.ok) {
+        return r.value;
+      }
+      lastFail = r;
+      if (r.reason !== "timeout") {
+        break;
+      }
+    }
+
+    const fail = lastFail;
+    if (fail === null) {
+      // Only reachable if timeouts is empty, which is impossible.
+      throw new CodexAdapterError({
+        kind: "terminal",
+        reason: "other",
+        detail: "no attempts were run",
+      });
+    }
+
+    const isRetryableClass = fail.reason === "timeout";
+    const attempts = isRetryableClass ? attemptCount : 1;
+    const base: CodexAdapterErrorPayload = {
+      kind: "terminal",
+      reason: fail.reason,
+      attempts,
+    };
+    throw new CodexAdapterError(
+      fail.detail !== undefined ? { ...base, detail: fail.detail } : base,
     );
   }
 
-  revise(_input: ReviseInput): Promise<ReviseOutput> {
-    return Promise.reject(
-      new Error("CodexAdapter.revise not yet implemented"),
+  /**
+   * One timeout-attempt, which itself is a fallback sweep over the
+   * configured model chain. Each model gets up to two spawns — an
+   * initial call plus one schema-repair retry. Model-unavailable on a
+   * given model rolls to the next; other non-timeout errors bail.
+   */
+  private async runSingleAttempt(args: {
+    binary: string;
+    prompt: string;
+    timeoutMs: number;
+    effort: EffortLevel;
+    structured: boolean;
+    models: readonly string[];
+  }): Promise<CodexAttemptResult<string>> {
+    let lastFailure: CodexAttemptFail | null = null;
+
+    for (const model of args.models) {
+      const r = await this.runModelAttempt({
+        binary: args.binary,
+        prompt: args.prompt,
+        timeoutMs: args.timeoutMs,
+        effort: args.effort,
+        structured: args.structured,
+        model,
+      });
+      if (r.ok) {
+        return r;
+      }
+      lastFailure = r;
+      // Only "model_unavailable" rolls forward to the next model.
+      // Timeout / schema / other bail now (upper layer may timeout-retry
+      // under the capped policy).
+      if (r.reason !== "model_unavailable") {
+        return r;
+      }
+    }
+
+    // Every model failed with model_unavailable -> terminal.
+    return (
+      lastFailure ?? {
+        ok: false,
+        reason: "model_unavailable",
+        detail: "no models configured",
+      }
     );
+  }
+
+  private async runModelAttempt(args: {
+    binary: string;
+    prompt: string;
+    timeoutMs: number;
+    effort: EffortLevel;
+    structured: boolean;
+    model: string;
+  }): Promise<CodexAttemptResult<string>> {
+    const first = await this.spawnOnce({
+      binary: args.binary,
+      prompt: args.prompt,
+      timeoutMs: args.timeoutMs,
+      effort: args.effort,
+      model: args.model,
+    });
+
+    if (!first.ok) {
+      if (first.reason === "timeout") {
+        return { ok: false, reason: "timeout" };
+      }
+      return {
+        ok: false,
+        reason: "other",
+        detail: `spawn_error: ${first.detail ?? ""}`,
+      };
+    }
+    if (first.exitCode !== 0) {
+      return classifyExit(first.exitCode, first.stderr);
+    }
+
+    if (!args.structured) {
+      return { ok: true, value: first.stdout };
+    }
+
+    const parsed = preParseJson(first.stdout);
+    if (parsed.ok) {
+      return { ok: true, value: first.stdout };
+    }
+
+    // Structured violation -> ONE repair retry on this model.
+    const repairPrompt = buildRepairPrompt(args.prompt, first.stdout);
+    const repair = await this.spawnOnce({
+      binary: args.binary,
+      prompt: repairPrompt,
+      timeoutMs: args.timeoutMs,
+      effort: args.effort,
+      model: args.model,
+    });
+
+    if (!repair.ok) {
+      if (repair.reason === "timeout") {
+        return { ok: false, reason: "timeout" };
+      }
+      return {
+        ok: false,
+        reason: "other",
+        detail: `spawn_error: ${repair.detail ?? ""}`,
+      };
+    }
+    if (repair.exitCode !== 0) {
+      return classifyExit(repair.exitCode, repair.stderr);
+    }
+
+    const parsedRepair = preParseJson(repair.stdout);
+    if (!parsedRepair.ok) {
+      return {
+        ok: false,
+        reason: "schema_violation",
+        detail: parsedRepair.error.message,
+      };
+    }
+    return { ok: true, value: repair.stdout };
+  }
+
+  private async spawnOnce(args: {
+    binary: string;
+    prompt: string;
+    timeoutMs: number;
+    effort: EffortLevel;
+    model: string;
+  }): Promise<SpawnCliResult> {
+    const reasoning = EFFORT_TO_REASONING[args.effort];
+    const cmd: readonly string[] = [
+      args.binary,
+      ...CODEX_NON_INTERACTIVE_FLAGS,
+      "--model",
+      args.model,
+      "--reasoning_effort",
+      reasoning,
+    ];
+    const input: SpawnCliInput = {
+      cmd,
+      stdin: args.prompt,
+      env: {},
+      timeoutMs: args.timeoutMs,
+      extraAllowedEnvKeys: CODEX_AUTH_ENV_KEYS,
+      host: this.host,
+    };
+    return await this.spawnFn(input);
+  }
+}
+
+// ---------- prompt builders ----------
+
+function buildAskPrompt(input: AskInput): string {
+  const ctx = input.context === "" ? "" : `\n\nContext:\n${input.context}\n`;
+  return (
+    "You are the samospec Reviewer A (Codex). Respond ONLY with a JSON " +
+    'object matching the schema { "answer": string, "usage": null, ' +
+    `"effort_used": "${input.opts.effort}" }. Do not wrap in code ` +
+    "fences." +
+    ctx +
+    `\n\nQuestion:\n${input.prompt}\n`
+  );
+}
+
+function buildCritiquePrompt(input: CritiqueInput): string {
+  // Persona prefix + taxonomy weighting (SPEC §7 Model roles).
+  // Advisory, not a hard filter — reviewer may still surface other
+  // categories.
+  return (
+    `${CODEX_CRITIQUE_PERSONA_PREFIX}\n\n` +
+    "You are the samospec reviewer. Return ONLY a JSON object matching " +
+    'the review-taxonomy schema: { "findings": Array<{ "category": ' +
+    'string, "text": string, "severity": "major"|"minor" }>, "summary":' +
+    ' string, "suggested_next_version": string, "usage": null, ' +
+    `"effort_used": "${input.opts.effort}" }. Do not wrap in code fences.` +
+    `\n\nGuidelines:\n${input.guidelines}\n\nSpec:\n${input.spec}\n`
+  );
+}
+
+function buildRevisePrompt(input: ReviseInput): string {
+  // Reviewer seats rarely call revise(); the method is exposed for
+  // adapter-contract parity with the lead seat.
+  return (
+    "You are the samospec reviewer operating in revise mode. Emit the " +
+    "FULL revised SPEC.md text — not a patch. Return ONLY a JSON " +
+    'object: { "spec": <full text>, "ready": boolean, "rationale": ' +
+    'string, "usage": null, ' +
+    `"effort_used": "${input.opts.effort}" }. Do not wrap in code ` +
+    `fences.\n\nCurrent spec:\n${input.spec}\n\nReviews (JSON):\n` +
+    `${JSON.stringify(input.reviews)}\n\nDecisions so far (JSON):\n` +
+    `${JSON.stringify(input.decisions_history)}\n`
+  );
+}
+
+function buildRepairPrompt(originalPrompt: string, badOutput: string): string {
+  return (
+    "Your previous response was not valid JSON per the required schema." +
+    " Re-emit ONLY the required JSON object. No prose, no code fences. " +
+    "Previous invalid output was:\n" +
+    badOutput +
+    "\n\nRe-attempt the original request:\n" +
+    originalPrompt
+  );
+}
+
+// ---------- fallback chain ----------
+
+function buildFallbackChain(
+  models: readonly ModelInfo[],
+  defaultModel: string,
+): readonly string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  // Default model first (even if absent from modelList for safety).
+  if (!seen.has(defaultModel)) {
+    out.push(defaultModel);
+    seen.add(defaultModel);
+  }
+  for (const m of models) {
+    if (!seen.has(m.id)) {
+      out.push(m.id);
+      seen.add(m.id);
+    }
+  }
+  return out;
+}
+
+// ---------- response parsing ----------
+
+function parseStructuredJson(
+  raw: string,
+  requestedEffort: EffortLevel,
+): unknown {
+  const parsed = preParseJson<Record<string, unknown>>(raw);
+  if (!parsed.ok) {
+    throw new CodexAdapterError({
+      kind: "terminal",
+      reason: "schema_violation",
+      detail: parsed.error.message,
+    });
+  }
+  return normalizeUsageAndEffort(parsed.value, requestedEffort);
+}
+
+function normalizeUsageAndEffort(
+  value: Record<string, unknown>,
+  requestedEffort: EffortLevel,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...value };
+  if (!("usage" in out)) {
+    out["usage"] = null;
+  }
+  if (!("effort_used" in out)) {
+    out["effort_used"] = requestedEffort;
+  }
+  return out;
+}
+
+// ---------- error classification ----------
+
+function classifyExit(
+  exitCode: number,
+  stderr: string,
+): CodexAttemptResult<string> {
+  // Stderr heuristic classification per SPEC §7 failure classes.
+  // "model not available" / "model unavailable" / "model not found" →
+  //   model_unavailable (triggers fallback chain in runSingleAttempt).
+  // Rate-limit / 5xx / network / timeout → retryable (maps to timeout).
+  // Anything else → terminal (auth, quota, refusal).
+  const lower = stderr.toLowerCase();
+  // Model-unavailable heuristic: stderr mentions "model" AND one of
+  // the unavailable phrases. A vendor-name/quote/etc. may appear
+  // between the two tokens, so we test them independently on the
+  // same line rather than as a fixed substring.
+  const mentionsModel = lower.includes("model");
+  const unavailablePhrase =
+    lower.includes("not available") ||
+    lower.includes("unavailable") ||
+    lower.includes("not found") ||
+    lower.includes("does not exist") ||
+    lower.includes("no such model");
+  if (mentionsModel && unavailablePhrase) {
+    return {
+      ok: false,
+      reason: "model_unavailable",
+      detail: `exit ${String(exitCode)}: ${stderr.trim()}`,
+    };
+  }
+  const retryable =
+    lower.includes("rate limit") ||
+    lower.includes("rate-limit") ||
+    lower.includes("network error") ||
+    lower.includes("timeout") ||
+    /\b5\d{2}\b/.test(stderr);
+  return {
+    ok: false,
+    reason: retryable ? "timeout" : "other",
+    detail: `exit ${String(exitCode)}: ${stderr.trim()}`,
+  };
+}
+
+// ---------- error type ----------
+
+export type CodexAdapterErrorReason =
+  | "timeout"
+  | "schema_violation"
+  | "model_unavailable"
+  | "other";
+
+export interface CodexAdapterErrorPayload {
+  readonly kind: "terminal";
+  readonly reason: CodexAdapterErrorReason;
+  readonly detail?: string;
+  readonly attempts?: number;
+}
+
+export class CodexAdapterError extends Error {
+  readonly payload: CodexAdapterErrorPayload;
+  constructor(payload: CodexAdapterErrorPayload) {
+    const detail = payload.detail ?? "";
+    super(`Codex adapter ${payload.reason}: ${detail}`);
+    this.name = "CodexAdapterError";
+    this.payload = payload;
   }
 }

--- a/src/adapter/codex.ts
+++ b/src/adapter/codex.ts
@@ -1,0 +1,196 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §7 + §11: the real Codex adapter (Reviewer A seat).
+//
+// Lifecycle skeleton only. Work calls (ask/critique/revise) and auth
+// probing are added in subsequent red-green commits.
+//
+// Non-interactive flags: `codex exec` subcommand is the installed
+// target's headless mode (see src/adapter/spawn.ts CODEX_NON_INTERACTIVE_FLAGS).
+// Minimal env: HOME, PATH, TMPDIR, OPENAI_API_KEY (when present).
+// Structured output: stdout is captured, passed through the shared
+// pre-parser, then zod-validated.
+// Pinned default model: gpt-5.1-codex-max. Fallback chain:
+// gpt-5.1-codex-max -> gpt-5.1-codex -> terminal (SPEC §11).
+
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { spawnCli } from "./spawn.ts";
+import {
+  type Adapter,
+  type AskInput,
+  type AskOutput,
+  type AuthStatus,
+  type CritiqueInput,
+  type CritiqueOutput,
+  type DetectResult,
+  type EffortLevel,
+  type ModelInfo,
+  type ReviseInput,
+  type ReviseOutput,
+} from "./types.ts";
+
+// ---------- constants ----------
+
+const CODEX_VENDOR = "codex";
+const CODEX_BINARY_NAME = "codex";
+const CODEX_AUTH_ENV_KEYS: readonly string[] = ["OPENAI_API_KEY"];
+
+// SPEC §11 pinned model + fallback chain. First entry is the default;
+// subsequent entries form the ordered fallback chain.
+const DEFAULT_MODELS: readonly ModelInfo[] = [
+  { id: "gpt-5.1-codex-max", family: "codex" },
+  { id: "gpt-5.1-codex", family: "codex" },
+];
+
+// ---------- adapter options / dependency injection ----------
+
+export type SpawnFn = typeof spawnCli;
+
+export interface CodexAdapterOpts {
+  /** Binary name (or absolute path) to exec. Default: "codex". */
+  readonly binary?: string;
+  /**
+   * Host env snapshot for env derivation and PATH-based binary resolution.
+   * Defaults to process.env. Tests inject a deterministic map.
+   */
+  readonly host?: Readonly<Record<string, string | undefined>>;
+  /**
+   * spawnCli replacement for tests. Defaults to `./spawn.ts` spawnCli.
+   */
+  readonly spawn?: SpawnFn;
+  /**
+   * Models override. Defaults to pinned `gpt-5.1-codex-max` + fallback.
+   */
+  readonly models?: readonly ModelInfo[];
+}
+
+// ---------- binary discovery ----------
+
+function resolveBinaryPath(
+  host: Readonly<Record<string, string | undefined>>,
+  binary: string,
+): string | null {
+  if (binary.includes("/")) {
+    return existsSync(binary) ? binary : null;
+  }
+  const pathVar = host["PATH"];
+  if (typeof pathVar !== "string" || pathVar.length === 0) {
+    return null;
+  }
+  for (const segment of pathVar.split(":")) {
+    if (segment === "") continue;
+    const candidate = join(segment, binary);
+    try {
+      if (existsSync(candidate)) {
+        const st = statSync(candidate);
+        if (st.isFile()) {
+          return candidate;
+        }
+      }
+    } catch {
+      // permission denied etc.; keep looking
+    }
+  }
+  return null;
+}
+
+function parseVersionOutput(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed === "") return "unknown";
+  const semverMatch = /\d+\.\d+(?:\.\d+)?/.exec(trimmed);
+  if (semverMatch !== null) {
+    return semverMatch[0];
+  }
+  const firstLine = trimmed.split("\n")[0];
+  return firstLine ?? "unknown";
+}
+
+// ---------- CodexAdapter ----------
+
+export class CodexAdapter implements Adapter {
+  readonly vendor: string = CODEX_VENDOR;
+
+  private readonly binary: string;
+  private readonly host: Readonly<Record<string, string | undefined>>;
+  private readonly spawnFn: SpawnFn;
+  private readonly modelList: readonly ModelInfo[];
+
+  constructor(opts: CodexAdapterOpts = {}) {
+    this.binary = opts.binary ?? CODEX_BINARY_NAME;
+    this.host =
+      opts.host ?? (process.env as Record<string, string | undefined>);
+    this.spawnFn = opts.spawn ?? spawnCli;
+    this.modelList = opts.models ?? DEFAULT_MODELS;
+  }
+
+  // ---------- lifecycle ----------
+
+  detect(): Promise<DetectResult> {
+    const resolved = resolveBinaryPath(this.host, this.binary);
+    if (resolved === null) {
+      return Promise.resolve({ installed: false });
+    }
+    return this.probeVersion(resolved);
+  }
+
+  private async probeVersion(resolvedPath: string): Promise<DetectResult> {
+    const r = await this.spawnFn({
+      cmd: [resolvedPath, "--version"],
+      stdin: "",
+      env: {},
+      timeoutMs: 5_000,
+      extraAllowedEnvKeys: CODEX_AUTH_ENV_KEYS,
+      host: this.host,
+    });
+    if (!r.ok || r.exitCode !== 0) {
+      return {
+        installed: true,
+        version: "unknown",
+        path: resolvedPath,
+      };
+    }
+    return {
+      installed: true,
+      version: parseVersionOutput(r.stdout),
+      path: resolvedPath,
+    };
+  }
+
+  // ---------- auth (stub — expanded in later commit) ----------
+
+  auth_status(): Promise<AuthStatus> {
+    return Promise.resolve({ authenticated: false });
+  }
+
+  supports_structured_output(): boolean {
+    return true;
+  }
+
+  supports_effort(_level: EffortLevel): boolean {
+    return true;
+  }
+
+  models(): Promise<readonly ModelInfo[]> {
+    return Promise.resolve(this.modelList);
+  }
+
+  // ---------- work calls (stubs — expanded in later commit) ----------
+
+  ask(_input: AskInput): Promise<AskOutput> {
+    return Promise.reject(new Error("CodexAdapter.ask not yet implemented"));
+  }
+
+  critique(_input: CritiqueInput): Promise<CritiqueOutput> {
+    return Promise.reject(
+      new Error("CodexAdapter.critique not yet implemented"),
+    );
+  }
+
+  revise(_input: ReviseInput): Promise<ReviseOutput> {
+    return Promise.reject(
+      new Error("CodexAdapter.revise not yet implemented"),
+    );
+  }
+}

--- a/tests/adapter/auth-status.test.ts
+++ b/tests/adapter/auth-status.test.ts
@@ -32,14 +32,25 @@ describe("detectSubscriptionAuth (SPEC §11 escape)", () => {
     expect(r).toBe(false);
   });
 
-  test("codex + authenticated + no OPENAI_API_KEY -> NOT subscription auth", () => {
-    // Codex does not currently support subscription auth; only Claude does.
+  test("codex + authenticated + OPENAI_API_KEY set -> NOT subscription auth", () => {
+    const r = detectSubscriptionAuth({
+      vendor: "codex",
+      authenticated: true,
+      env: { OPENAI_API_KEY: "sk-..." },
+    });
+    expect(r).toBe(false);
+  });
+
+  test("codex + authenticated + no OPENAI_API_KEY -> subscription auth (ChatGPT login)", () => {
+    // As of Sprint 3 (#23), Codex CLI supports ChatGPT-subscription auth
+    // in addition to the API-key path. With no API-key env var and an
+    // authenticated CLI, treat as subscription auth (usage: null path).
     const r = detectSubscriptionAuth({
       vendor: "codex",
       authenticated: true,
       env: {},
     });
-    expect(r).toBe(false);
+    expect(r).toBe(true);
   });
 
   test("claude + authenticated + ANTHROPIC_API_KEY empty string -> subscription auth", () => {

--- a/tests/adapter/codex.contract.test.ts
+++ b/tests/adapter/codex.contract.test.ts
@@ -22,7 +22,8 @@ const FAKE_CLI = new URL("../fixtures/fake-cli.ts", import.meta.url).pathname;
 const BUN_DIR = dirname(process.execPath);
 
 function codexFixture(name: string): string {
-  return new URL(`../fixtures/codex-fixtures/${name}`, import.meta.url).pathname;
+  return new URL(`../fixtures/codex-fixtures/${name}`, import.meta.url)
+    .pathname;
 }
 
 const TMP: string[] = [];
@@ -61,7 +62,9 @@ function makeHost(): Record<string, string | undefined> {
 function makeDelegator(
   fixture: string,
 ): (i: SpawnCliInput) => Promise<SpawnCliResult> {
-  const stateDir = mkdtempSync(join(tmpdir(), "samospec-codex-contract-state-"));
+  const stateDir = mkdtempSync(
+    join(tmpdir(), "samospec-codex-contract-state-"),
+  );
   TMP.push(stateDir);
   const stateFile = join(stateDir, "state.json");
   writeFileSync(stateFile, JSON.stringify({ call: 0 }));

--- a/tests/adapter/codex.contract.test.ts
+++ b/tests/adapter/codex.contract.test.ts
@@ -1,0 +1,111 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Drives CodexAdapter through the shared contract helper
+// (SPEC §13 test 4). The adapter is wired to the fake-CLI harness
+// via an injected spawn. Fixtures live under
+// tests/fixtures/codex-fixtures/.
+
+import { afterAll, describe, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { CodexAdapter } from "../../src/adapter/codex.ts";
+import { runAdapterContract } from "../../src/adapter/contract-test.ts";
+import {
+  spawnCli,
+  type SpawnCliInput,
+  type SpawnCliResult,
+} from "../../src/adapter/spawn.ts";
+
+const FAKE_CLI = new URL("../fixtures/fake-cli.ts", import.meta.url).pathname;
+const BUN_DIR = dirname(process.execPath);
+
+function codexFixture(name: string): string {
+  return new URL(`../fixtures/codex-fixtures/${name}`, import.meta.url).pathname;
+}
+
+const TMP: string[] = [];
+
+afterAll(() => {
+  for (const d of TMP) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+});
+
+function makeHost(): Record<string, string | undefined> {
+  const stateDir = mkdtempSync(join(tmpdir(), "samospec-codex-contract-"));
+  TMP.push(stateDir);
+  const binDir = mkdtempSync(join(tmpdir(), "samospec-codex-contract-bin-"));
+  TMP.push(binDir);
+  const binPath = join(binDir, "codex");
+  writeFileSync(binPath, "#!/usr/bin/env bash\necho 0.41.0\n");
+  Bun.spawnSync(["chmod", "+x", binPath]);
+  return {
+    PATH: `${BUN_DIR}:${binDir}`,
+    HOME: stateDir,
+    TMPDIR: stateDir,
+  };
+}
+
+/**
+ * Spawn delegator that forwards work-call spawns to the fake-CLI
+ * harness, keyed by a per-adapter state file so response branches
+ * advance. Detect (--version) spawns are satisfied inline so they
+ * don't consume a branch.
+ */
+function makeDelegator(
+  fixture: string,
+): (i: SpawnCliInput) => Promise<SpawnCliResult> {
+  const stateDir = mkdtempSync(join(tmpdir(), "samospec-codex-contract-state-"));
+  TMP.push(stateDir);
+  const stateFile = join(stateDir, "state.json");
+  writeFileSync(stateFile, JSON.stringify({ call: 0 }));
+
+  return async (input: SpawnCliInput): Promise<SpawnCliResult> => {
+    // Intercept --version probes so they don't consume a branch.
+    if (input.cmd.includes("--version")) {
+      return {
+        ok: true,
+        exitCode: 0,
+        stdout: "codex-cli 0.41.0\n",
+        stderr: "",
+      };
+    }
+    const env: Record<string, string | undefined> = {
+      ...input.env,
+      FAKE_CLI_FIXTURE: fixture,
+      FAKE_CLI_STATE_FILE: stateFile,
+    };
+    const rewritten: SpawnCliInput = {
+      cmd: ["bun", "run", FAKE_CLI],
+      stdin: input.stdin,
+      env,
+      timeoutMs: input.timeoutMs,
+      extraAllowedEnvKeys: [
+        ...(input.extraAllowedEnvKeys ?? []),
+        "FAKE_CLI_FIXTURE",
+        "FAKE_CLI_STATE_FILE",
+      ],
+      ...(input.host !== undefined ? { host: input.host } : {}),
+    };
+    return await spawnCli(rewritten);
+  };
+}
+
+describe("CodexAdapter — shared contract (SPEC §13 test 4)", () => {
+  test("passes the full contract suite via fake-CLI trio fixture", async () => {
+    await runAdapterContract({
+      name: "codex",
+      makeAdapter: () =>
+        new CodexAdapter({
+          host: makeHost(),
+          spawn: makeDelegator(codexFixture("contract-trio.json")),
+        }),
+    });
+  });
+});

--- a/tests/adapter/codex.effort.test.ts
+++ b/tests/adapter/codex.effort.test.ts
@@ -1,0 +1,166 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Effort mapping + fallback chain ordering tests (SPEC §11).
+// These assertions complement the contract suite: they lock down the
+// exact reasoning_effort value emitted per logical EffortLevel and the
+// order in which the adapter walks the pinned fallback chain.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { CodexAdapter } from "../../src/adapter/codex.ts";
+import {
+  type AskInput,
+  type EffortLevel,
+  type ModelInfo,
+} from "../../src/adapter/types.ts";
+import {
+  type SpawnCliInput,
+  type SpawnCliResult,
+} from "../../src/adapter/spawn.ts";
+
+const TMP: string[] = [];
+
+function makeFakeBinaryDir(): { dir: string; binary: string } {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-codex-effort-"));
+  TMP.push(dir);
+  const binary = join(dir, "codex");
+  writeFileSync(binary, "#!/usr/bin/env bash\necho 0.41.0\n");
+  chmodSync(binary, 0o755);
+  return { dir, binary };
+}
+
+afterAll(() => {
+  for (const d of TMP) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+});
+
+interface SpyCall {
+  readonly cmd: readonly string[];
+}
+interface Spy {
+  readonly spawn: (input: SpawnCliInput) => Promise<SpawnCliResult>;
+  readonly calls: SpyCall[];
+}
+
+function scriptedSpy(responses: readonly SpawnCliResult[]): Spy {
+  const calls: SpyCall[] = [];
+  const spawn = (input: SpawnCliInput): Promise<SpawnCliResult> => {
+    calls.push({ cmd: [...input.cmd] });
+    const r = responses[calls.length - 1] ?? responses[responses.length - 1]!;
+    return Promise.resolve(r);
+  };
+  return { spawn, calls };
+}
+
+const HAPPY: SpawnCliResult = {
+  ok: true,
+  exitCode: 0,
+  stdout: '{"answer":"ok","usage":null,"effort_used":"high"}',
+  stderr: "",
+};
+
+function sampleAskWithEffort(level: EffortLevel): AskInput {
+  return {
+    prompt: "ping",
+    context: "",
+    opts: { effort: level, timeout: 120_000 },
+  };
+}
+
+describe("CodexAdapter effort-level mapping (SPEC §11 table)", () => {
+  const cases: ReadonlyArray<[EffortLevel, string]> = [
+    ["max", "high"],
+    ["high", "high"],
+    ["medium", "medium"],
+    ["low", "low"],
+    ["off", "minimal"],
+  ];
+
+  for (const [level, expected] of cases) {
+    test(`logical '${level}' -> reasoning_effort '${expected}'`, async () => {
+      const spy = scriptedSpy([HAPPY]);
+      const { dir } = makeFakeBinaryDir();
+      const adapter = new CodexAdapter({
+        host: { PATH: dir, HOME: "/tmp" },
+        spawn: spy.spawn,
+      });
+      await adapter.ask(sampleAskWithEffort(level));
+
+      // The work-call includes the model id plus the reasoning-effort
+      // value, positional-paired after `--reasoning_effort`.
+      const work = spy.calls[0];
+      expect(work).toBeDefined();
+      if (work === undefined) return;
+      const idx = work.cmd.findIndex((c) => c === "--reasoning_effort");
+      expect(idx).toBeGreaterThan(-1);
+      expect(work.cmd[idx + 1]).toBe(expected);
+    });
+  }
+});
+
+describe("CodexAdapter fallback-chain ordering (SPEC §11)", () => {
+  test("default chain is gpt-5.1-codex-max first, gpt-5.1-codex second", async () => {
+    // Rejecting every attempt with model-not-available forces the
+    // adapter to walk the chain; the spawn cmds capture the order.
+    const reject: SpawnCliResult = {
+      ok: true,
+      exitCode: 2,
+      stdout: "",
+      stderr: "error: model is not available for this account\n",
+    };
+    const spy = scriptedSpy([reject, reject]);
+    const { dir } = makeFakeBinaryDir();
+    const adapter = new CodexAdapter({
+      host: { PATH: dir, HOME: "/tmp" },
+      spawn: spy.spawn,
+    });
+
+    await adapter.ask(sampleAskWithEffort("high")).catch(() => {
+      /* expected terminal */
+    });
+
+    expect(spy.calls.length).toBe(2);
+    const first = spy.calls[0]?.cmd ?? [];
+    const second = spy.calls[1]?.cmd ?? [];
+    expect(first).toContain("gpt-5.1-codex-max");
+    expect(second).toContain("gpt-5.1-codex");
+    expect(second).not.toContain("gpt-5.1-codex-max");
+  });
+
+  test("custom model list is respected in order, default still leads", async () => {
+    const reject: SpawnCliResult = {
+      ok: true,
+      exitCode: 2,
+      stdout: "",
+      stderr: "error: model is not available for this account\n",
+    };
+    const custom: readonly ModelInfo[] = [
+      { id: "custom-a", family: "codex" },
+      { id: "custom-b", family: "codex" },
+    ];
+    const spy = scriptedSpy([reject, reject, reject]);
+    const { dir } = makeFakeBinaryDir();
+    const adapter = new CodexAdapter({
+      host: { PATH: dir, HOME: "/tmp" },
+      spawn: spy.spawn,
+      models: custom,
+      defaultModel: "custom-a",
+    });
+
+    await adapter.ask(sampleAskWithEffort("high")).catch(() => {
+      /* expected terminal */
+    });
+
+    expect(spy.calls.length).toBe(2);
+    expect(spy.calls[0]?.cmd).toContain("custom-a");
+    expect(spy.calls[1]?.cmd).toContain("custom-b");
+  });
+});

--- a/tests/adapter/codex.effort.test.ts
+++ b/tests/adapter/codex.effort.test.ts
@@ -54,7 +54,7 @@ function scriptedSpy(responses: readonly SpawnCliResult[]): Spy {
   const calls: SpyCall[] = [];
   const spawn = (input: SpawnCliInput): Promise<SpawnCliResult> => {
     calls.push({ cmd: [...input.cmd] });
-    const r = responses[calls.length - 1] ?? responses[responses.length - 1]!;
+    const r = responses[calls.length - 1] ?? responses[responses.length - 1];
     return Promise.resolve(r);
   };
   return { spawn, calls };
@@ -76,7 +76,7 @@ function sampleAskWithEffort(level: EffortLevel): AskInput {
 }
 
 describe("CodexAdapter effort-level mapping (SPEC §11 table)", () => {
-  const cases: ReadonlyArray<[EffortLevel, string]> = [
+  const cases: readonly [EffortLevel, string][] = [
     ["max", "high"],
     ["high", "high"],
     ["medium", "medium"],

--- a/tests/adapter/codex.test.ts
+++ b/tests/adapter/codex.test.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Lifecycle tests for the Codex adapter (SPEC §7, §11, §13 test 4).
+// Mirrors tests/adapter/claude.test.ts but for the `codex` CLI and the
+// Reviewer A seat.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { CodexAdapter } from "../../src/adapter/codex.ts";
+
+const TMP_DIRS: string[] = [];
+
+function makeEmptyPathDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-codex-empty-path-"));
+  TMP_DIRS.push(dir);
+  return dir;
+}
+
+function makeFakeBinaryDir(
+  name: string,
+  script: string,
+): { dir: string; binary: string } {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-codex-fake-bin-"));
+  TMP_DIRS.push(dir);
+  const binary = join(dir, name);
+  writeFileSync(binary, `#!/usr/bin/env bash\n${script}\n`);
+  chmodSync(binary, 0o755);
+  return { dir, binary };
+}
+
+afterAll(() => {
+  for (const d of TMP_DIRS) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+});
+
+describe("CodexAdapter — lifecycle (SPEC §7, §11)", () => {
+  test("vendor is 'codex'", () => {
+    const adapter = new CodexAdapter();
+    expect(adapter.vendor).toBe("codex");
+  });
+
+  test("detect() returns { installed: false } when PATH has no codex binary", async () => {
+    const emptyDir = makeEmptyPathDir();
+    const adapter = new CodexAdapter({
+      host: { PATH: emptyDir, HOME: "/tmp" },
+    });
+    const result = await adapter.detect();
+    expect(result.installed).toBe(false);
+  });
+
+  test("detect() returns { installed: true, version, path } when codex binary exists", async () => {
+    const { dir, binary } = makeFakeBinaryDir(
+      "codex",
+      'echo "codex-cli 0.41.0"',
+    );
+    const adapter = new CodexAdapter({
+      host: { PATH: `${dir}:/bin:/usr/bin`, HOME: "/tmp" },
+    });
+    const result = await adapter.detect();
+    expect(result.installed).toBe(true);
+    if (result.installed) {
+      expect(result.version).toBe("0.41.0");
+      expect(result.path).toBe(binary);
+    }
+  });
+
+  test("supports_structured_output() returns true", () => {
+    const adapter = new CodexAdapter();
+    expect(adapter.supports_structured_output()).toBe(true);
+  });
+
+  test("supports_effort() returns true for every effort level", () => {
+    const adapter = new CodexAdapter();
+    for (const level of ["max", "high", "medium", "low", "off"] as const) {
+      expect(adapter.supports_effort(level)).toBe(true);
+    }
+  });
+
+  test("models() returns pinned default gpt-5.1-codex-max + gpt-5.1-codex fallback; family 'codex'", async () => {
+    const adapter = new CodexAdapter();
+    const models = await adapter.models();
+    expect(models.length).toBeGreaterThanOrEqual(2);
+    const ids = models.map((m) => m.id);
+    expect(ids).toContain("gpt-5.1-codex-max");
+    expect(ids).toContain("gpt-5.1-codex");
+    // Pinned default must be first in the chain.
+    expect(ids[0]).toBe("gpt-5.1-codex-max");
+    for (const m of models) {
+      expect(m.family).toBe("codex");
+    }
+  });
+});

--- a/tests/adapter/codex.work.test.ts
+++ b/tests/adapter/codex.work.test.ts
@@ -47,7 +47,8 @@ const BUN_DIR = dirname(process.execPath);
 const FAKE_CLI = new URL("../fixtures/fake-cli.ts", import.meta.url).pathname;
 
 function codexFixture(name: string): string {
-  return new URL(`../fixtures/codex-fixtures/${name}`, import.meta.url).pathname;
+  return new URL(`../fixtures/codex-fixtures/${name}`, import.meta.url)
+    .pathname;
 }
 
 const TMP: string[] = [];

--- a/tests/adapter/codex.work.test.ts
+++ b/tests/adapter/codex.work.test.ts
@@ -1,0 +1,675 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Work-call tests for the Codex adapter (Reviewer A seat). Mirrors
+// tests/adapter/claude.work.test.ts but for the `codex` CLI and the
+// security/ops persona (SPEC §7 Model roles, §11).
+//
+// Covers:
+// - auth_status: subscription_auth detection both branches
+//   (OPENAI_API_KEY present -> false, absent -> true)
+// - spawn-spy: non-interactive flags (`exec`) passed on every work call
+// - spawn-spy: minimal env — only HOME, PATH, TMPDIR, OPENAI_API_KEY
+//   forwarded; no host secret leaks
+// - spawn-spy: pinned model `gpt-5.1-codex-max` passed on first attempt
+// - spawn-spy: reasoning-effort flag matches the logical effort per
+//   SPEC §11 effort-level table
+// - critique(): persona system prompt + taxonomy weighting literal
+//   wording present in the stdin prompt
+// - schema-violation repair: one retry, then terminal
+// - usage: null default when CLI omits it
+// - revise() returns { ready, rationale }
+// - capped timeout retry (base -> +50% -> base -> terminal)
+// - exit-code classification (rate-limit retries, auth terminal)
+// - Markdown-code-fence stripping end-to-end
+// - Model fallback chain: first model refused -> second model tried
+//
+// Fixtures live under tests/fixtures/codex-fixtures/.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { CodexAdapter, CodexAdapterError } from "../../src/adapter/codex.ts";
+import {
+  type AskInput,
+  type CritiqueInput,
+  type EffortLevel,
+  type ReviseInput,
+} from "../../src/adapter/types.ts";
+import {
+  type SpawnCliInput,
+  type SpawnCliResult,
+} from "../../src/adapter/spawn.ts";
+import { spawnCli } from "../../src/adapter/spawn.ts";
+
+const BUN_DIR = dirname(process.execPath);
+const FAKE_CLI = new URL("../fixtures/fake-cli.ts", import.meta.url).pathname;
+
+function codexFixture(name: string): string {
+  return new URL(`../fixtures/codex-fixtures/${name}`, import.meta.url).pathname;
+}
+
+const TMP: string[] = [];
+
+function makeFakeBinaryDir(
+  name: string,
+  script: string,
+): { dir: string; binary: string } {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-codex-bin-"));
+  TMP.push(dir);
+  const binary = join(dir, name);
+  writeFileSync(binary, `#!/usr/bin/env bash\n${script}\n`);
+  chmodSync(binary, 0o755);
+  return { dir, binary };
+}
+
+afterAll(() => {
+  for (const d of TMP) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+});
+
+// ---------- spawn-spy ----------
+
+interface SpawnSpyCall {
+  readonly cmd: readonly string[];
+  readonly env: Record<string, string | undefined>;
+  readonly timeoutMs: number;
+  readonly stdin: string;
+  readonly extraAllowedEnvKeys: readonly string[];
+}
+
+interface SpawnSpy {
+  readonly spawn: (input: SpawnCliInput) => Promise<SpawnCliResult>;
+  readonly calls: SpawnSpyCall[];
+}
+
+function makeSpy(
+  scripted: SpawnCliResult | readonly SpawnCliResult[],
+): SpawnSpy {
+  const calls: SpawnSpyCall[] = [];
+  const spawn = (input: SpawnCliInput): Promise<SpawnCliResult> => {
+    calls.push({
+      cmd: [...input.cmd],
+      env: { ...input.env },
+      timeoutMs: input.timeoutMs,
+      stdin: input.stdin,
+      extraAllowedEnvKeys: [...(input.extraAllowedEnvKeys ?? [])],
+    });
+    const result = Array.isArray(scripted)
+      ? (scripted[calls.length - 1] ?? scripted[scripted.length - 1]!)
+      : (scripted as SpawnCliResult);
+    return Promise.resolve(result);
+  };
+  return { spawn, calls };
+}
+
+function makeFakeCliSpy(opts: {
+  fixture: string;
+  stateFile?: string;
+}): SpawnSpy {
+  const calls: SpawnSpyCall[] = [];
+  const spawn = async (input: SpawnCliInput): Promise<SpawnCliResult> => {
+    calls.push({
+      cmd: [...input.cmd],
+      env: { ...input.env },
+      timeoutMs: input.timeoutMs,
+      stdin: input.stdin,
+      extraAllowedEnvKeys: [...(input.extraAllowedEnvKeys ?? [])],
+    });
+    const env: Record<string, string | undefined> = {
+      ...input.env,
+      FAKE_CLI_FIXTURE: opts.fixture,
+    };
+    if (opts.stateFile !== undefined) {
+      env["FAKE_CLI_STATE_FILE"] = opts.stateFile;
+    }
+    const hostSnapshot: Record<string, string | undefined> = {
+      ...(input.host ?? {}),
+    };
+    const hostPath = hostSnapshot["PATH"] ?? "";
+    const mergedPath = hostPath === "" ? BUN_DIR : `${BUN_DIR}:${hostPath}`;
+    hostSnapshot["PATH"] = mergedPath;
+
+    const rewritten: SpawnCliInput = {
+      cmd: ["bun", "run", FAKE_CLI],
+      stdin: input.stdin,
+      env,
+      timeoutMs: input.timeoutMs,
+      extraAllowedEnvKeys: [
+        ...(input.extraAllowedEnvKeys ?? []),
+        "FAKE_CLI_FIXTURE",
+        "FAKE_CLI_STATE_FILE",
+      ],
+      host: hostSnapshot,
+    };
+    return await spawnCli(rewritten);
+  };
+  return { spawn, calls };
+}
+
+// ---------- helpers ----------
+
+const OPTS_HIGH_120: { effort: EffortLevel; timeout: number } = {
+  effort: "high",
+  timeout: 120_000,
+};
+
+function makeInstalledHost(): {
+  host: Record<string, string | undefined>;
+  binaryPath: string;
+} {
+  const { dir, binary } = makeFakeBinaryDir("codex", 'echo "0.41.0"');
+  return {
+    host: { PATH: dir, HOME: "/tmp" },
+    binaryPath: binary,
+  };
+}
+
+function sampleAsk(): AskInput {
+  return { prompt: "ping", context: "", opts: OPTS_HIGH_120 };
+}
+function sampleCritique(): CritiqueInput {
+  return {
+    spec: "# SPEC\n\nplaceholder",
+    guidelines: "be paranoid",
+    opts: OPTS_HIGH_120,
+  };
+}
+function sampleRevise(): ReviseInput {
+  return {
+    spec: "# SPEC\n\nplaceholder",
+    reviews: [],
+    decisions_history: [],
+    opts: OPTS_HIGH_120,
+  };
+}
+
+// ---------- auth_status ----------
+
+describe("CodexAdapter.auth_status (SPEC §11 subscription-auth)", () => {
+  test("no binary on PATH -> { authenticated: false }", async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "samospec-codex-empty-"));
+    TMP.push(emptyDir);
+    const adapter = new CodexAdapter({
+      host: { PATH: emptyDir, HOME: "/tmp" },
+    });
+    const result = await adapter.auth_status();
+    expect(result.authenticated).toBe(false);
+  });
+
+  test("binary present + OPENAI_API_KEY set -> subscription_auth=false", async () => {
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({
+      host: { ...host, OPENAI_API_KEY: "sk-test-not-a-real-key" },
+    });
+    const result = await adapter.auth_status();
+    expect(result.authenticated).toBe(true);
+    expect(result.subscription_auth).toBe(false);
+  });
+
+  test("binary present + no API key -> subscription_auth=true (ChatGPT login assumed)", async () => {
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host });
+    const result = await adapter.auth_status();
+    expect(result.authenticated).toBe(true);
+    expect(result.subscription_auth).toBe(true);
+  });
+});
+
+// ---------- spawn-spy: non-interactive flags + env + model pin ----------
+
+describe("CodexAdapter spawn flags + minimal env (SPEC §7)", () => {
+  test("ask() passes `exec` subcommand and --model pin", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: '{"answer":"ok","usage":null,"effort_used":"high"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    await adapter.ask(sampleAsk());
+
+    const workCall = spy.calls.find((c) => c.stdin.length > 0);
+    expect(workCall).toBeDefined();
+    if (workCall === undefined) return;
+    expect(workCall.cmd).toContain("exec");
+    expect(workCall.cmd).toContain("--model");
+    expect(workCall.cmd).toContain("gpt-5.1-codex-max");
+  });
+
+  test("ask() passes reasoning_effort flag matching logical effort (SPEC §11 table)", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: '{"answer":"ok","usage":null,"effort_used":"high"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    await adapter.ask({
+      prompt: "ping",
+      context: "",
+      opts: { effort: "high", timeout: 120_000 },
+    });
+
+    const workCall = spy.calls.find((c) => c.stdin.length > 0);
+    expect(workCall).toBeDefined();
+    if (workCall === undefined) return;
+    // Effort mapping per SPEC §11: logical 'high' -> reasoning_effort high
+    const cmdJoined = workCall.cmd.join(" ");
+    expect(cmdJoined).toContain("high");
+    // The flag itself must be present.
+    expect(workCall.cmd.some((c) => c.includes("reasoning"))).toBe(true);
+  });
+
+  test("work-call spawn forwards OPENAI_API_KEY via extraAllowedEnvKeys", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: '{"answer":"ok","usage":null,"effort_used":"high"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({
+      host: { ...host, TMPDIR: "/tmp", OPENAI_API_KEY: "sk-test" },
+      spawn: spy.spawn,
+    });
+    await adapter.ask(sampleAsk());
+
+    const workCall = spy.calls.find((c) => c.stdin.length > 0);
+    expect(workCall).toBeDefined();
+    if (workCall === undefined) return;
+    expect(workCall.extraAllowedEnvKeys).toContain("OPENAI_API_KEY");
+  });
+
+  test("end-to-end minimal-env: fake-CLI child sees only allowlist keys (no host leaks)", async () => {
+    const echoEnv = new URL(
+      "../fixtures/fake-cli-fixtures/echo-env.json",
+      import.meta.url,
+    ).pathname;
+    let capturedKeys: readonly string[] = [];
+
+    const peekSpawn = async (input: SpawnCliInput): Promise<SpawnCliResult> => {
+      const env: Record<string, string | undefined> = {
+        ...input.env,
+        FAKE_CLI_FIXTURE: echoEnv,
+      };
+      const hostSnapshot: Record<string, string | undefined> = {
+        ...(input.host ?? {}),
+      };
+      const hostPath = hostSnapshot["PATH"] ?? "";
+      hostSnapshot["PATH"] =
+        hostPath === "" ? BUN_DIR : `${BUN_DIR}:${hostPath}`;
+
+      const raw = await spawnCli({
+        cmd: ["bun", "run", FAKE_CLI],
+        stdin: input.stdin,
+        env,
+        timeoutMs: input.timeoutMs,
+        extraAllowedEnvKeys: [
+          ...(input.extraAllowedEnvKeys ?? []),
+          "FAKE_CLI_FIXTURE",
+        ],
+        host: hostSnapshot,
+      });
+      if (raw.ok) {
+        const parsed = JSON.parse(raw.stdout) as { keys?: string[] };
+        capturedKeys = parsed.keys ?? [];
+      }
+      return {
+        ok: true,
+        exitCode: 0,
+        stdout: '{"answer":"ok","usage":null,"effort_used":"high"}',
+        stderr: "",
+      };
+    };
+
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({
+      host: {
+        ...host,
+        TMPDIR: "/tmp",
+        OPENAI_API_KEY: "sk-forwarded-value",
+        ANTHROPIC_API_KEY: "not-leaked",
+        LEAKY_HOST_SECRET: "nope",
+      },
+      spawn: peekSpawn,
+    });
+
+    await adapter.ask(sampleAsk());
+
+    // Allowlist: HOME, PATH, TMPDIR, OPENAI_API_KEY
+    // (+ FAKE_CLI_FIXTURE for the peek harness).
+    expect(capturedKeys).toContain("OPENAI_API_KEY");
+    expect(capturedKeys).not.toContain("ANTHROPIC_API_KEY");
+    expect(capturedKeys).not.toContain("LEAKY_HOST_SECRET");
+  });
+
+  test("revise() returns ready + rationale from JSON body", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout:
+        '{"spec":"# SPEC\\n\\nrevised.","ready":false,' +
+        '"rationale":"reviewer rarely revises","usage":null,"effort_used":"high"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    const out = await adapter.revise(sampleRevise());
+    expect(out.ready).toBe(false);
+    expect(out.rationale).toBe("reviewer rarely revises");
+    expect(out.spec).toContain("# SPEC");
+    expect(out.usage).toBeNull();
+  });
+
+  test("usage defaults to null when CLI omits it", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: '{"answer":"no usage info"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+    const out = await adapter.ask(sampleAsk());
+    expect(out.usage).toBeNull();
+    expect(out.effort_used).toBe("high");
+  });
+});
+
+// ---------- persona system prompt + taxonomy weighting ----------
+
+describe("CodexAdapter.critique persona prefix (SPEC §7 Model roles)", () => {
+  test("critique stdin contains paranoid security/ops persona", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout:
+        '{"findings":[],"summary":"ok","suggested_next_version":"0.1.0",' +
+        '"usage":null,"effort_used":"high"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    await adapter.critique(sampleCritique());
+
+    const workCall = spy.calls.find((c) => c.stdin.length > 0);
+    expect(workCall).toBeDefined();
+    if (workCall === undefined) return;
+    // Persona must identify as paranoid security/ops engineer (SPEC §7).
+    expect(workCall.stdin.toLowerCase()).toContain("paranoid");
+    expect(workCall.stdin.toLowerCase()).toContain("security");
+  });
+
+  test("critique stdin contains literal taxonomy-weighting wording (SPEC §7)", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout:
+        '{"findings":[],"summary":"ok","suggested_next_version":"0.1.0",' +
+        '"usage":null,"effort_used":"high"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    await adapter.critique(sampleCritique());
+
+    const workCall = spy.calls.find((c) => c.stdin.length > 0);
+    expect(workCall).toBeDefined();
+    if (workCall === undefined) return;
+    // Literal wording from issue #23 (advisory, not a hard filter).
+    const literal =
+      "Focus especially on missing-risk, weak-implementation, and " +
+      "unnecessary-scope. You may surface findings in other categories " +
+      "when warranted, but weight your effort toward these.";
+    expect(workCall.stdin).toContain(literal);
+  });
+
+  test("ask() does NOT contain the persona prefix (critique-only)", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: '{"answer":"ok","usage":null,"effort_used":"high"}',
+      stderr: "",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    await adapter.ask(sampleAsk());
+
+    const workCall = spy.calls.find((c) => c.stdin.length > 0);
+    expect(workCall).toBeDefined();
+    if (workCall === undefined) return;
+    expect(workCall.stdin.toLowerCase()).not.toContain("paranoid");
+  });
+});
+
+// ---------- schema-violation repair (end-to-end via fake-CLI) ----------
+
+describe("CodexAdapter schema-violation repair (SPEC §7)", () => {
+  test("happy ask(): fake-CLI emits valid JSON once", async () => {
+    const spy = makeFakeCliSpy({
+      fixture: codexFixture("ask-happy.json"),
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+    const out = await adapter.ask(sampleAsk());
+    expect(out.answer).toBe("hello from codex");
+    expect(out.usage).toBeNull();
+  });
+
+  test("schema-violation then repair: first call garbage, second valid", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "samospec-codex-state-"));
+    TMP.push(stateDir);
+    const stateJson = join(stateDir, "call-state.json");
+    writeFileSync(stateJson, JSON.stringify({ call: 0 }));
+
+    const spy = makeFakeCliSpy({
+      fixture: codexFixture("ask-schema-repair.json"),
+      stateFile: stateJson,
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    const out = await adapter.ask(sampleAsk());
+    expect(out.answer).toBe("repaired");
+    // Exactly two spawns: one bad, one repair.
+    expect(spy.calls.length).toBe(2);
+  });
+
+  test("schema-violation twice: terminal after ONE repair retry", async () => {
+    const spy = makeFakeCliSpy({
+      fixture: codexFixture("ask-schema-fatal.json"),
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    if (err instanceof CodexAdapterError) {
+      expect(err.payload.reason).toBe("schema_violation");
+      expect(err.payload.kind).toBe("terminal");
+    }
+    expect(spy.calls.length).toBe(2);
+  });
+
+  test("Markdown-fenced JSON is stripped and validated end-to-end", async () => {
+    const spy = makeFakeCliSpy({
+      fixture: codexFixture("ask-fenced.json"),
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    const out = await adapter.ask(sampleAsk());
+    expect(out.answer).toBe("fenced-ok");
+    expect(out.usage).toBeNull();
+  });
+});
+
+// ---------- exit-code classification ----------
+
+describe("CodexAdapter exit-code classification (SPEC §7)", () => {
+  test("non-zero exit with auth stderr -> terminal error, no retry", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 2,
+      stdout: "",
+      stderr: "unauthorized: no OPENAI_API_KEY",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    if (err instanceof CodexAdapterError) {
+      expect(err.payload.kind).toBe("terminal");
+      expect(err.payload.reason).toBe("other");
+    }
+    expect(spy.calls.length).toBe(1);
+  });
+
+  test("non-zero exit with rate-limit stderr -> retried as timeout class", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 1,
+      stdout: "",
+      stderr: "rate limit exceeded (429)",
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    expect(spy.calls.length).toBe(3);
+  });
+});
+
+// ---------- capped timeout retry ----------
+
+describe("CodexAdapter capped timeout retry (SPEC §7)", () => {
+  test("three timeouts -> terminal; timeouts are base, +50%, base", async () => {
+    const spy = makeSpy({ ok: false, reason: "timeout" });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    let err: unknown;
+    try {
+      await adapter.ask({
+        prompt: "slow",
+        context: "",
+        opts: { effort: "high", timeout: 1000 },
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    if (err instanceof CodexAdapterError) {
+      expect(err.payload.reason).toBe("timeout");
+      expect(err.payload.kind).toBe("terminal");
+      expect(err.payload.attempts).toBe(3);
+    }
+    expect(spy.calls.length).toBe(3);
+    expect(spy.calls[0]?.timeoutMs).toBe(1000);
+    expect(spy.calls[1]?.timeoutMs).toBe(1500);
+    expect(spy.calls[2]?.timeoutMs).toBe(1000);
+  });
+});
+
+// ---------- critique schema ----------
+
+describe("CodexAdapter.critique (SPEC §7)", () => {
+  test("returns schema-valid findings + summary + suggested_next_version", async () => {
+    const spy = makeFakeCliSpy({
+      fixture: codexFixture("critique-happy.json"),
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    const out = await adapter.critique(sampleCritique());
+    expect(Array.isArray(out.findings)).toBe(true);
+    expect(out.findings.length).toBeGreaterThan(0);
+    expect(out.summary).toBeTruthy();
+    expect(out.suggested_next_version).toBeTruthy();
+    expect(out.usage).toBeNull();
+  });
+});
+
+// ---------- model fallback chain ----------
+
+describe("CodexAdapter model fallback (SPEC §11)", () => {
+  test("pinned model rejected -> falls back to gpt-5.1-codex and succeeds", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "samospec-codex-fb-"));
+    TMP.push(stateDir);
+    const stateJson = join(stateDir, "call-state.json");
+    writeFileSync(stateJson, JSON.stringify({ call: 0 }));
+
+    const spy = makeFakeCliSpy({
+      fixture: codexFixture("model-fallback.json"),
+      stateFile: stateJson,
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    const out = await adapter.ask(sampleAsk());
+    expect(out.answer).toBe("fallback-ok");
+    // Exactly two spawns: max (rejected), then codex.
+    expect(spy.calls.length).toBe(2);
+    // First call carried the pinned model.
+    const firstCmd = spy.calls[0]?.cmd.join(" ") ?? "";
+    expect(firstCmd).toContain("gpt-5.1-codex-max");
+    // Second call carried the fallback model.
+    const secondCmd = spy.calls[1]?.cmd.join(" ") ?? "";
+    expect(secondCmd).toContain("gpt-5.1-codex");
+    expect(secondCmd).not.toContain("gpt-5.1-codex-max");
+  });
+
+  test("all models rejected -> terminal", async () => {
+    const spy = makeFakeCliSpy({
+      fixture: codexFixture("model-fallback-all-fail.json"),
+    });
+    const { host } = makeInstalledHost();
+    const adapter = new CodexAdapter({ host, spawn: spy.spawn });
+
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    if (err instanceof CodexAdapterError) {
+      expect(err.payload.kind).toBe("terminal");
+      expect(err.payload.reason).toBe("model_unavailable");
+    }
+    // Both models were attempted.
+    expect(spy.calls.length).toBe(2);
+  });
+});

--- a/tests/fixtures/codex-fixtures/ask-fenced.json
+++ b/tests/fixtures/codex-fixtures/ask-fenced.json
@@ -1,0 +1,9 @@
+{
+  "script": [
+    {
+      "type": "stdout",
+      "text": "```json\n{\"answer\":\"fenced-ok\",\"usage\":null,\"effort_used\":\"high\"}\n```"
+    },
+    { "type": "exit", "code": 0 }
+  ]
+}

--- a/tests/fixtures/codex-fixtures/ask-happy.json
+++ b/tests/fixtures/codex-fixtures/ask-happy.json
@@ -1,0 +1,9 @@
+{
+  "script": [
+    {
+      "type": "stdout",
+      "text": "{\"answer\":\"hello from codex\",\"usage\":null,\"effort_used\":\"high\"}"
+    },
+    { "type": "exit", "code": 0 }
+  ]
+}

--- a/tests/fixtures/codex-fixtures/ask-schema-fatal.json
+++ b/tests/fixtures/codex-fixtures/ask-schema-fatal.json
@@ -1,0 +1,6 @@
+{
+  "script": [
+    { "type": "stdout", "text": "always garbage" },
+    { "type": "exit", "code": 0 }
+  ]
+}

--- a/tests/fixtures/codex-fixtures/ask-schema-repair.json
+++ b/tests/fixtures/codex-fixtures/ask-schema-repair.json
@@ -1,0 +1,19 @@
+{
+  "branches": {
+    "0": {
+      "script": [
+        { "type": "stdout", "text": "this is not json at all" },
+        { "type": "exit", "code": 0 }
+      ]
+    },
+    "default": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"answer\":\"repaired\",\"usage\":null,\"effort_used\":\"high\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/codex-fixtures/contract-trio.json
+++ b/tests/fixtures/codex-fixtures/contract-trio.json
@@ -1,0 +1,40 @@
+{
+  "branches": {
+    "0": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"answer\":\"ok\",\"usage\":null,\"effort_used\":\"max\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    },
+    "1": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"findings\":[{\"category\":\"missing-risk\",\"text\":\"x\",\"severity\":\"major\"}],\"summary\":\"s\",\"suggested_next_version\":\"0.1.1\",\"usage\":null,\"effort_used\":\"max\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    },
+    "2": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"spec\":\"# SPEC\\n\\n.\",\"ready\":false,\"rationale\":\"reviewer seat — no revise commitment\",\"usage\":null,\"effort_used\":\"max\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    },
+    "default": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"answer\":\"extra-call\",\"usage\":null,\"effort_used\":\"max\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/codex-fixtures/critique-happy.json
+++ b/tests/fixtures/codex-fixtures/critique-happy.json
@@ -1,0 +1,9 @@
+{
+  "script": [
+    {
+      "type": "stdout",
+      "text": "{\"findings\":[{\"category\":\"missing-risk\",\"text\":\"credentials file not locked down\",\"severity\":\"major\"}],\"summary\":\"one missing-risk finding\",\"suggested_next_version\":\"0.1.1\",\"usage\":null,\"effort_used\":\"high\"}"
+    },
+    { "type": "exit", "code": 0 }
+  ]
+}

--- a/tests/fixtures/codex-fixtures/model-fallback-all-fail.json
+++ b/tests/fixtures/codex-fixtures/model-fallback-all-fail.json
@@ -1,0 +1,9 @@
+{
+  "script": [
+    {
+      "type": "stderr",
+      "text": "error: model is not available for this account\n"
+    },
+    { "type": "exit", "code": 2 }
+  ]
+}

--- a/tests/fixtures/codex-fixtures/model-fallback.json
+++ b/tests/fixtures/codex-fixtures/model-fallback.json
@@ -1,0 +1,22 @@
+{
+  "branches": {
+    "0": {
+      "script": [
+        {
+          "type": "stderr",
+          "text": "error: model 'gpt-5.1-codex-max' is not available for this account\n"
+        },
+        { "type": "exit", "code": 2 }
+      ]
+    },
+    "default": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"answer\":\"fallback-ok\",\"usage\":null,\"effort_used\":\"high\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/codex-fixtures/revise-happy.json
+++ b/tests/fixtures/codex-fixtures/revise-happy.json
@@ -1,0 +1,9 @@
+{
+  "script": [
+    {
+      "type": "stdout",
+      "text": "{\"spec\":\"# SPEC\\n\\nrevised by reviewer A.\",\"ready\":false,\"rationale\":\"review seat rarely revises but the method must work\",\"usage\":null,\"effort_used\":\"high\"}"
+    },
+    { "type": "exit", "code": 0 }
+  ]
+}


### PR DESCRIPTION
Closes #23

## Summary

- Adds `src/adapter/codex.ts` — `CodexAdapter` implementing the shared `Adapter` interface (SPEC §7, §11). Mirrors the structure of the Sprint 2 `ClaudeAdapter` but targets `codex exec` + `gpt-5.1-codex-max` as the Reviewer A seat.
- Updates `src/adapter/auth-status.ts` so the codex vendor recognises `OPENAI_API_KEY` and surfaces `subscription_auth: true` when a ChatGPT-login user runs the adapter.
- Adds `tests/adapter/codex.test.ts` (lifecycle), `codex.work.test.ts` (spawn spy + persona + fallback), `codex.effort.test.ts` (effort-table lockdown), `codex.contract.test.ts` (shared contract helper), plus 8 scripted fake-CLI fixtures under `tests/fixtures/codex-fixtures/`.

## Checklist (from issue #23)

- [x] `CodexAdapter` exports class implementing `Adapter` from `types.ts`.
- [x] `codex exec` subcommand used for non-interactive spawn (probed via `--version` in `detect()`; documented in `spawn.ts`).
- [x] Minimal env: only `HOME`, `PATH`, `TMPDIR`, `OPENAI_API_KEY` forwarded (spawn-spy verified end-to-end).
- [x] `detect()` returns `{ installed, version, path }`; falls back to `unknown` on version-probe exit code ≠ 0.
- [x] `auth_status()` returns `subscription_auth: true` when `OPENAI_API_KEY` is absent; `false` when present.
- [x] `supports_structured_output()` returns `true`.
- [x] `supports_effort()` accepts every `EffortLevel` and maps to `reasoning_effort: high|medium|low|minimal` per SPEC §11.
- [x] `models()` returns pinned `gpt-5.1-codex-max` first, `gpt-5.1-codex` second.
- [x] `ask`, `critique`, `revise` implemented via a shared spawn + capped-retry loop.
- [x] `critique()` carries the paranoid security/ops persona and the literal taxonomy-weighting wording from SPEC §7 / issue #23. `ask()` and `revise()` skip the prefix.
- [x] Pinned model `gpt-5.1-codex-max` passed via `--model`; fallback chain attempts `gpt-5.1-codex` on "model not available" stderr, then terminal (`CodexAdapterError.reason === "model_unavailable"`).
- [x] Same failure classification + capped timeout retry (base → +50% → base → terminal) + `usage: null` path as Claude adapter.
- [x] Markdown code-fence stripping routed through `src/adapter/json-parse.ts`.
- [x] Shared `runAdapterContract` helper driven against `CodexAdapter` — all branches pass via `codex-fixtures/contract-trio.json`.
- [x] Copyright 2026 header on every new file. Markdown lists with `- ` (none added in prose).

## Testing evidence

- Full suite: `bun test` → **780 / 780 pass**, 7741 expect() calls across 61 files.
- Focused codex suites: `bun test tests/adapter/codex*.ts` → **36 / 36 pass**, 119 expect() calls.
- Lint: `bun run lint` → clean.
- Typecheck: `bun run typecheck` → clean.
- Format: `bun run format:check` → clean.

### Spawn-spy verification

- Non-interactive flags: `workCall.cmd` contains `exec` and `--model gpt-5.1-codex-max` (see `codex.work.test.ts` — "ask() passes `exec` subcommand and --model pin").
- Minimal env: fake-CLI env dump shows `OPENAI_API_KEY` forwarded, `ANTHROPIC_API_KEY` + `LEAKY_HOST_SECRET` blocked (see "end-to-end minimal-env" test).
- Persona prefix: `critique()` stdin contains `"paranoid"` + `"security"` (case-insensitive) and the literal taxonomy-weighting sentence.
- Taxonomy weighting: literal string `"Focus especially on missing-risk, weak-implementation, and unnecessary-scope. You may surface findings in other categories when warranted, but weight your effort toward these."` asserted byte-for-byte.
- Fallback chain: first spawn carries `gpt-5.1-codex-max`, second carries `gpt-5.1-codex` (and not the pinned default) when model-unavailable stderr is returned.

### Contract-test output

`tests/adapter/codex.contract.test.ts` drives `CodexAdapter` through `runAdapterContract` via the `codex-fixtures/contract-trio.json` fake-CLI script; the single contract test passes (12 expect() calls covering lifecycle + ask/critique/revise + `usage: null` + `subscription_auth`).

## Test plan

- [x] `bun test` green.
- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean.
- [x] `bun run format:check` clean.
- [x] No real network calls — every spawn delegates to the fake-CLI harness or the scripted spy.
- [x] No real `OPENAI_API_KEY` values committed (only `sk-test*` / `sk-forwarded-value` placeholders in test env injection).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>