### PR TITLE
feat: Sprint 4 #31 — first-push consent flow + round-boundary push

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,12 @@ import { createFakeAdapter } from "./adapter/fake-adapter.ts";
 import type { Adapter } from "./adapter/types.ts";
 import { runInit } from "./cli/init.ts";
 import { runDoctor, type DoctorAdapterBinding } from "./cli/doctor.ts";
-import { runIterate, type IterateResolvers } from "./cli/iterate.ts";
+import {
+  runIterate,
+  type IterateResolvers,
+  type PushOptions,
+} from "./cli/iterate.ts";
+import { describePrCapability } from "./git/push-consent.ts";
 import { runNew, type ChoiceResolvers } from "./cli/new.ts";
 import {
   PERSONA_FORM_RE,
@@ -42,7 +47,8 @@ const USAGE =
   "  doctor                      Diagnose CLI availability, auth, git, lock, and config.\n" +
   "  new <slug> [--idea ...]     Start a new spec (persona + 5-question interview).\n" +
   "  resume [<slug>]             Resume an in-progress spec from state.json.\n" +
-  "  iterate [<slug>] [--rounds] Run review rounds until a stopping condition fires.\n" +
+  "  iterate [<slug>] [--rounds N] [--no-push] [--remote <name>]\n" +
+  "                              Run review rounds until a stopping condition fires.\n" +
   "  status [<slug>]             Print phase, round, cost, wall-clock, and next action.\n" +
   "  version                     Print the samospec version and exit.\n";
 
@@ -298,11 +304,15 @@ async function runResumeCommand(rest: readonly string[]) {
 interface IterateArgs {
   readonly slug: string;
   readonly rounds?: number;
+  readonly noPush: boolean;
+  readonly remote: string;
 }
 
 function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
   let slug: string | null = null;
   let rounds: number | undefined;
+  let noPush = false;
+  let remote = "origin";
   for (let i = 0; i < argv.length; i += 1) {
     const t = argv[i];
     if (t === undefined) continue;
@@ -320,13 +330,32 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
       if (Number.isFinite(n) && n > 0) rounds = n;
       continue;
     }
+    if (t === "--no-push") {
+      noPush = true;
+      continue;
+    }
+    if (t === "--remote") {
+      const v = argv[i + 1];
+      i += 1;
+      if (v !== undefined && v.length > 0) remote = v;
+      continue;
+    }
+    if (t.startsWith("--remote=")) {
+      remote = t.slice("--remote=".length);
+      continue;
+    }
     if (t.startsWith("--")) continue;
     slug ??= t;
   }
   if (slug === null || slug.length === 0) {
     return "samospec iterate: missing <slug>";
   }
-  return rounds === undefined ? { slug } : { slug, rounds };
+  return {
+    slug,
+    noPush,
+    remote,
+    ...(rounds !== undefined ? { rounds } : {}),
+  };
 }
 
 function parseStatusArgs(argv: readonly string[]): { slug: string } | string {
@@ -395,6 +424,23 @@ function interactiveIterateResolvers(): IterateResolvers {
       if (ans === "c" || ans === "continue") return "continue";
       return "abort";
     },
+    onPushConsent: async (payload) => {
+      process.stdout.write(`\nFirst push in this repo — consent required.\n`);
+      process.stdout.write(`  remote: ${payload.remoteName}\n`);
+      process.stdout.write(`  remote URL: ${payload.remoteUrl}\n`);
+      process.stdout.write(`  branch: ${payload.targetBranch}\n`);
+      process.stdout.write(`  default branch: ${payload.defaultBranch}\n`);
+      process.stdout.write(`  ${describePrCapability(payload.prCapability)}\n`);
+      const ans = (
+        await rl.question(
+          "[A]ccept (persist) / [R]efuse (persist) [Enter=refuse]: ",
+        )
+      )
+        .trim()
+        .toLowerCase();
+      if (ans === "a" || ans === "accept") return "accept";
+      return "refuse";
+    },
   };
 }
 
@@ -404,12 +450,17 @@ async function runIterateCommand(rest: readonly string[]) {
     return { exitCode: 1, stdout: "", stderr: `${parsed}\n\n${USAGE}` };
   }
   const adapters = buildReviewLoopAdapters();
+  const pushOptions: PushOptions = {
+    remote: parsed.remote,
+    noPush: parsed.noPush,
+  };
   const result = await runIterate({
     cwd: process.cwd(),
     slug: parsed.slug,
     now: new Date().toISOString(),
     resolvers: interactiveIterateResolvers(),
     adapters,
+    pushOptions,
     ...(parsed.rounds !== undefined ? { maxRounds: parsed.rounds } : {}),
   });
   return {

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -30,10 +30,12 @@
  *   - NO reviewer system-prompt changes beyond wiring.
  */
 
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import type { Adapter, Finding } from "../adapter/types.ts";
+import { currentBranch } from "../git/branch.ts";
 import { specCommit } from "../git/commit.ts";
 import { ProtectedBranchError } from "../git/errors.ts";
 import {
@@ -41,6 +43,13 @@ import {
   detectManualEdits,
   type ManualEditChoice,
 } from "../git/manual-edit.ts";
+import { pushBranch, type PushBranchResult } from "../git/push.ts";
+import {
+  probePrCapability,
+  requestPushConsent,
+  type PushConsentDecision,
+  type PushConsentPrompt,
+} from "../git/push-consent.ts";
 import {
   shouldStartNextRound,
   type CallTimeoutsMs,
@@ -106,10 +115,28 @@ export type DegradeResolver = (summary: string) => Promise<DegradeChoice>;
 export type ContinueReviewersChoice = "continue" | "abort";
 export type ContinueReviewersResolver = () => Promise<ContinueReviewersChoice>;
 
+/** SPEC §8 — first-push consent resolver. See src/git/push-consent.ts. */
+export type PushConsentResolver = (
+  payload: PushConsentPrompt,
+) => Promise<PushConsentDecision>;
+
 export interface IterateResolvers {
   readonly onManualEdit: ManualEditResolver;
   readonly onDegraded: DegradeResolver;
   readonly onReviewerExhausted: ContinueReviewersResolver;
+  /**
+   * SPEC §8: first time a push would happen for a remote URL in this
+   * repo, invoke this resolver once. Persisted decisions silently
+   * short-circuit the resolver on later sessions.
+   */
+  readonly onPushConsent?: PushConsentResolver;
+}
+
+export interface PushOptions {
+  /** Remote name to target (e.g. `origin`). */
+  readonly remote: string;
+  /** `--no-push` invocation override; beats persisted consent per §8. */
+  readonly noPush: boolean;
 }
 
 export interface IterateInput {
@@ -143,6 +170,11 @@ export interface IterateInput {
   readonly degradeOnFirstRound?: boolean;
   /** A pre-fired signal for SIGINT-style tests. */
   readonly sigintSignal?: { readonly triggered: boolean };
+  /**
+   * SPEC §8 — when present, triggers the round-boundary push flow.
+   * Absent = local-only, no consent prompt, no push attempts.
+   */
+  readonly pushOptions?: PushOptions;
 }
 
 export interface IterateResult {
@@ -265,6 +297,11 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
     // Initial state tracking.
     let currentState: State = state;
     let currentSpec: string = readFileSync(paths.specPath, "utf8");
+    // SPEC §8 — session-scoped push-consent snapshot. `null` means "not
+    // yet resolved this session"; once resolved it's respected silently
+    // across the remaining round boundaries. The value here mirrors
+    // persisted state when present, or the prompt answer otherwise.
+    let pushGrantedThisSession: boolean | null = null;
     // SPEC §12 conditions 3 + 4 require round-(N-1) signals. The
     // classifier's "previous" is only a real round when
     // `hasPreviousRound === true`; round 1 passes synthetic signals
@@ -570,6 +607,52 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
             notice(
               `committed spec(${input.slug}): refine ${formatVersionLabel(newVersion)} after review r${String(roundIndex).padStart(2, "0")}`,
             );
+
+            // SPEC §5 Phase 6 + §8 — round-boundary push. Exactly one
+            // push per `committed` transition; never per commit.
+            if (input.pushOptions !== undefined) {
+              const pushOutcome = await handleRoundBoundaryPush({
+                cwd: input.cwd,
+                slug: input.slug,
+                pushOptions: input.pushOptions,
+                onPushConsent: input.resolvers.onPushConsent,
+                sessionGranted: pushGrantedThisSession,
+                now: input.now,
+              });
+              if (pushOutcome.kind === "interrupt") {
+                const interrupted: State = {
+                  ...currentState,
+                  updated_at: input.now,
+                  exit: {
+                    code: 3,
+                    reason: "push-consent-interrupted",
+                    round_index: roundIndex,
+                  },
+                };
+                writeState(paths.statePath, interrupted);
+                error(
+                  `samospec: push-consent prompt interrupted (Ctrl-C).`,
+                );
+                return {
+                  exitCode: 3,
+                  stdout: lines.join("\n"),
+                  stderr: `${errLines.join("\n")}\n`,
+                  roundsRun,
+                  finalVersion: currentState.version,
+                };
+              }
+              if (pushOutcome.sessionGranted !== undefined) {
+                pushGrantedThisSession = pushOutcome.sessionGranted;
+              }
+              if (pushOutcome.pushResult !== undefined) {
+                emitPushNotice(
+                  notice,
+                  error,
+                  pushOutcome.pushResult,
+                  input.pushOptions.remote,
+                );
+              }
+            }
           } catch (err) {
             if (err instanceof ProtectedBranchError) {
               error(
@@ -692,6 +775,191 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
 
 function ensureTrailingNewline(s: string): string {
   return s.endsWith("\n") ? s : `${s}\n`;
+}
+
+// ---------- round-boundary push plumbing (SPEC §5 Phase 6 + §8) ----------
+
+interface HandlePushArgs {
+  readonly cwd: string;
+  readonly slug: string;
+  readonly pushOptions: PushOptions;
+  readonly onPushConsent: PushConsentResolver | undefined;
+  readonly sessionGranted: boolean | null;
+  readonly now: string;
+}
+
+interface PushResult {
+  readonly kind: "ok" | "interrupt";
+  /** Set when a decision was reached; propagates to the next round. */
+  readonly sessionGranted?: boolean;
+  readonly pushResult?: PushBranchResult;
+}
+
+/**
+ * Coordinate consent + push at a single round boundary. Returns
+ * `kind: "interrupt"` when the user Ctrl-C'd the consent prompt so
+ * the caller can emit exit 3 per SPEC §10. Otherwise returns a
+ * `pushResult` the caller can surface via notice/error.
+ *
+ * Idempotency: once the session has resolved consent (granted or
+ * refused), this short-circuits on subsequent rounds without calling
+ * the resolver again. Persisted choices on disk short-circuit the same
+ * way — the resolver is invoked at most once per session.
+ */
+async function handleRoundBoundaryPush(
+  args: HandlePushArgs,
+): Promise<PushResult> {
+  // `--no-push` invocation override: never pushes, never prompts. Beats
+  // persisted-accept and session-accept alike.
+  if (args.pushOptions.noPush) {
+    return {
+      kind: "ok",
+      ...(args.sessionGranted !== null
+        ? { sessionGranted: args.sessionGranted }
+        : {}),
+      pushResult: pushBranchSafely({
+        repoPath: args.cwd,
+        remote: args.pushOptions.remote,
+        branch: currentBranch(args.cwd),
+        granted: true,
+        noPush: true,
+      }),
+    };
+  }
+
+  const branch = currentBranch(args.cwd);
+  const remoteUrl = resolveRemoteUrl(args.cwd, args.pushOptions.remote);
+  if (remoteUrl === null) {
+    // Remote not configured — skip silently, like a refused consent.
+    return { kind: "ok" };
+  }
+
+  let granted: boolean;
+  let sessionGranted: boolean | undefined;
+  if (args.sessionGranted !== null) {
+    granted = args.sessionGranted;
+    sessionGranted = args.sessionGranted;
+  } else {
+    const resolver = args.onPushConsent;
+    const defaultBranch = resolveDefaultBranch(
+      args.cwd,
+      args.pushOptions.remote,
+    );
+    const capability = probePrCapability();
+    const outcome = await requestPushConsent({
+      repoPath: args.cwd,
+      remoteName: args.pushOptions.remote,
+      remoteUrl,
+      targetBranch: branch,
+      defaultBranch,
+      prCapability: capability,
+      prompt:
+        resolver ??
+        ((): Promise<PushConsentDecision> => Promise.resolve("refuse")),
+    });
+    if (outcome.decision === "interrupt") {
+      return { kind: "interrupt" };
+    }
+    granted = outcome.decision === "accept";
+    sessionGranted = granted;
+  }
+
+  const pushResult = pushBranchSafely({
+    repoPath: args.cwd,
+    remote: args.pushOptions.remote,
+    branch,
+    granted,
+    noPush: false,
+  });
+  return {
+    kind: "ok",
+    ...(sessionGranted !== undefined ? { sessionGranted } : {}),
+    pushResult,
+  };
+}
+
+function pushBranchSafely(args: {
+  readonly repoPath: string;
+  readonly remote: string;
+  readonly branch: string;
+  readonly granted: boolean;
+  readonly noPush: boolean;
+}): PushBranchResult {
+  try {
+    return pushBranch(args);
+  } catch (err) {
+    return {
+      state: "failed",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function resolveRemoteUrl(cwd: string, remoteName: string): string | null {
+  const res = spawnSync("git", ["remote", "get-url", remoteName], {
+    cwd,
+    encoding: "utf8",
+  });
+  if ((res.status ?? 1) !== 0) return null;
+  const url = (res.stdout ?? "").trim();
+  return url.length > 0 ? url : null;
+}
+
+function resolveDefaultBranch(cwd: string, remoteName: string): string {
+  // `git symbolic-ref refs/remotes/<remote>/HEAD` → `refs/remotes/<remote>/<name>`
+  const head = spawnSync(
+    "git",
+    ["symbolic-ref", "--quiet", `refs/remotes/${remoteName}/HEAD`],
+    { cwd, encoding: "utf8" },
+  );
+  if ((head.status ?? 1) === 0) {
+    const ref = (head.stdout ?? "").trim();
+    const prefix = `refs/remotes/${remoteName}/`;
+    if (ref.startsWith(prefix)) {
+      return ref.slice(prefix.length);
+    }
+  }
+  // Fallback to the local config `init.defaultBranch`, then `main`.
+  const cfg = spawnSync("git", ["config", "--get", "init.defaultBranch"], {
+    cwd,
+    encoding: "utf8",
+  });
+  if ((cfg.status ?? 1) === 0) {
+    const value = (cfg.stdout ?? "").trim();
+    if (value.length > 0) return value;
+  }
+  return "main";
+}
+
+function emitPushNotice(
+  notice: (line: string) => void,
+  error: (line: string) => void,
+  result: PushBranchResult,
+  remote: string,
+): void {
+  switch (result.state) {
+    case "pushed":
+      notice(`pushed to ${remote}.`);
+      return;
+    case "skipped-no-push":
+      notice(`push skipped (--no-push).`);
+      return;
+    case "skipped-refused":
+      notice(`push skipped (consent refused).`);
+      return;
+    case "failed":
+      error(
+        `samospec: push to ${remote} failed: ${
+          result.message ?? "(no detail)"
+        }`,
+      );
+      return;
+    default: {
+      // Exhaustiveness check; unreachable.
+      const _never: never = result.state;
+      void _never;
+    }
+  }
 }
 
 function appendOrCreateChangelog(filePath: string, entry: string): void {

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -630,9 +630,7 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
                   },
                 };
                 writeState(paths.statePath, interrupted);
-                error(
-                  `samospec: push-consent prompt interrupted (Ctrl-C).`,
-                );
+                error(`samospec: push-consent prompt interrupted (Ctrl-C).`);
                 return {
                   exitCode: 3,
                   stdout: lines.join("\n"),

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -19,9 +19,11 @@
  * No commits, no network.
  */
 
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 
 import type { Adapter, AuthStatus, Usage } from "../adapter/types.ts";
+import { loadPersistedConsent } from "../git/push-consent.ts";
 import { stateSchema } from "../state/types.ts";
 import {
   detectDegradedResolution,
@@ -191,6 +193,12 @@ export async function runStatus(input: StatusInput): Promise<StatusResult> {
     lines.push(`- ${formatDegradedSummary(deg)}`);
   }
 
+  // Push consent (SPEC §8) — one bullet per configured remote.
+  const consentLines = renderPushConsent(input.cwd);
+  for (const line of consentLines) {
+    lines.push(line);
+  }
+
   // Exit reason (when halted).
   if (state.exit !== null) {
     lines.push(
@@ -232,6 +240,41 @@ function computeNextAction(state: State, slug: string): string {
 function fmtMinutes(ms: number): string {
   const mins = ms / 60000;
   return `${mins.toFixed(1)}min`;
+}
+
+function renderPushConsent(cwd: string): string[] {
+  const remotes = listGitRemotes(cwd);
+  if (remotes.length === 0) return [];
+  const out: string[] = [];
+  out.push(`- push consent:`);
+  for (const { name, url } of remotes) {
+    let state: "granted" | "refused" | "not yet decided";
+    try {
+      const persisted = loadPersistedConsent({ repoPath: cwd, remoteUrl: url });
+      if (persisted === true) state = "granted";
+      else if (persisted === false) state = "refused";
+      else state = "not yet decided";
+    } catch {
+      state = "not yet decided";
+    }
+    out.push(`  - ${name} → ${state} (${url})`);
+  }
+  return out;
+}
+
+function listGitRemotes(cwd: string): { name: string; url: string }[] {
+  const res = spawnSync("git", ["remote", "-v"], { cwd, encoding: "utf8" });
+  if ((res.status ?? 1) !== 0) return [];
+  const seen = new Map<string, string>();
+  for (const line of (res.stdout ?? "").split("\n")) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 2) continue;
+    const name = parts[0];
+    const url = parts[1];
+    if (name === undefined || url === undefined) continue;
+    if (!seen.has(name)) seen.set(name, url);
+  }
+  return Array.from(seen, ([name, url]) => ({ name, url }));
 }
 
 function inferStatusResolutions(

--- a/src/git/push-consent.ts
+++ b/src/git/push-consent.ts
@@ -281,9 +281,7 @@ function readConfig(repoPath: string): JsonObject | null {
     );
   }
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    throw new Error(
-      `.samospec/config.json: top-level must be a JSON object.`,
-    );
+    throw new Error(`.samospec/config.json: top-level must be a JSON object.`);
   }
   return parsed as JsonObject;
 }

--- a/src/git/push-consent.ts
+++ b/src/git/push-consent.ts
@@ -1,0 +1,380 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §8 — first-push consent flow.
+ *
+ * Contract:
+ *   - The first time samospec would push in a repo, `requestPushConsent`
+ *     surfaces a prompt with remote name, remote URL, target branch,
+ *     default branch, and PR-creation capability.
+ *   - User answers `accept` / `refuse` → persisted to
+ *     `.samospec/config.json` under `git.push_consent.<remote-url>`.
+ *     Key is the remote URL (not name) so two remotes sharing a name on
+ *     different URLs get distinct decisions.
+ *   - Ctrl-C at the prompt surfaces as `interrupt` → exit 3 (SPEC §10).
+ *   - On subsequent sessions the persisted choice is honored silently
+ *     without re-prompting.
+ *   - Consent `refuse` is NOT exit 5 (exit 5 is reserved for preflight
+ *     cost refusal per SPEC §10). The session continues local-only.
+ *
+ * This module only handles consent and persistence — the actual
+ * `git push` invocation lives in src/git/push.ts.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+// ---------- types ----------
+
+export type PushConsentDecision = "accept" | "refuse" | "interrupt";
+
+export interface PrCapabilityProbe {
+  readonly available: boolean;
+  /** `gh` when GitHub is authenticated, `glab` when GitLab. */
+  readonly tool?: "gh" | "glab";
+}
+
+export interface PushConsentPrompt {
+  readonly remoteName: string;
+  readonly remoteUrl: string;
+  readonly targetBranch: string;
+  readonly defaultBranch: string;
+  readonly prCapability: PrCapabilityProbe;
+}
+
+export type PushConsentPromptFn = (
+  prompt: PushConsentPrompt,
+) => Promise<PushConsentDecision>;
+
+export interface RequestPushConsentOpts {
+  readonly repoPath: string;
+  readonly remoteName: string;
+  readonly remoteUrl: string;
+  readonly targetBranch: string;
+  readonly defaultBranch: string;
+  readonly prCapability: PrCapabilityProbe;
+  readonly prompt: PushConsentPromptFn;
+}
+
+export interface PushConsentOutcome {
+  readonly decision: PushConsentDecision;
+  /** Truthy when this invocation just wrote to .samospec/config.json. */
+  readonly persisted: boolean;
+  /** Exit code on `interrupt` (SPEC §10: 3). Undefined otherwise. */
+  readonly exitCode?: number;
+}
+
+// ---------- persistence helpers ----------
+
+export interface PersistConsentOpts {
+  readonly repoPath: string;
+  readonly remoteUrl: string;
+  readonly granted: boolean;
+}
+
+export interface LoadConsentOpts {
+  readonly repoPath: string;
+  readonly remoteUrl: string;
+}
+
+export interface ClearConsentOpts {
+  readonly repoPath: string;
+  readonly remoteUrl: string;
+}
+
+/**
+ * Return the persisted consent for a remote URL:
+ *   - `true`  → granted
+ *   - `false` → refused
+ *   - `null`  → not yet decided (prompt on first push)
+ *
+ * Throws if `.samospec/config.json` is present but malformed — we refuse
+ * to silently pass through when user configuration is corrupt.
+ */
+export function loadPersistedConsent(opts: LoadConsentOpts): boolean | null {
+  const cfg = readConfig(opts.repoPath);
+  if (cfg === null) return null;
+  const push = extractPushConsent(cfg);
+  const value = push[opts.remoteUrl];
+  if (value === undefined) return null;
+  if (typeof value !== "boolean") {
+    throw new Error(
+      `.samospec/config.json: git.push_consent[${JSON.stringify(
+        opts.remoteUrl,
+      )}] must be a boolean (got ${typeof value}).`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Persist `granted` as `git.push_consent.<remote-url>` in config.json.
+ * Creates the `.samospec/config.json` file if missing (keeps a schema_version
+ * so a later `samospec init` merges defaults without surprise).
+ */
+export function persistConsent(opts: PersistConsentOpts): void {
+  mutateConsent(opts.repoPath, (push) => {
+    push[opts.remoteUrl] = opts.granted;
+  });
+}
+
+/** Remove the stored consent for a remote URL. */
+export function clearPersistedConsent(opts: ClearConsentOpts): void {
+  mutateConsent(opts.repoPath, (push) => {
+    delete push[opts.remoteUrl];
+  });
+}
+
+// ---------- core request flow ----------
+
+export async function requestPushConsent(
+  opts: RequestPushConsentOpts,
+): Promise<PushConsentOutcome> {
+  const persisted = loadPersistedConsent({
+    repoPath: opts.repoPath,
+    remoteUrl: opts.remoteUrl,
+  });
+  if (persisted === true) {
+    return { decision: "accept", persisted: false };
+  }
+  if (persisted === false) {
+    return { decision: "refuse", persisted: false };
+  }
+
+  const decision = await opts.prompt({
+    remoteName: opts.remoteName,
+    remoteUrl: opts.remoteUrl,
+    targetBranch: opts.targetBranch,
+    defaultBranch: opts.defaultBranch,
+    prCapability: opts.prCapability,
+  });
+
+  if (decision === "interrupt") {
+    return { decision, persisted: false, exitCode: 3 };
+  }
+
+  persistConsent({
+    repoPath: opts.repoPath,
+    remoteUrl: opts.remoteUrl,
+    granted: decision === "accept",
+  });
+  return { decision, persisted: true };
+}
+
+// ---------- PR-capability probe ----------
+
+export interface PrCapabilityRunner {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface ProbePrCapabilityOpts {
+  readonly gh?: () => PrCapabilityRunner;
+  readonly glab?: () => PrCapabilityRunner;
+}
+
+/**
+ * Detect whether a PR-creation tool is authenticated on this host.
+ * Informational: the prompt surfaces it, never blocks on it. `gh` takes
+ * precedence when both are authenticated (v1 targets GitHub primarily).
+ *
+ * Tests inject stub runners; the default production runners exec
+ * `gh auth status` / `glab auth status` with silenced stdin.
+ */
+export function probePrCapability(
+  opts: ProbePrCapabilityOpts = {},
+): PrCapabilityProbe {
+  const ghRun = opts.gh ?? defaultGhProbe;
+  const glabRun = opts.glab ?? defaultGlabProbe;
+
+  const ghResult = safeRun(ghRun);
+  if (ghResult?.status === 0) {
+    return { available: true, tool: "gh" };
+  }
+  const glabResult = safeRun(glabRun);
+  if (glabResult?.status === 0) {
+    return { available: true, tool: "glab" };
+  }
+  return { available: false };
+}
+
+function defaultGhProbe(): PrCapabilityRunner {
+  const res = spawnSync("gh", ["auth", "status"], {
+    encoding: "utf8",
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+  });
+  return {
+    status: res.status ?? 1,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
+}
+
+function defaultGlabProbe(): PrCapabilityRunner {
+  const res = spawnSync("glab", ["auth", "status"], {
+    encoding: "utf8",
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+  });
+  return {
+    status: res.status ?? 1,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
+}
+
+function safeRun(
+  run: () => PrCapabilityRunner,
+): PrCapabilityRunner | undefined {
+  try {
+    return run();
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------- helpers to describe capability ----------
+
+/**
+ * Render a single-line human summary of PR capability suitable for the
+ * consent prompt. Kept module-local so CLI callers share the phrasing.
+ */
+export function describePrCapability(probe: PrCapabilityProbe): string {
+  if (!probe.available) return "PR creation unavailable (no gh/glab auth).";
+  if (probe.tool === "gh") return "PR creation available via gh.";
+  if (probe.tool === "glab") return "PR creation available via glab.";
+  return "PR creation available.";
+}
+
+// ---------- internal helpers ----------
+
+type JsonObject = Record<string, unknown>;
+
+const CONFIG_REL = path.join(".samospec", "config.json");
+
+function configPath(repoPath: string): string {
+  return path.join(repoPath, CONFIG_REL);
+}
+
+function readConfig(repoPath: string): JsonObject | null {
+  const file = configPath(repoPath);
+  if (!existsSync(file)) return null;
+  const raw = readFileSync(file, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `.samospec/config.json is not valid JSON: ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      `.samospec/config.json: top-level must be a JSON object.`,
+    );
+  }
+  return parsed as JsonObject;
+}
+
+function extractPushConsent(cfg: JsonObject): Record<string, unknown> {
+  const git = cfg["git"];
+  if (typeof git !== "object" || git === null || Array.isArray(git)) {
+    return {};
+  }
+  const push = (git as JsonObject)["push_consent"];
+  if (typeof push !== "object" || push === null || Array.isArray(push)) {
+    return {};
+  }
+  return push as Record<string, unknown>;
+}
+
+function mutateConsent(
+  repoPath: string,
+  mutator: (push: Record<string, boolean>) => void,
+): void {
+  const file = configPath(repoPath);
+  let cfg: JsonObject;
+  if (existsSync(file)) {
+    const existing = readConfig(repoPath);
+    cfg = existing ?? {};
+  } else {
+    cfg = { schema_version: 1 };
+  }
+
+  let gitBlock: JsonObject;
+  const existingGit = cfg["git"];
+  if (
+    typeof existingGit === "object" &&
+    existingGit !== null &&
+    !Array.isArray(existingGit)
+  ) {
+    gitBlock = existingGit as JsonObject;
+  } else {
+    gitBlock = {};
+    cfg["git"] = gitBlock;
+  }
+
+  let push: Record<string, boolean>;
+  const existingPush = gitBlock["push_consent"];
+  if (
+    typeof existingPush === "object" &&
+    existingPush !== null &&
+    !Array.isArray(existingPush)
+  ) {
+    push = existingPush as Record<string, boolean>;
+  } else {
+    push = {};
+    gitBlock["push_consent"] = push;
+  }
+
+  mutator(push);
+
+  cfg["git"] = gitBlock;
+  atomicWriteJson(file, cfg);
+}
+
+function atomicWriteJson(file: string, body: JsonObject): void {
+  const dir = path.dirname(file);
+  mkdirSync(dir, { recursive: true });
+  const tmp = path.join(dir, `.${path.basename(file)}.tmp.${process.pid}`);
+  const payload = `${JSON.stringify(body, null, 2)}\n`;
+  const fd = openSync(tmp, "w", 0o644);
+  try {
+    writeSync(fd, payload, 0, "utf8");
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  try {
+    renameSync(tmp, file);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+  try {
+    const dfd = openSync(dir, "r");
+    try {
+      fsyncSync(dfd);
+    } finally {
+      closeSync(dfd);
+    }
+  } catch {
+    /* platform-specific */
+  }
+}

--- a/src/git/push.ts
+++ b/src/git/push.ts
@@ -1,0 +1,84 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §8 — `pushBranch` helper.
+ *
+ * Guarantees:
+ *   - Never invokes git with a forbidden flag. The only argv shape is
+ *     `git push <remote> <branch>` — no refspec manipulation, no force,
+ *     no leading-plus push, no hook bypass. The no-force regression test
+ *     in `tests/git/no-force.test.ts` greps this source.
+ *   - `--no-push` invocation override beats persisted consent: if
+ *     `noPush: true`, we never exec git at all.
+ *   - Consent refused → no push attempt, state `skipped-refused`.
+ *     Consent accepted → push runs, state `pushed` on success,
+ *     `failed` on non-zero exit (stderr captured, not thrown — the loop
+ *     keeps running local-only).
+ */
+
+import { spawnSync } from "node:child_process";
+
+export interface PushBranchOpts {
+  readonly repoPath: string;
+  readonly remote: string;
+  readonly branch: string;
+  /** True when the user has accepted push consent (persisted or prompt). */
+  readonly granted: boolean;
+  /** True when `--no-push` / `--no-commit` is set for this invocation. */
+  readonly noPush: boolean;
+}
+
+export type PushBranchState =
+  | "pushed"
+  | "skipped-no-push"
+  | "skipped-refused"
+  | "failed";
+
+export interface PushBranchResult {
+  readonly state: PushBranchState;
+  /** stderr / reason when state is `failed`. */
+  readonly message?: string;
+}
+
+export function pushBranch(opts: PushBranchOpts): PushBranchResult {
+  assertNonEmpty(opts.remote, "remote");
+  assertNonEmpty(opts.branch, "branch");
+
+  // `--no-push` wins over everything (SPEC §8). Evaluate it first so the
+  // branch is never pushed regardless of consent state.
+  if (opts.noPush) {
+    return { state: "skipped-no-push" };
+  }
+  if (!opts.granted) {
+    return { state: "skipped-refused" };
+  }
+
+  // SPEC §8 safety: argv array only, no refspec rewrite, no force.
+  const argv: readonly string[] = ["push", opts.remote, opts.branch];
+  const res = spawnSync("git", argv as string[], {
+    cwd: opts.repoPath,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: "0",
+    },
+  });
+  const status = res.status ?? 1;
+  if (status !== 0) {
+    const detail = (res.stderr ?? "").trim() || (res.stdout ?? "").trim();
+    return {
+      state: "failed",
+      message:
+        detail.length > 0
+          ? detail
+          : `git push exited ${String(status)} without output.`,
+    };
+  }
+  return { state: "pushed" };
+}
+
+function assertNonEmpty(value: string, name: string): void {
+  if (value.length === 0) {
+    throw new Error(`pushBranch: '${name}' must be non-empty.`);
+  }
+}

--- a/tests/cli/status-push-consent.test.ts
+++ b/tests/cli/status-push-consent.test.ts
@@ -22,9 +22,13 @@ beforeEach(() => {
   spawnSync("git", ["init", "-q"], { cwd: tmp });
   spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: tmp });
   spawnSync("git", ["config", "user.name", "Test"], { cwd: tmp });
-  spawnSync("git", ["remote", "add", "origin", "git@example.invalid:me/x.git"], {
-    cwd: tmp,
-  });
+  spawnSync(
+    "git",
+    ["remote", "add", "origin", "git@example.invalid:me/x.git"],
+    {
+      cwd: tmp,
+    },
+  );
 });
 
 afterEach(() => {

--- a/tests/cli/status-push-consent.test.ts
+++ b/tests/cli/status-push-consent.test.ts
@@ -1,0 +1,140 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §8 — `samospec status` surfaces `push_consent` per remote URL.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import { runStatus, type StatusAdapterBinding } from "../../src/cli/status.ts";
+import { writeState } from "../../src/state/store.ts";
+import type { State } from "../../src/state/types.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-status-push-"));
+  spawnSync("git", ["init", "-q"], { cwd: tmp });
+  spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: tmp });
+  spawnSync("git", ["config", "user.name", "Test"], { cwd: tmp });
+  spawnSync("git", ["remote", "add", "origin", "git@example.invalid:me/x.git"], {
+    cwd: tmp,
+  });
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function seedState(slug: string): void {
+  const slugDir = path.join(tmp, ".samospec", "spec", slug);
+  mkdirSync(slugDir, { recursive: true });
+  const state: State = {
+    slug,
+    phase: "review_loop",
+    round_index: 1,
+    version: "0.2.0",
+    persona: { skill: "refunds", accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: "2026-04-19T12:00:00Z",
+    updated_at: "2026-04-19T12:00:00Z",
+  };
+  writeState(path.join(slugDir, "state.json"), state);
+}
+
+function bindings(): readonly StatusAdapterBinding[] {
+  return [
+    { role: "lead", adapter: createFakeAdapter({}) },
+    { role: "reviewer_a", adapter: createFakeAdapter({}) },
+    { role: "reviewer_b", adapter: createFakeAdapter({}) },
+  ];
+}
+
+describe("status — push_consent surfacing (SPEC §8)", () => {
+  test("shows 'push consent: refused' when the repo's remote URL is refused", async () => {
+    seedState("refunds");
+    writeFileSync(
+      path.join(tmp, ".samospec", "config.json"),
+      JSON.stringify(
+        {
+          schema_version: 1,
+          git: {
+            push_consent: {
+              "git@example.invalid:me/x.git": false,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    const res = await runStatus({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T12:00:00Z",
+      adapters: bindings(),
+    });
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("push consent");
+    expect(res.stdout).toContain("origin → refused");
+  });
+
+  test("shows 'granted' when persisted consent is true", async () => {
+    seedState("refunds");
+    writeFileSync(
+      path.join(tmp, ".samospec", "config.json"),
+      JSON.stringify(
+        {
+          schema_version: 1,
+          git: {
+            push_consent: {
+              "git@example.invalid:me/x.git": true,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    const res = await runStatus({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T12:00:00Z",
+      adapters: bindings(),
+    });
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("push consent");
+    expect(res.stdout).toContain("origin → granted");
+  });
+
+  test("shows 'not yet decided' when no persisted choice exists for this remote", async () => {
+    seedState("refunds");
+    writeFileSync(
+      path.join(tmp, ".samospec", "config.json"),
+      JSON.stringify({ schema_version: 1 }, null, 2),
+      "utf8",
+    );
+    const res = await runStatus({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T12:00:00Z",
+      adapters: bindings(),
+    });
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("push consent");
+    expect(res.stdout).toContain("origin → not yet decided");
+  });
+});

--- a/tests/git/push-consent.test.ts
+++ b/tests/git/push-consent.test.ts
@@ -1,0 +1,439 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §8 — first-push consent flow.
+ *
+ * Covers:
+ *   - Prompt payload includes remote name, target branch, default branch,
+ *     and PR-creation capability.
+ *   - `accept` → persisted to `.samospec/config.json` under
+ *     `git.push_consent.<remote-url>: true`.
+ *   - `refuse` → persisted as `false`.
+ *   - Persisted choice is respected silently (no reprompt).
+ *   - Distinct remote URLs get distinct persistence keys (key-by-URL).
+ *   - `--no-push` invocation override short-circuits even when consent is
+ *     persisted true.
+ *   - Ctrl-C / prompt abort surfaces as `interrupted` (exit 3).
+ *   - PR capability probe surfaces `unavailable` on missing tool.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  clearPersistedConsent,
+  loadPersistedConsent,
+  persistConsent,
+  probePrCapability,
+  requestPushConsent,
+  type PrCapabilityProbe,
+  type PushConsentPrompt,
+} from "../../src/git/push-consent.ts";
+import { createTempRepo } from "./helpers/tempRepo.ts";
+
+describe("push-consent persistence (git.push_consent.<remote-url>)", () => {
+  test("persistConsent writes to .samospec/config.json keyed by remote URL", () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      mkdirSync(samoDir, { recursive: true });
+      writeFileSync(
+        path.join(samoDir, "config.json"),
+        JSON.stringify({ schema_version: 1 }, null, 2) + "\n",
+        "utf8",
+      );
+
+      persistConsent({
+        repoPath: repo.dir,
+        remoteUrl: "git@github.com:foo/bar.git",
+        granted: true,
+      });
+
+      const raw = readFileSync(path.join(samoDir, "config.json"), "utf8");
+      const parsed = JSON.parse(raw) as {
+        git?: {
+          push_consent?: Record<string, boolean>;
+        };
+      };
+      expect(parsed.git?.push_consent?.["git@github.com:foo/bar.git"]).toBe(
+        true,
+      );
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  test("loadPersistedConsent returns saved choice", () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      mkdirSync(samoDir, { recursive: true });
+      writeFileSync(
+        path.join(samoDir, "config.json"),
+        JSON.stringify(
+          {
+            schema_version: 1,
+            git: {
+              push_consent: {
+                "https://github.com/foo/bar.git": false,
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      const out = loadPersistedConsent({
+        repoPath: repo.dir,
+        remoteUrl: "https://github.com/foo/bar.git",
+      });
+      expect(out).toBe(false);
+
+      const missing = loadPersistedConsent({
+        repoPath: repo.dir,
+        remoteUrl: "git@other:x.git",
+      });
+      expect(missing).toBeNull();
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  test("distinct remote URLs get distinct consent keys", () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      mkdirSync(samoDir, { recursive: true });
+      writeFileSync(
+        path.join(samoDir, "config.json"),
+        JSON.stringify({ schema_version: 1 }, null, 2) + "\n",
+        "utf8",
+      );
+
+      persistConsent({
+        repoPath: repo.dir,
+        remoteUrl: "git@github.com:me/a.git",
+        granted: true,
+      });
+      persistConsent({
+        repoPath: repo.dir,
+        remoteUrl: "git@gitlab.com:me/a.git",
+        granted: false,
+      });
+
+      expect(
+        loadPersistedConsent({
+          repoPath: repo.dir,
+          remoteUrl: "git@github.com:me/a.git",
+        }),
+      ).toBe(true);
+      expect(
+        loadPersistedConsent({
+          repoPath: repo.dir,
+          remoteUrl: "git@gitlab.com:me/a.git",
+        }),
+      ).toBe(false);
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  test("clearPersistedConsent removes the key", () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      mkdirSync(samoDir, { recursive: true });
+      writeFileSync(
+        path.join(samoDir, "config.json"),
+        JSON.stringify({ schema_version: 1 }, null, 2) + "\n",
+        "utf8",
+      );
+
+      persistConsent({
+        repoPath: repo.dir,
+        remoteUrl: "X",
+        granted: true,
+      });
+      clearPersistedConsent({ repoPath: repo.dir, remoteUrl: "X" });
+
+      expect(
+        loadPersistedConsent({ repoPath: repo.dir, remoteUrl: "X" }),
+      ).toBeNull();
+    } finally {
+      repo.cleanup();
+    }
+  });
+});
+
+describe("requestPushConsent — prompt shape + decisions", () => {
+  function baseOpts(repoDir: string): {
+    repoPath: string;
+    remoteName: string;
+    remoteUrl: string;
+    targetBranch: string;
+    defaultBranch: string;
+    prCapability: PrCapabilityProbe;
+  } {
+    return {
+      repoPath: repoDir,
+      remoteName: "origin",
+      remoteUrl: "git@github.com:me/app.git",
+      targetBranch: "samospec/refunds",
+      defaultBranch: "main",
+      prCapability: { available: true, tool: "gh" },
+    };
+  }
+
+  test("prompt shows remote, target branch, default branch, and PR capability", async () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      mkdirSync(samoDir, { recursive: true });
+      writeFileSync(
+        path.join(samoDir, "config.json"),
+        JSON.stringify({ schema_version: 1 }, null, 2) + "\n",
+        "utf8",
+      );
+
+      let payload: PushConsentPrompt | null = null;
+      const outcome = await requestPushConsent({
+        ...baseOpts(repo.dir),
+        prompt: async (p) => {
+          payload = p;
+          return "accept";
+        },
+      });
+      expect(outcome.decision).toBe("accept");
+      expect(payload).not.toBeNull();
+      expect(payload!.remoteName).toBe("origin");
+      expect(payload!.remoteUrl).toBe("git@github.com:me/app.git");
+      expect(payload!.targetBranch).toBe("samospec/refunds");
+      expect(payload!.defaultBranch).toBe("main");
+      expect(payload!.prCapability.available).toBe(true);
+      expect(payload!.prCapability.tool).toBe("gh");
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  test("accept persists push_consent.<url>=true and returns granted", async () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      mkdirSync(samoDir, { recursive: true });
+      writeFileSync(
+        path.join(samoDir, "config.json"),
+        JSON.stringify({ schema_version: 1 }, null, 2) + "\n",
+        "utf8",
+      );
+
+      const out = await requestPushConsent({
+        ...baseOpts(repo.dir),
+        prompt: async () => "accept",
+      });
+      expect(out.decision).toBe("accept");
+      expect(out.persisted).toBe(true);
+      expect(
+        loadPersistedConsent({
+          repoPath: repo.dir,
+          remoteUrl: "git@github.com:me/app.git",
+        }),
+      ).toBe(true);
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  test("refuse persists push_consent.<url>=false", async () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      mkdirSync(samoDir, { recursive: true });
+      writeFileSync(
+        path.join(samoDir, "config.json"),
+        JSON.stringify({ schema_version: 1 }, null, 2) + "\n",
+        "utf8",
+      );
+
+      const out = await requestPushConsent({
+        ...baseOpts(repo.dir),
+        prompt: async () => "refuse",
+      });
+      expect(out.decision).toBe("refuse");
+      expect(out.persisted).toBe(true);
+      expect(
+        loadPersistedConsent({
+          repoPath: repo.dir,
+          remoteUrl: "git@github.com:me/app.git",
+        }),
+      ).toBe(false);
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  test("persisted choice short-circuits reprompt silently", async () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      mkdirSync(samoDir, { recursive: true });
+      writeFileSync(
+        path.join(samoDir, "config.json"),
+        JSON.stringify(
+          {
+            schema_version: 1,
+            git: {
+              push_consent: {
+                "git@github.com:me/app.git": true,
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      let promptCalls = 0;
+      const out = await requestPushConsent({
+        ...baseOpts(repo.dir),
+        prompt: async () => {
+          promptCalls += 1;
+          return "accept";
+        },
+      });
+      expect(promptCalls).toBe(0);
+      expect(out.decision).toBe("accept");
+      expect(out.persisted).toBe(false);
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  test("persisted false is respected silently (no reprompt)", async () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      mkdirSync(samoDir, { recursive: true });
+      writeFileSync(
+        path.join(samoDir, "config.json"),
+        JSON.stringify(
+          {
+            schema_version: 1,
+            git: {
+              push_consent: {
+                "git@github.com:me/app.git": false,
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      let promptCalls = 0;
+      const out = await requestPushConsent({
+        ...baseOpts(repo.dir),
+        prompt: async () => {
+          promptCalls += 1;
+          return "accept";
+        },
+      });
+      expect(promptCalls).toBe(0);
+      expect(out.decision).toBe("refuse");
+      expect(out.persisted).toBe(false);
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  test("prompt returning 'interrupt' surfaces exit code 3", async () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      mkdirSync(samoDir, { recursive: true });
+      writeFileSync(
+        path.join(samoDir, "config.json"),
+        JSON.stringify({ schema_version: 1 }, null, 2) + "\n",
+        "utf8",
+      );
+
+      const out = await requestPushConsent({
+        ...baseOpts(repo.dir),
+        prompt: async () => "interrupt",
+      });
+      expect(out.decision).toBe("interrupt");
+      expect(out.exitCode).toBe(3);
+      expect(out.persisted).toBe(false);
+    } finally {
+      repo.cleanup();
+    }
+  });
+});
+
+describe("probePrCapability", () => {
+  test("reports 'unavailable' when both gh and glab fail", () => {
+    const probe = probePrCapability({
+      gh: () => ({ status: 1, stdout: "", stderr: "" }),
+      glab: () => ({ status: 1, stdout: "", stderr: "" }),
+    });
+    expect(probe.available).toBe(false);
+  });
+
+  test("reports 'gh' when gh auth status succeeds", () => {
+    const probe = probePrCapability({
+      gh: () => ({ status: 0, stdout: "Logged in", stderr: "" }),
+      glab: () => ({ status: 1, stdout: "", stderr: "" }),
+    });
+    expect(probe.available).toBe(true);
+    expect(probe.tool).toBe("gh");
+  });
+
+  test("reports 'glab' when glab succeeds but gh fails", () => {
+    const probe = probePrCapability({
+      gh: () => ({ status: 1, stdout: "", stderr: "" }),
+      glab: () => ({ status: 0, stdout: "Logged in", stderr: "" }),
+    });
+    expect(probe.available).toBe(true);
+    expect(probe.tool).toBe("glab");
+  });
+});
+
+describe("config corruption surfaces on load, not silent passthrough", () => {
+  test("loadPersistedConsent throws on malformed JSON", () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      mkdirSync(samoDir, { recursive: true });
+      writeFileSync(path.join(samoDir, "config.json"), "not json", "utf8");
+      expect(() =>
+        loadPersistedConsent({
+          repoPath: repo.dir,
+          remoteUrl: "X",
+        }),
+      ).toThrow();
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  test("loadPersistedConsent returns null when config.json is absent", () => {
+    const repo = createTempRepo();
+    try {
+      const samoDir = path.join(repo.dir, ".samospec");
+      expect(existsSync(samoDir)).toBe(false);
+      expect(
+        loadPersistedConsent({
+          repoPath: repo.dir,
+          remoteUrl: "X",
+        }),
+      ).toBeNull();
+    } finally {
+      repo.cleanup();
+    }
+  });
+});

--- a/tests/git/push-consent.test.ts
+++ b/tests/git/push-consent.test.ts
@@ -201,9 +201,9 @@ describe("requestPushConsent — prompt shape + decisions", () => {
       let payload: PushConsentPrompt | null = null;
       const outcome = await requestPushConsent({
         ...baseOpts(repo.dir),
-        prompt: async (p) => {
+        prompt: (p) => {
           payload = p;
-          return "accept";
+          return Promise.resolve("accept");
         },
       });
       expect(outcome.decision).toBe("accept");
@@ -232,7 +232,7 @@ describe("requestPushConsent — prompt shape + decisions", () => {
 
       const out = await requestPushConsent({
         ...baseOpts(repo.dir),
-        prompt: async () => "accept",
+        prompt: () => Promise.resolve("accept"),
       });
       expect(out.decision).toBe("accept");
       expect(out.persisted).toBe(true);
@@ -260,7 +260,7 @@ describe("requestPushConsent — prompt shape + decisions", () => {
 
       const out = await requestPushConsent({
         ...baseOpts(repo.dir),
-        prompt: async () => "refuse",
+        prompt: () => Promise.resolve("refuse"),
       });
       expect(out.decision).toBe("refuse");
       expect(out.persisted).toBe(true);
@@ -300,9 +300,9 @@ describe("requestPushConsent — prompt shape + decisions", () => {
       let promptCalls = 0;
       const out = await requestPushConsent({
         ...baseOpts(repo.dir),
-        prompt: async () => {
+        prompt: () => {
           promptCalls += 1;
-          return "accept";
+          return Promise.resolve("accept");
         },
       });
       expect(promptCalls).toBe(0);
@@ -338,9 +338,9 @@ describe("requestPushConsent — prompt shape + decisions", () => {
       let promptCalls = 0;
       const out = await requestPushConsent({
         ...baseOpts(repo.dir),
-        prompt: async () => {
+        prompt: () => {
           promptCalls += 1;
-          return "accept";
+          return Promise.resolve("accept");
         },
       });
       expect(promptCalls).toBe(0);
@@ -364,7 +364,7 @@ describe("requestPushConsent — prompt shape + decisions", () => {
 
       const out = await requestPushConsent({
         ...baseOpts(repo.dir),
-        prompt: async () => "interrupt",
+        prompt: () => Promise.resolve("interrupt"),
       });
       expect(out.decision).toBe("interrupt");
       expect(out.exitCode).toBe(3);

--- a/tests/git/push-no-force.test.ts
+++ b/tests/git/push-no-force.test.ts
@@ -12,7 +12,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -130,4 +136,3 @@ describe("pushBranch runtime argv: no forbidden flags", () => {
     }
   });
 });
-

--- a/tests/git/push-no-force.test.ts
+++ b/tests/git/push-no-force.test.ts
@@ -1,0 +1,133 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Forbidden-flag regression specific to Sprint 4 #31's pushBranch helper.
+ * tests/git/no-force.test.ts greps the src/git tree for dangerous
+ * tokens; this suite exercises the runtime path to prove the argv that
+ * reaches git push never carries one.
+ *
+ * Approach: shim the $PATH so `git push ...` resolves to a wrapper
+ * script that records its argv to a file and exits 0. Then inspect the
+ * recorded argv for forbidden tokens.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { pushBranch } from "../../src/git/push.ts";
+
+const FORBIDDEN_TOKENS = [
+  "--force",
+  "--force-with-lease",
+  "-f",
+  "--no-verify",
+  "+refs/",
+];
+
+let shimDir: string;
+let argvLog: string;
+let savedPath: string | undefined;
+
+beforeEach(() => {
+  shimDir = mkdtempSync(path.join(tmpdir(), "samospec-push-shim-"));
+  argvLog = path.join(shimDir, "argv.log");
+  // bash shim that records argv (one arg per line) and exits 0.
+  const shimScript = [
+    "#!/usr/bin/env bash",
+    "set -Eeuo pipefail",
+    `printf '%s\\n' "$@" > "${argvLog}"`,
+    "exit 0",
+  ].join("\n");
+  writeFileSync(path.join(shimDir, "git"), shimScript, "utf8");
+  chmodSync(path.join(shimDir, "git"), 0o755);
+  savedPath = process.env["PATH"];
+  process.env["PATH"] = `${shimDir}:${savedPath ?? ""}`;
+});
+
+afterEach(() => {
+  if (savedPath !== undefined) {
+    process.env["PATH"] = savedPath;
+  } else {
+    delete process.env["PATH"];
+  }
+  rmSync(shimDir, { recursive: true, force: true });
+});
+
+describe("pushBranch runtime argv: no forbidden flags", () => {
+  test("argv observed by `git` contains exactly ['push', '<remote>', '<branch>']", () => {
+    // Use a fake repoPath — the shim ignores cwd.
+    const fakeRepo = mkdtempSync(path.join(tmpdir(), "samospec-push-repo-"));
+    try {
+      const result = pushBranch({
+        repoPath: fakeRepo,
+        remote: "origin",
+        branch: "samospec/refunds",
+        granted: true,
+        noPush: false,
+      });
+      expect(result.state).toBe("pushed");
+      const argv = readFileSync(argvLog, "utf8")
+        .split("\n")
+        .filter((l) => l.length > 0);
+      expect(argv).toEqual(["push", "origin", "samospec/refunds"]);
+
+      for (const token of FORBIDDEN_TOKENS) {
+        for (const arg of argv) {
+          expect(arg.includes(token)).toBe(false);
+        }
+      }
+    } finally {
+      rmSync(fakeRepo, { recursive: true, force: true });
+    }
+  });
+
+  test("no invocation emitted when noPush=true (shim never runs)", () => {
+    const fakeRepo = mkdtempSync(path.join(tmpdir(), "samospec-push-repo-"));
+    try {
+      const result = pushBranch({
+        repoPath: fakeRepo,
+        remote: "origin",
+        branch: "samospec/refunds",
+        granted: true,
+        noPush: true,
+      });
+      expect(result.state).toBe("skipped-no-push");
+      // argvLog wasn't created because the shim was never invoked.
+      let exists = true;
+      try {
+        readFileSync(argvLog, "utf8");
+      } catch {
+        exists = false;
+      }
+      expect(exists).toBe(false);
+    } finally {
+      rmSync(fakeRepo, { recursive: true, force: true });
+    }
+  });
+
+  test("no invocation emitted when granted=false", () => {
+    const fakeRepo = mkdtempSync(path.join(tmpdir(), "samospec-push-repo-"));
+    try {
+      const result = pushBranch({
+        repoPath: fakeRepo,
+        remote: "origin",
+        branch: "samospec/refunds",
+        granted: false,
+        noPush: false,
+      });
+      expect(result.state).toBe("skipped-refused");
+      let exists = true;
+      try {
+        readFileSync(argvLog, "utf8");
+      } catch {
+        exists = false;
+      }
+      expect(exists).toBe(false);
+    } finally {
+      rmSync(fakeRepo, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/tests/git/push.test.ts
+++ b/tests/git/push.test.ts
@@ -61,7 +61,13 @@ describe("pushBranch — real bare remote integration", () => {
 
       const ls = spawnSync(
         "git",
-        ["--git-dir", bare, "show-ref", "--verify", "refs/heads/samospec/refunds"],
+        [
+          "--git-dir",
+          bare,
+          "show-ref",
+          "--verify",
+          "refs/heads/samospec/refunds",
+        ],
         { encoding: "utf8" },
       );
       expect(ls.status).toBe(0);

--- a/tests/git/push.test.ts
+++ b/tests/git/push.test.ts
@@ -1,0 +1,165 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §8 — `pushBranch` contract.
+ *
+ * - Pushes `git push <remote> <branch>` (never `--force`, `--force-with-lease`,
+ *   `+refs/`, `--no-verify`).
+ * - Honors `noPush: true` → no push attempt, result state `skipped-no-push`.
+ * - Honors consent `refuse` → no push attempt, result state `skipped-refused`.
+ * - Ungated consent accept → pushes and reports `pushed`.
+ * - Uses argv arrays only (no shell concat).
+ * - Integration test: drives a real temp bare remote; confirms the ref
+ *   lands on the remote after push.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { pushBranch } from "../../src/git/push.ts";
+import { createTempRepo } from "./helpers/tempRepo.ts";
+
+function makeBareRemote(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "samospec-bare-remote-"));
+  const res = spawnSync("git", ["init", "--bare", "--initial-branch", "main"], {
+    cwd: dir,
+    encoding: "utf8",
+  });
+  if (res.status !== 0) {
+    throw new Error(`bare init failed: ${res.stderr}`);
+  }
+  return dir;
+}
+
+function cleanupDir(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+describe("pushBranch — real bare remote integration", () => {
+  test("granted consent: pushes the branch and ref lands on the remote", () => {
+    const repo = createTempRepo();
+    const bare = makeBareRemote();
+    try {
+      // Wire origin → bare remote.
+      repo.run(["remote", "add", "origin", bare]);
+      repo.run(["checkout", "-b", "samospec/refunds"]);
+      writeFileSync(path.join(repo.dir, "touch.txt"), "x\n");
+      repo.run(["add", "touch.txt"]);
+      repo.run(["commit", "-m", "spec(refunds): draft v0.1"]);
+
+      const result = pushBranch({
+        repoPath: repo.dir,
+        remote: "origin",
+        branch: "samospec/refunds",
+        granted: true,
+        noPush: false,
+      });
+      expect(result.state).toBe("pushed");
+
+      const ls = spawnSync(
+        "git",
+        ["--git-dir", bare, "show-ref", "--verify", "refs/heads/samospec/refunds"],
+        { encoding: "utf8" },
+      );
+      expect(ls.status).toBe(0);
+      expect(ls.stdout).toContain("refs/heads/samospec/refunds");
+    } finally {
+      repo.cleanup();
+      cleanupDir(bare);
+    }
+  });
+
+  test("noPush=true skips even with granted consent; ref never hits remote", () => {
+    const repo = createTempRepo();
+    const bare = makeBareRemote();
+    try {
+      repo.run(["remote", "add", "origin", bare]);
+      repo.run(["checkout", "-b", "samospec/refunds"]);
+      writeFileSync(path.join(repo.dir, "touch.txt"), "x\n");
+      repo.run(["add", "touch.txt"]);
+      repo.run(["commit", "-m", "spec(refunds): draft v0.1"]);
+
+      const result = pushBranch({
+        repoPath: repo.dir,
+        remote: "origin",
+        branch: "samospec/refunds",
+        granted: true,
+        noPush: true,
+      });
+      expect(result.state).toBe("skipped-no-push");
+
+      const ls = spawnSync(
+        "git",
+        ["--git-dir", bare, "show-ref", "refs/heads/samospec/refunds"],
+        { encoding: "utf8", cwd: bare },
+      );
+      expect(ls.status).not.toBe(0);
+    } finally {
+      repo.cleanup();
+      cleanupDir(bare);
+    }
+  });
+
+  test("granted=false (consent refused): no push attempt", () => {
+    const repo = createTempRepo();
+    const bare = makeBareRemote();
+    try {
+      repo.run(["remote", "add", "origin", bare]);
+      repo.run(["checkout", "-b", "samospec/refunds"]);
+      writeFileSync(path.join(repo.dir, "touch.txt"), "x\n");
+      repo.run(["add", "touch.txt"]);
+      repo.run(["commit", "-m", "spec(refunds): draft v0.1"]);
+
+      const result = pushBranch({
+        repoPath: repo.dir,
+        remote: "origin",
+        branch: "samospec/refunds",
+        granted: false,
+        noPush: false,
+      });
+      expect(result.state).toBe("skipped-refused");
+
+      const ls = spawnSync(
+        "git",
+        ["--git-dir", bare, "show-ref", "refs/heads/samospec/refunds"],
+        { encoding: "utf8", cwd: bare },
+      );
+      expect(ls.status).not.toBe(0);
+    } finally {
+      repo.cleanup();
+      cleanupDir(bare);
+    }
+  });
+
+  test("push failure returns { state: 'failed' } with captured stderr (no throw)", () => {
+    const repo = createTempRepo();
+    try {
+      // Configure a bogus remote URL so push fails.
+      repo.run([
+        "remote",
+        "add",
+        "origin",
+        path.join(repo.dir, "does-not-exist.git"),
+      ]);
+      repo.run(["checkout", "-b", "samospec/x"]);
+      writeFileSync(path.join(repo.dir, "touch.txt"), "x\n");
+      repo.run(["add", "touch.txt"]);
+      repo.run(["commit", "-m", "spec(x): draft v0.1"]);
+
+      const result = pushBranch({
+        repoPath: repo.dir,
+        remote: "origin",
+        branch: "samospec/x",
+        granted: true,
+        noPush: false,
+      });
+      expect(result.state).toBe("failed");
+      expect(result.message?.length ?? 0).toBeGreaterThan(0);
+    } finally {
+      repo.cleanup();
+    }
+  });
+});

--- a/tests/loop/push-round-boundary.test.ts
+++ b/tests/loop/push-round-boundary.test.ts
@@ -265,12 +265,12 @@ describe("iterate — round-boundary push integration", () => {
     // The branch on the bare remote has two refine commits plus the
     // seed commit — one push per round boundary landed the latest tip.
     const commits = logOnBare("samospec/refunds");
-    expect(commits.some((c) => c.startsWith("spec(refunds): refine v0.2"))).toBe(
-      true,
-    );
-    expect(commits.some((c) => c.startsWith("spec(refunds): refine v0.3"))).toBe(
-      true,
-    );
+    expect(
+      commits.some((c) => c.startsWith("spec(refunds): refine v0.2")),
+    ).toBe(true);
+    expect(
+      commits.some((c) => c.startsWith("spec(refunds): refine v0.3")),
+    ).toBe(true);
   });
 
   test("--no-push override: persisted consent = true, invocation flag skips all pushes", async () => {
@@ -468,9 +468,9 @@ describe("iterate — round-boundary push integration", () => {
       expect(resA.exitCode).toBe(0);
 
       const refs = refsOnBare();
-      expect(
-        refs.some((r) => r.includes("refs/heads/samospec/refunds")),
-      ).toBe(true);
+      expect(refs.some((r) => r.includes("refs/heads/samospec/refunds"))).toBe(
+        true,
+      );
 
       const mirrorRefs = spawnSync(
         "git",
@@ -483,10 +483,7 @@ describe("iterate — round-boundary push integration", () => {
 
       // Config should still reflect both choices verbatim.
       const cfg = JSON.parse(
-        readFileSync(
-          path.join(tmp, ".samospec", "config.json"),
-          "utf8",
-        ),
+        readFileSync(path.join(tmp, ".samospec", "config.json"), "utf8"),
       ) as {
         git: { push_consent: Record<string, boolean> };
       };

--- a/tests/loop/push-round-boundary.test.ts
+++ b/tests/loop/push-round-boundary.test.ts
@@ -1,0 +1,499 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §5 Phase 6 + §8 — round-boundary push integration.
+ *
+ * Tests the contract between `runIterate` and the push-consent +
+ * pushBranch helpers:
+ *
+ *   - Consent `accept` + 2 rounds to ready → exactly 2 pushes land on
+ *     the real bare remote, not 2 * N commits' worth.
+ *   - `--no-push` invocation override wins over persisted-accept.
+ *   - Persisted `refuse` skips all pushes silently; no prompt fires
+ *     during the loop; the loop exits 0 (not 5) — SPEC §10 reserves
+ *     exit 5 for preflight refusal.
+ *   - Prompt fires only once per session (first round); subsequent
+ *     rounds respect the session decision without re-prompting.
+ *   - Ctrl-C at first consent prompt → exit 3.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type { Adapter, CritiqueOutput } from "../../src/adapter/types.ts";
+import { runIterate, type IterateResolvers } from "../../src/cli/iterate.ts";
+import { writeState } from "../../src/state/store.ts";
+import type { State } from "../../src/state/types.ts";
+
+let tmp: string;
+let bare: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-push-iter-"));
+  bare = mkdtempSync(path.join(tmpdir(), "samospec-push-bare-"));
+  spawnSync("git", ["init", "--bare", "--initial-branch", "main"], {
+    cwd: bare,
+  });
+  initRepo(tmp, bare);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  rmSync(bare, { recursive: true, force: true });
+});
+
+function initRepo(cwd: string, bareUrl: string): void {
+  spawnSync("git", ["init", "-q", "--initial-branch", "main"], { cwd });
+  spawnSync("git", ["config", "user.email", "test@example.com"], { cwd });
+  spawnSync("git", ["config", "user.name", "Test"], { cwd });
+  spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd });
+  writeFileSync(path.join(cwd, "README.md"), "seed\n", "utf8");
+  spawnSync("git", ["add", "README.md"], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "seed"], { cwd });
+  spawnSync("git", ["remote", "add", "origin", bareUrl], { cwd });
+  spawnSync("git", ["checkout", "-q", "-b", "samospec/refunds"], { cwd });
+}
+
+function seedSpec(cwd: string, slug: string): void {
+  const slugDir = path.join(cwd, ".samospec", "spec", slug);
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(
+    path.join(slugDir, "SPEC.md"),
+    "# SPEC\n\nv0.1 body\n- initial requirement\n",
+    "utf8",
+  );
+  writeFileSync(path.join(slugDir, "TLDR.md"), "# TLDR\n\n- stub\n", "utf8");
+  writeFileSync(
+    path.join(slugDir, "decisions.md"),
+    "# decisions\n\n- No review-loop decisions yet.\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "changelog.md"),
+    "# changelog\n\n## v0.1 — seed\n\n- initial\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "interview.json"),
+    JSON.stringify({
+      slug,
+      persona: 'Veteran "refunds" expert',
+      generated_at: "2026-04-19T12:00:00Z",
+      questions: [],
+      answers: [],
+    }),
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "context.json"),
+    JSON.stringify({
+      phase: "draft",
+      files: [],
+      risk_flags: [],
+      budget: { phase: "draft", tokens_used: 0, tokens_budget: 0 },
+    }),
+    "utf8",
+  );
+  const state: State = {
+    slug,
+    phase: "review_loop",
+    round_index: 0,
+    version: "0.1.0",
+    persona: { skill: "refunds", accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: "2026-04-19T12:00:00Z",
+    updated_at: "2026-04-19T12:00:00Z",
+  };
+  writeState(path.join(slugDir, "state.json"), state);
+  // .samospec/config.json so the consent layer has a real file.
+  writeFileSync(
+    path.join(cwd, ".samospec", "config.json"),
+    JSON.stringify({ schema_version: 1 }, null, 2) + "\n",
+    "utf8",
+  );
+  spawnSync("git", ["add", "."], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "spec(refunds): draft v0.1"], {
+    cwd,
+  });
+}
+
+const BASE_RESOLVERS: IterateResolvers = {
+  onManualEdit: () => Promise.resolve("incorporate"),
+  onDegraded: () => Promise.resolve("accept"),
+  onReviewerExhausted: () => Promise.resolve("abort"),
+};
+const DEFAULT_TIME_INPUTS = {
+  sessionStartedAtMs: 0,
+  nowMs: 0,
+  maxWallClockMs: 60 * 60 * 1000,
+};
+
+function buildCritique(suffix: number): CritiqueOutput {
+  return {
+    findings: [
+      {
+        category: "ambiguity",
+        text: `finding #${String(suffix)} in spec body`,
+        severity: "minor",
+      },
+    ],
+    summary: `round ${String(suffix)} summary`,
+    suggested_next_version: `0.${String(suffix + 1)}`,
+    usage: null,
+    effort_used: "max",
+  };
+}
+
+function makeLead(readyOnRound: number): Adapter {
+  let roundCounter = 0;
+  return {
+    vendor: "fake",
+    detect: () =>
+      Promise.resolve({ installed: true, version: "x", path: "/x" }),
+    auth_status: () => Promise.resolve({ authenticated: true }),
+    supports_structured_output: () => true,
+    supports_effort: () => true,
+    models: () => Promise.resolve([{ id: "x", family: "fake" }]),
+    ask: () => Promise.reject(new Error("unused")),
+    critique: () => Promise.reject(new Error("unused")),
+    revise: () => {
+      roundCounter += 1;
+      return Promise.resolve({
+        spec: `# SPEC\n\nrevised body round ${String(roundCounter)}\n- item ${String(roundCounter)}\n`,
+        ready: roundCounter >= readyOnRound,
+        rationale: JSON.stringify([
+          {
+            finding_ref: "codex#1",
+            decision: "accepted",
+            rationale: `applied round ${String(roundCounter)}`,
+          },
+        ]),
+        usage: null,
+        effort_used: "max",
+      });
+    },
+  };
+}
+
+function makeCritiqueAdapter(): Adapter {
+  let cCounter = 0;
+  return {
+    ...createFakeAdapter({}),
+    critique: () => {
+      cCounter += 1;
+      return Promise.resolve(buildCritique(cCounter));
+    },
+  };
+}
+
+function refsOnBare(): string[] {
+  const res = spawnSync("git", ["--git-dir", bare, "show-ref"], {
+    encoding: "utf8",
+  });
+  return res.stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+function logOnBare(branch: string): string[] {
+  const res = spawnSync(
+    "git",
+    ["--git-dir", bare, "log", "--format=%s", branch],
+    { encoding: "utf8" },
+  );
+  if (res.status !== 0) return [];
+  return res.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+describe("iterate — round-boundary push integration", () => {
+  test("accept consent + 2-round loop → exactly 2 pushes, 1 prompt", async () => {
+    seedSpec(tmp, "refunds");
+
+    let promptCalls = 0;
+    const res = await runIterate({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T12:00:00Z",
+      resolvers: {
+        ...BASE_RESOLVERS,
+        onPushConsent: () => {
+          promptCalls += 1;
+          return Promise.resolve("accept");
+        },
+      },
+      adapters: {
+        lead: makeLead(2),
+        reviewerA: makeCritiqueAdapter(),
+        reviewerB: makeCritiqueAdapter(),
+      },
+      maxRounds: 5,
+      pushOptions: { remote: "origin", noPush: false },
+      ...DEFAULT_TIME_INPUTS,
+    });
+
+    expect(res.exitCode).toBe(0);
+    expect(res.roundsRun).toBe(2);
+    expect(promptCalls).toBe(1);
+
+    // Branch should exist on the bare remote.
+    const refs = refsOnBare();
+    const branchRef = refs.find((r) =>
+      r.includes("refs/heads/samospec/refunds"),
+    );
+    expect(branchRef).toBeDefined();
+
+    // The branch on the bare remote has two refine commits plus the
+    // seed commit — one push per round boundary landed the latest tip.
+    const commits = logOnBare("samospec/refunds");
+    expect(commits.some((c) => c.startsWith("spec(refunds): refine v0.2"))).toBe(
+      true,
+    );
+    expect(commits.some((c) => c.startsWith("spec(refunds): refine v0.3"))).toBe(
+      true,
+    );
+  });
+
+  test("--no-push override: persisted consent = true, invocation flag skips all pushes", async () => {
+    seedSpec(tmp, "refunds");
+    // Pre-persist consent = true so the loop would push by default.
+    writeFileSync(
+      path.join(tmp, ".samospec", "config.json"),
+      JSON.stringify(
+        {
+          schema_version: 1,
+          git: { push_consent: { [bare]: true } },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const res = await runIterate({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T12:00:00Z",
+      resolvers: {
+        ...BASE_RESOLVERS,
+        onPushConsent: () => Promise.resolve("accept"),
+      },
+      adapters: {
+        lead: makeLead(2),
+        reviewerA: makeCritiqueAdapter(),
+        reviewerB: makeCritiqueAdapter(),
+      },
+      maxRounds: 5,
+      pushOptions: { remote: "origin", noPush: true },
+      ...DEFAULT_TIME_INPUTS,
+    });
+
+    expect(res.exitCode).toBe(0);
+    // Bare remote must not have received samospec/refunds.
+    const refs = refsOnBare();
+    const branchRef = refs.find((r) =>
+      r.includes("refs/heads/samospec/refunds"),
+    );
+    expect(branchRef).toBeUndefined();
+  });
+
+  test("persisted refuse: no prompt, no pushes, exits 0 (not 5)", async () => {
+    seedSpec(tmp, "refunds");
+    writeFileSync(
+      path.join(tmp, ".samospec", "config.json"),
+      JSON.stringify(
+        {
+          schema_version: 1,
+          git: { push_consent: { [bare]: false } },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    let promptCalls = 0;
+    const res = await runIterate({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T12:00:00Z",
+      resolvers: {
+        ...BASE_RESOLVERS,
+        onPushConsent: () => {
+          promptCalls += 1;
+          return Promise.resolve("accept");
+        },
+      },
+      adapters: {
+        lead: makeLead(2),
+        reviewerA: makeCritiqueAdapter(),
+        reviewerB: makeCritiqueAdapter(),
+      },
+      maxRounds: 5,
+      pushOptions: { remote: "origin", noPush: false },
+      ...DEFAULT_TIME_INPUTS,
+    });
+
+    expect(res.exitCode).toBe(0);
+    expect(promptCalls).toBe(0);
+    const refs = refsOnBare();
+    const branchRef = refs.find((r) =>
+      r.includes("refs/heads/samospec/refunds"),
+    );
+    expect(branchRef).toBeUndefined();
+  });
+
+  test("Ctrl-C at first consent prompt → exit 3", async () => {
+    seedSpec(tmp, "refunds");
+
+    const res = await runIterate({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T12:00:00Z",
+      resolvers: {
+        ...BASE_RESOLVERS,
+        onPushConsent: () => Promise.resolve("interrupt"),
+      },
+      adapters: {
+        lead: makeLead(1),
+        reviewerA: makeCritiqueAdapter(),
+        reviewerB: makeCritiqueAdapter(),
+      },
+      maxRounds: 5,
+      pushOptions: { remote: "origin", noPush: false },
+      ...DEFAULT_TIME_INPUTS,
+    });
+
+    expect(res.exitCode).toBe(3);
+  });
+
+  test("no pushOptions provided → local-only (no push attempts, no prompt)", async () => {
+    seedSpec(tmp, "refunds");
+
+    let promptCalls = 0;
+    const res = await runIterate({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T12:00:00Z",
+      resolvers: {
+        ...BASE_RESOLVERS,
+        onPushConsent: () => {
+          promptCalls += 1;
+          return Promise.resolve("accept");
+        },
+      },
+      adapters: {
+        lead: makeLead(1),
+        reviewerA: makeCritiqueAdapter(),
+        reviewerB: makeCritiqueAdapter(),
+      },
+      maxRounds: 5,
+      ...DEFAULT_TIME_INPUTS,
+    });
+
+    expect(res.exitCode).toBe(0);
+    expect(promptCalls).toBe(0);
+    const refs = refsOnBare();
+    const branchRef = refs.find((r) =>
+      r.includes("refs/heads/samospec/refunds"),
+    );
+    expect(branchRef).toBeUndefined();
+  });
+
+  test("distinct remotes with different persisted choices are honored independently", async () => {
+    seedSpec(tmp, "refunds");
+    // Add a second remote URL and persist opposite choices.
+    const otherBare = mkdtempSync(path.join(tmpdir(), "samospec-push-bare-2-"));
+    spawnSync("git", ["init", "--bare", "--initial-branch", "main"], {
+      cwd: otherBare,
+    });
+    try {
+      spawnSync("git", ["remote", "add", "mirror", otherBare], { cwd: tmp });
+
+      writeFileSync(
+        path.join(tmp, ".samospec", "config.json"),
+        JSON.stringify(
+          {
+            schema_version: 1,
+            git: {
+              push_consent: {
+                [bare]: true,
+                [otherBare]: false,
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      // Run two single-round loops, once per remote.
+      const resA = await runIterate({
+        cwd: tmp,
+        slug: "refunds",
+        now: "2026-04-19T12:00:00Z",
+        resolvers: {
+          ...BASE_RESOLVERS,
+          onPushConsent: () => Promise.resolve("accept"),
+        },
+        adapters: {
+          lead: makeLead(1),
+          reviewerA: makeCritiqueAdapter(),
+          reviewerB: makeCritiqueAdapter(),
+        },
+        maxRounds: 1,
+        pushOptions: { remote: "origin", noPush: false },
+        ...DEFAULT_TIME_INPUTS,
+      });
+      expect(resA.exitCode).toBe(0);
+
+      const refs = refsOnBare();
+      expect(
+        refs.some((r) => r.includes("refs/heads/samospec/refunds")),
+      ).toBe(true);
+
+      const mirrorRefs = spawnSync(
+        "git",
+        ["--git-dir", otherBare, "show-ref"],
+        { encoding: "utf8" },
+      );
+      expect(
+        (mirrorRefs.stdout ?? "").includes("refs/heads/samospec/refunds"),
+      ).toBe(false);
+
+      // Config should still reflect both choices verbatim.
+      const cfg = JSON.parse(
+        readFileSync(
+          path.join(tmp, ".samospec", "config.json"),
+          "utf8",
+        ),
+      ) as {
+        git: { push_consent: Record<string, boolean> };
+      };
+      expect(cfg.git.push_consent[bare]).toBe(true);
+      expect(cfg.git.push_consent[otherBare]).toBe(false);
+    } finally {
+      rmSync(otherBare, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #31.

## Summary

- Adds `src/git/push-consent.ts` (`requestPushConsent`, `persistConsent`, `loadPersistedConsent`, `clearPersistedConsent`, `probePrCapability`, `describePrCapability`) — first-push prompt showing remote, target/default branches, PR-creation capability; persists by remote URL to `.samospec/config.json` → `git.push_consent.<url>`.
- Adds `src/git/push.ts` (`pushBranch`) — argv-only, no force, honors `--no-push` and consent refuse; no exceptions thrown.
- Wires round-boundary push into `runIterate` at each `committed` transition: session-scoped consent cache so the resolver is called at most once per run; Ctrl-C at prompt returns exit 3 with `state.json.exit.reason = "push-consent-interrupted"`.
- `samospec iterate` CLI grows `--no-push` and `--remote <name>`; interactive resolver renders the prompt with URL, branches, and PR capability.
- `samospec status` surfaces `push consent:` bullet with `<remote> → granted|refused|not yet decided (<url>)` per configured remote.
- Forbidden-flag regression extended with runtime argv-shim test (`tests/git/push-no-force.test.ts`).

## Test plan

- [x] `bun test` — 966 pass / 0 fail (6 new integration tests cover: 2-round accept → 1 prompt + 2 pushes; `--no-push` override beats persisted-accept; persisted refuse exits 0 not 5; Ctrl-C exit 3; absent pushOptions → local-only; distinct-remote-URL independence).
- [x] `bun test tests/git/no-force.test.ts tests/git/push-no-force.test.ts` — static grep + runtime argv shim both clean.
- [x] `bun run typecheck` and `bun run lint` — clean.

## Hard-rule compliance

- No amends. No force-push. No hook skips. No `--force` / `--force-with-lease` / `+refs/` anywhere in the git layer (static + runtime tests both green).
- Conventional Commits; red-first TDD per commit.
- No real credentials anywhere (PR-capability probes are argv runners; tests stub them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)