### PR TITLE
feat: Sprint 4 #33 — publish lint (paths + commands + branches + adapters; hard vs soft)

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -65,6 +65,16 @@ export interface ConvergenceDefaults {
   readonly min_delta_lines: number;
 }
 
+/**
+ * Sprint 4 #33 — publish lint. The `allowed_commands` array is additive
+ * (user entries layer on top of the hardcoded allowlist in
+ * `src/publish/lint.ts`). Defaults to empty so the hardcoded list is the
+ * baseline; users extend for custom shell helpers.
+ */
+export interface PublishLintDefaults {
+  readonly allowed_commands: readonly string[];
+}
+
 export interface DefaultConfig {
   readonly schema_version: typeof CONFIG_SCHEMA_VERSION;
   readonly adapters: {
@@ -76,6 +86,7 @@ export interface DefaultConfig {
   readonly git: GitDefaults;
   readonly context: ContextDefaults;
   readonly convergence: ConvergenceDefaults;
+  readonly publish_lint: PublishLintDefaults;
 }
 
 /**
@@ -126,6 +137,9 @@ export const DEFAULT_CONFIG: DefaultConfig = {
   },
   convergence: {
     min_delta_lines: 20,
+  },
+  publish_lint: {
+    allowed_commands: [],
   },
 };
 

--- a/src/publish/lint-extractors.ts
+++ b/src/publish/lint-extractors.ts
@@ -1,0 +1,382 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Pure extractors used by `publishLint`. Each function is input-only
+ * (string) and returns position-annotated candidates — no filesystem,
+ * no repo state. Keeping these pure lets the lint be unit-tested with a
+ * corpus of edge cases (SPEC §14 inclusion + exclusion rules).
+ *
+ * SPEC §14 path extraction rules:
+ *   (a) fenced code blocks (any language)
+ *   (b) backtick-wrapped strings containing `/` OR matching a known
+ *       extension: `.md|.json|.ts|.js|.sql|.py|.rs|.go|.yaml|.yml|.toml|.sh`
+ *   (c) bulleted lines under section headers suffix-named
+ *       `Files` / `Layout` / `Storage` (case-insensitive suffix match
+ *       per spec "or similar — suffix-match on section titles")
+ *
+ * SPEC §14 excluded-from-path rules (always rejected, both inside and
+ * outside backticks):
+ *   - URLs (http / https)
+ *   - version-number-like strings: `v1.2.3`, `0.1.0`, `1.0`
+ *   - bare dotted prose with no slash and no known extension
+ *     (`e.g.`, `example.com`, `foo.bar.baz`, `example.com.au`)
+ */
+
+/** Extensions that turn a backticked token into a path candidate. */
+const PATH_EXTENSIONS = [
+  "md",
+  "json",
+  "ts",
+  "js",
+  "sql",
+  "py",
+  "rs",
+  "go",
+  "yaml",
+  "yml",
+  "toml",
+  "sh",
+] as const;
+
+/**
+ * Ends with `.<known-ext>` (case-sensitive per shell/file conventions).
+ * Trailing punctuation like `.` / `,` / `)` is stripped before match.
+ */
+const EXTENSION_RE = new RegExp(`\\.(?:${PATH_EXTENSIONS.join("|")})$`);
+
+/**
+ * Version-number-like strings (rejected from path extraction):
+ *   - `v` prefix optional
+ *   - at least two dot-separated digit groups
+ *   - overall pattern: ^v?\d+(\.\d+){1,}$
+ */
+const VERSION_LIKE_RE = /^v?\d+(?:\.\d+){1,}$/;
+
+/** URL-looking tokens (rejected from path extraction). */
+const URL_RE = /^https?:\/\//i;
+
+/** Fence open/close line — captures the language tag. */
+const FENCE_RE = /^```([A-Za-z0-9+#-]*)\s*$/;
+
+/** Section headers `## Files` / `### State Storage` / `## Layout`. */
+const SECTION_HEADER_RE = /^(#{1,6})\s+(.+?)\s*$/;
+
+/** Keyword suffixes that trigger path-in-bullet extraction (case-insensitive). */
+const PATH_SECTION_SUFFIXES = ["files", "layout", "storage"] as const;
+
+/** Strip wrapping punctuation commonly surrounding a path in prose. */
+function stripTrailingPunctuation(s: string): string {
+  return s.replace(/[.,;:!?)\]>]+$/u, "");
+}
+
+/**
+ * A token is a URL (external reference, never a repo-relative path).
+ */
+function isUrl(token: string): boolean {
+  return URL_RE.test(token);
+}
+
+/**
+ * A token is version-number-like (e.g. `v1.2.3`, `0.1.0`).
+ */
+function isVersionLike(token: string): boolean {
+  return VERSION_LIKE_RE.test(token);
+}
+
+/** Known extension: does the token end with `.<one of PATH_EXTENSIONS>`? */
+function hasKnownExtension(token: string): boolean {
+  return EXTENSION_RE.test(token);
+}
+
+/** Does the token plausibly reference a file path? */
+function looksLikePath(token: string): boolean {
+  if (token.length === 0) return false;
+  if (isUrl(token)) return false;
+  if (isVersionLike(token)) return false;
+  // Rule (b): backtick-wrapped strings containing `/` or known extension.
+  if (token.includes("/")) return true;
+  if (hasKnownExtension(token)) return true;
+  return false;
+}
+
+export interface PathExtraction {
+  readonly path: string;
+  readonly line: number;
+  readonly source: "fenced" | "backtick" | "bullet-section";
+}
+
+/**
+ * Extract candidate file paths from a spec string.
+ *
+ * Returns unique (by path) candidates preserving the first-seen line
+ * location. See module comment for the inclusion / exclusion rules.
+ */
+export function extractPaths(spec: string): readonly PathExtraction[] {
+  const lines = spec.split("\n");
+  const seen = new Map<string, PathExtraction>();
+
+  let inFence = false;
+  let currentSection = "";
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const lineNo = i + 1;
+
+    const fenceMatch = FENCE_RE.exec(line);
+    if (fenceMatch) {
+      inFence = !inFence;
+      continue;
+    }
+
+    if (inFence) {
+      // Rule (a): any non-empty fenced line is scanned for path-like tokens.
+      // Whitespace-split — tokens that look like paths (per `looksLikePath`)
+      // are captured. Multiple per line possible (e.g. inline comments).
+      for (const rawToken of line.split(/\s+/)) {
+        const token = stripWrappers(rawToken);
+        if (!looksLikePath(token)) continue;
+        if (!seen.has(token)) {
+          seen.set(token, { path: token, line: lineNo, source: "fenced" });
+        }
+      }
+      continue;
+    }
+
+    const headerMatch = SECTION_HEADER_RE.exec(line);
+    if (headerMatch) {
+      const title = (headerMatch[2] ?? "").trim().toLowerCase();
+      // Suffix-insensitive match per SPEC §14 "or similar — suffix-match".
+      if (PATH_SECTION_SUFFIXES.some((suf) => title.endsWith(suf))) {
+        currentSection = "path-section";
+      } else {
+        currentSection = "";
+      }
+      continue;
+    }
+
+    // Rule (c): bullet under a path-ish section.
+    if (currentSection === "path-section") {
+      const bulletMatch = /^\s*-\s+(.+?)\s*$/.exec(line);
+      if (bulletMatch) {
+        for (const rawToken of (bulletMatch[1] ?? "").split(/\s+/)) {
+          const token = stripWrappers(rawToken);
+          if (!looksLikePath(token)) continue;
+          if (!seen.has(token)) {
+            seen.set(token, {
+              path: token,
+              line: lineNo,
+              source: "bullet-section",
+            });
+          }
+        }
+        continue;
+      }
+    }
+
+    // Rule (b): every backticked span in the line.
+    for (const token of scanBacktickedTokens(line)) {
+      if (!looksLikePath(token)) continue;
+      if (!seen.has(token)) {
+        seen.set(token, { path: token, line: lineNo, source: "backtick" });
+      }
+    }
+  }
+
+  return [...seen.values()];
+}
+
+/**
+ * Yield every backtick-wrapped token on a line. We use a simple regex
+ * since specs are small; the extractor is idempotent under nesting
+ * because we only look at the innermost `...` pair.
+ */
+function scanBacktickedTokens(line: string): string[] {
+  const tokens: string[] = [];
+  const re = /`([^`]+)`/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(line)) !== null) {
+    tokens.push(m[1] ?? "");
+  }
+  return tokens;
+}
+
+/** Strip common wrapping characters (backticks, quotes, trailing `,`, `)`). */
+function stripWrappers(raw: string): string {
+  let s = raw.trim();
+  // Drop leading / trailing backticks, single quotes, double quotes.
+  s = s.replace(/^[`'"]+/, "").replace(/[`'"]+$/, "");
+  s = stripTrailingPunctuation(s);
+  return s;
+}
+
+// -------- Commands ----------------------------------------------------
+
+/** Shell language tags eligible for command scanning. */
+const SHELL_FENCES = new Set(["bash", "sh", "shell"]);
+
+export interface CommandExtraction {
+  readonly command: string;
+  readonly line: number;
+}
+
+/**
+ * Extract the first token of every non-blank, non-comment line inside
+ * `bash` / `sh` / `shell` fenced blocks. Fences with no language tag or
+ * with other languages (`ts`, `js`, `json`) are NOT scanned.
+ *
+ * Shell prompts (`$ `, `# `) and comment lines (`# ...`) are skipped.
+ */
+export function extractCommands(spec: string): readonly CommandExtraction[] {
+  const lines = spec.split("\n");
+  const out: CommandExtraction[] = [];
+
+  let inShellFence = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const lineNo = i + 1;
+    const fenceMatch = FENCE_RE.exec(line);
+    if (fenceMatch) {
+      const tag = (fenceMatch[1] ?? "").toLowerCase();
+      if (inShellFence) {
+        inShellFence = false;
+      } else {
+        inShellFence = SHELL_FENCES.has(tag);
+      }
+      continue;
+    }
+
+    if (!inShellFence) continue;
+
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    // Comment line (shell `# comment`).
+    if (trimmed.startsWith("#")) continue;
+
+    // Strip optional prompt prefix (`$ ` for unprivileged, `# ` was already
+    // rejected above as a comment — privileged-root prompt is never mixed
+    // with actual commands in our spec corpus).
+    const afterPrompt = trimmed.startsWith("$ ")
+      ? trimmed.slice(2).trimStart()
+      : trimmed;
+
+    const first = afterPrompt.split(/\s+/)[0] ?? "";
+    if (first.length === 0) continue;
+    // Skip remaining prompt/comment sentinels that survived trimming.
+    if (first === "$" || first === "#") continue;
+
+    out.push({ command: first, line: lineNo });
+  }
+
+  return out;
+}
+
+// -------- Branch refs --------------------------------------------------
+
+/**
+ * Branch-like tokens — backticked names that either
+ *   (1) match `<word>/<slug>` (e.g. `samospec/refunds`, `feature/xyz`),
+ *   (2) are a bare short name (`main`, `develop`), or
+ *   (3) include slashes but are NOT plausibly file paths.
+ *
+ * File-looking tokens (ending in a known extension, or containing `.`
+ * before the final path segment) are filtered out so the caller can
+ * keep path warnings separate from ghost-branch warnings.
+ */
+export interface BranchRefExtraction {
+  readonly branch: string;
+  readonly line: number;
+}
+
+/** Set of bare short names we treat as plausible branch references. */
+const BARE_BRANCH_WORDS = new Set(["main", "master", "develop", "trunk"]);
+
+/**
+ * A backticked token is "branchy" if:
+ *   - not a URL
+ *   - not a known file extension
+ *   - not a version-like string
+ *   - AND either `<word>/<word>` shape OR in the bare-branch set.
+ *
+ * Token shape allows slashes, alphanumerics, `-`, `_`, `.` in segments.
+ */
+const BRANCHY_PAIR_RE = /^[A-Za-z][\w-]*\/[\w./-]+$/;
+const BARE_IDENT_RE = /^[A-Za-z][\w-]*$/;
+
+function looksLikeBranch(token: string): boolean {
+  if (token.length === 0) return false;
+  if (isUrl(token)) return false;
+  if (isVersionLike(token)) return false;
+  if (hasKnownExtension(token)) return false;
+  if (BRANCHY_PAIR_RE.test(token)) return true;
+  if (BARE_IDENT_RE.test(token) && BARE_BRANCH_WORDS.has(token)) return true;
+  return false;
+}
+
+export function extractBranchRefs(
+  spec: string,
+): readonly BranchRefExtraction[] {
+  const lines = spec.split("\n");
+  const seen = new Map<string, BranchRefExtraction>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const lineNo = i + 1;
+    for (const token of scanBacktickedTokens(line)) {
+      if (!looksLikeBranch(token)) continue;
+      if (!seen.has(token)) {
+        seen.set(token, { branch: token, line: lineNo });
+      }
+    }
+  }
+  return [...seen.values()];
+}
+
+// -------- Adapter / model refs -----------------------------------------
+
+/**
+ * Extract adapter/model-looking identifiers. v1 patterns:
+ *   - `claude-<family>-<n>-<n>` (e.g. `claude-opus-4-7`, `claude-sonnet-4-6`)
+ *   - `gpt-<major>.<minor>-<family>(-<suffix>)?` (e.g. `gpt-5.1-codex`,
+ *     `gpt-5.1-codex-max`)
+ *
+ * The regex is tight enough to avoid capturing ordinary prose and loose
+ * enough to catch the four name shapes we ship today plus minor variants.
+ * False positives here are cheap — drift warnings are soft.
+ */
+const ADAPTER_CLAUDE_RE = /^claude-[a-z0-9]+(?:-[a-z0-9]+)*-\d+(?:-\d+)+$/;
+const ADAPTER_GPT_RE = /^gpt-\d+(?:\.\d+)+-[a-z]+(?:-[a-z0-9]+)*$/;
+
+export interface AdapterRefExtraction {
+  readonly model: string;
+  readonly line: number;
+}
+
+function looksLikeAdapterModel(token: string): boolean {
+  return ADAPTER_CLAUDE_RE.test(token) || ADAPTER_GPT_RE.test(token);
+}
+
+export function extractAdapterRefs(
+  spec: string,
+): readonly AdapterRefExtraction[] {
+  const lines = spec.split("\n");
+  const seen = new Map<string, AdapterRefExtraction>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const lineNo = i + 1;
+    // Scan backticked tokens first — spec style favors quoting model names.
+    for (const token of scanBacktickedTokens(line)) {
+      if (looksLikeAdapterModel(token) && !seen.has(token)) {
+        seen.set(token, { model: token, line: lineNo });
+      }
+    }
+    // Then scan bare-word tokens for unbackticked mentions.
+    for (const rawToken of line.split(/\s+/)) {
+      const token = stripWrappers(rawToken);
+      if (looksLikeAdapterModel(token) && !seen.has(token)) {
+        seen.set(token, { model: token, line: lineNo });
+      }
+    }
+  }
+  return [...seen.values()];
+}

--- a/src/publish/lint-types.ts
+++ b/src/publish/lint-types.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Public types for `src/publish/lint.ts`. SPEC §14 "Hallucinated repo
+ * facts (publish lint, broadened)" defines two severity tiers:
+ *
+ * - **Hard warnings** — definitely wrong (missing file paths).
+ * - **Soft warnings** — heuristic (unknown commands, ghost branches,
+ *   adapter/model drift).
+ *
+ * `RepoState` is the read-only snapshot the lint uses to decide what is
+ * "real" — file system for paths, local branch list for branches,
+ * resolved adapter models from `state.json`, user config for the
+ * command allowlist.
+ */
+
+/** Source position inside the spec string (1-indexed line). */
+export interface LintLocation {
+  readonly line: number;
+}
+
+/** Fixed set of finding kinds. Used by tooling to classify outputs. */
+export type LintFindingKind =
+  | "missing-path"
+  | "unknown-command"
+  | "ghost-branch"
+  | "adapter-drift";
+
+export interface LintFinding {
+  readonly kind: LintFindingKind;
+  readonly message: string;
+  readonly location?: LintLocation;
+}
+
+export interface PublishLintReport {
+  readonly hardWarnings: readonly LintFinding[];
+  readonly softWarnings: readonly LintFinding[];
+}
+
+/**
+ * User-config subset read by the lint. Mirrors the shape `init.ts`
+ * writes to `.samospec/config.json` — a `publish_lint.allowed_commands`
+ * array layers on top of the hardcoded allowlist. Other unrelated
+ * config keys are ignored.
+ */
+export interface PublishLintConfig {
+  readonly publish_lint?: {
+    readonly allowed_commands?: readonly string[];
+  };
+}
+
+/**
+ * Read-only snapshot of repo facts used to decide what is "real".
+ *
+ * - `repoRoot` — absolute path used to resolve extracted paths.
+ * - `branches` — local branch list (from `git branch --list` or a mock).
+ * - `protectedBranches` — combined hardcoded + user-config list; any
+ *   branch name matching this list is never a ghost.
+ * - `adapterModels` — resolved model ids from `state.json` (lead +
+ *   reviewer_a + reviewer_b). Drift checks compare `claude-…` /
+ *   `gpt-…` tokens in prose against this list.
+ * - `config` — parsed `.samospec/config.json` content subset.
+ */
+export interface RepoState {
+  readonly repoRoot: string;
+  readonly branches: readonly string[];
+  readonly protectedBranches: readonly string[];
+  readonly adapterModels: readonly string[];
+  readonly config: PublishLintConfig;
+}

--- a/src/publish/lint.ts
+++ b/src/publish/lint.ts
@@ -1,0 +1,157 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * `publishLint(spec, repoState)` — returns hard + soft warnings per
+ * SPEC §14 "Hallucinated repo facts (publish lint, broadened)".
+ *
+ * **Hard** (definitely wrong — surfaced prominently in the PR body):
+ *   - `missing-path`: a path referenced in the spec (per extractor
+ *     rules) does not exist under `repoState.repoRoot`.
+ *
+ * **Soft** (heuristic — surfaced lower):
+ *   - `unknown-command`: first token of a `bash`/`sh`/`shell` fence
+ *     line is not in the hardcoded allowlist nor the user-extended
+ *     `publish_lint.allowed_commands` config. `$PATH` is **not**
+ *     consulted (user-controlled; security concern per SPEC §14).
+ *   - `ghost-branch`: branch-like name (`<word>/<word>` or a known
+ *     short branch like `main`) is not in `repoState.branches` or
+ *     `repoState.protectedBranches`.
+ *   - `adapter-drift`: adapter/model id in prose not in
+ *     `repoState.adapterModels`.
+ *
+ * Extraction helpers live in `./lint-extractors.ts`; types in
+ * `./lint-types.ts`.
+ */
+
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import {
+  extractAdapterRefs,
+  extractBranchRefs,
+  extractCommands,
+  extractPaths,
+} from "./lint-extractors.ts";
+import type {
+  LintFinding,
+  PublishLintReport,
+  RepoState,
+} from "./lint-types.ts";
+
+/**
+ * Extensions that make a `<word>/<...>` token unambiguously a file path.
+ * `samospec/refunds` lacks an extension → prefer the branch
+ * interpretation; `src/foo.ts` has one → unambiguously a path.
+ */
+const KNOWN_FILE_EXTENSIONS =
+  /\.(?:md|json|ts|js|sql|py|rs|go|yaml|yml|toml|sh)$/;
+const BRANCH_PAIR = /^[A-Za-z][\w-]*\/[\w./-]+$/;
+
+/**
+ * A candidate from `extractPaths` that matches `<word>/<slug>` with no
+ * known file extension is treated as a branch candidate, not a path.
+ * The SPEC's branch rule explicitly says "skip matches that are file
+ * paths"; the converse is intentionally enforced here so the two
+ * warning channels never double-count the same token.
+ */
+function prefersBranchInterpretation(token: string): boolean {
+  if (KNOWN_FILE_EXTENSIONS.test(token)) return false;
+  return BRANCH_PAIR.test(token);
+}
+
+/**
+ * Hardcoded command allowlist per SPEC §14. These are the binaries
+ * `samospec` itself orchestrates or embeds examples of. Any user
+ * extension layers on top via `publish_lint.allowed_commands`.
+ */
+export const HARDCODED_COMMAND_ALLOWLIST: readonly string[] = [
+  "samospec",
+  "git",
+  "gh",
+  "glab",
+  "bun",
+  "node",
+  "claude",
+  "codex",
+];
+
+/**
+ * Run the publish lint. Pure function w.r.t. the inputs plus the repo
+ * file system (existence check on `repoState.repoRoot`). `$PATH` is
+ * deliberately NOT consulted — a malicious `PATH` entry must not be
+ * able to silence a command warning.
+ */
+export function publishLint(
+  spec: string,
+  repoState: RepoState,
+): PublishLintReport {
+  const hard: LintFinding[] = [];
+  const soft: LintFinding[] = [];
+
+  // --- Hard: missing paths --------------------------------------------
+  for (const entry of extractPaths(spec)) {
+    if (prefersBranchInterpretation(entry.path)) continue;
+    const abs = path.join(repoState.repoRoot, entry.path);
+    if (!existsSync(abs)) {
+      hard.push({
+        kind: "missing-path",
+        message: `missing path referenced in spec: ${entry.path}`,
+        location: { line: entry.line },
+      });
+    }
+  }
+
+  // --- Soft: unknown commands -----------------------------------------
+  const userAllowed = new Set<string>(
+    repoState.config.publish_lint?.allowed_commands ?? [],
+  );
+  const allowed = new Set<string>([
+    ...HARDCODED_COMMAND_ALLOWLIST,
+    ...userAllowed,
+  ]);
+  const seenUnknownCommand = new Set<string>();
+  for (const entry of extractCommands(spec)) {
+    if (allowed.has(entry.command)) continue;
+    if (seenUnknownCommand.has(entry.command)) continue;
+    seenUnknownCommand.add(entry.command);
+    soft.push({
+      kind: "unknown-command",
+      message: `unknown command in shell fence: ${entry.command}`,
+      location: { line: entry.line },
+    });
+  }
+
+  // --- Soft: ghost branches -------------------------------------------
+  const knownBranches = new Set<string>([
+    ...repoState.branches,
+    ...repoState.protectedBranches,
+  ]);
+  // Per SPEC §14 "Skip matches that are clearly file paths" — an
+  // unambiguous file path (token ends in a known file extension) is
+  // never reported as a ghost branch.
+  for (const entry of extractBranchRefs(spec)) {
+    if (KNOWN_FILE_EXTENSIONS.test(entry.branch)) continue;
+    if (knownBranches.has(entry.branch)) continue;
+    soft.push({
+      kind: "ghost-branch",
+      message: `ghost branch reference: ${entry.branch}`,
+      location: { line: entry.line },
+    });
+  }
+
+  // --- Soft: adapter / model drift ------------------------------------
+  const known = new Set<string>(repoState.adapterModels);
+  const seenModel = new Set<string>();
+  for (const entry of extractAdapterRefs(spec)) {
+    if (known.has(entry.model)) continue;
+    if (seenModel.has(entry.model)) continue;
+    seenModel.add(entry.model);
+    soft.push({
+      kind: "adapter-drift",
+      message: `adapter/model not in resolved state: ${entry.model}`,
+      location: { line: entry.line },
+    });
+  }
+
+  return { hardWarnings: hard, softWarnings: soft };
+}

--- a/tests/publish/lint-extractors.test.ts
+++ b/tests/publish/lint-extractors.test.ts
@@ -48,13 +48,9 @@ describe("extractPaths — inclusion rule (a): fenced code blocks", () => {
   });
 
   test("records the line number of the extracted path", () => {
-    const spec = [
-      "line 1",
-      "line 2",
-      "```text",
-      "src/foo.ts",
-      "```",
-    ].join("\n");
+    const spec = ["line 1", "line 2", "```text", "src/foo.ts", "```"].join(
+      "\n",
+    );
     const extracted = extractPaths(spec);
     const found = extracted.find((p) => p.path === "src/foo.ts");
     expect(found).toBeDefined();
@@ -113,11 +109,7 @@ describe("extractPaths — inclusion rule (c): bulleted lines under Files/Layout
   });
 
   test("bulleted path under a `Storage` suffix-insensitive header", () => {
-    const spec = [
-      "### State Storage",
-      "",
-      "- .samospec/state.json",
-    ].join("\n");
+    const spec = ["### State Storage", "", "- .samospec/state.json"].join("\n");
     const paths = extractPaths(spec).map((p) => p.path);
     expect(paths).toContain(".samospec/state.json");
   });

--- a/tests/publish/lint-extractors.test.ts
+++ b/tests/publish/lint-extractors.test.ts
@@ -1,0 +1,308 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Unit tests for `src/publish/lint-extractors.ts` — each extractor is a
+ * pure function. Corpus-driven per SPEC §14 "hallucinated repo facts"
+ * sub-section: inclusion rules (a)(b)(c), exclusion rules (version
+ * strings, URLs, bare dotted prose), command language-tag filter, and
+ * adapter/model/branch reference shapes.
+ *
+ * Red-first: extractors do not exist yet, so every case should fail the
+ * initial run.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  extractAdapterRefs,
+  extractBranchRefs,
+  extractCommands,
+  extractPaths,
+} from "../../src/publish/lint-extractors.ts";
+
+describe("extractPaths — inclusion rule (a): fenced code blocks", () => {
+  test("plain path on its own line in a `text` fence is extracted", () => {
+    const spec = [
+      "Layout overview:",
+      "",
+      "```text",
+      "src/foo.ts",
+      "src/bar.ts",
+      "```",
+      "",
+    ].join("\n");
+    const paths = extractPaths(spec).map((p) => p.path);
+    expect(paths).toContain("src/foo.ts");
+    expect(paths).toContain("src/bar.ts");
+  });
+
+  test("path referenced inside a `ts` fence is extracted", () => {
+    const spec = [
+      "```ts",
+      "// see src/publish/lint.ts",
+      "import { publishLint } from 'src/publish/lint.ts';",
+      "```",
+    ].join("\n");
+    const paths = extractPaths(spec).map((p) => p.path);
+    expect(paths).toContain("src/publish/lint.ts");
+  });
+
+  test("records the line number of the extracted path", () => {
+    const spec = [
+      "line 1",
+      "line 2",
+      "```text",
+      "src/foo.ts",
+      "```",
+    ].join("\n");
+    const extracted = extractPaths(spec);
+    const found = extracted.find((p) => p.path === "src/foo.ts");
+    expect(found).toBeDefined();
+    expect(found?.line).toBe(4);
+  });
+});
+
+describe("extractPaths — inclusion rule (b): backtick-wrapped strings", () => {
+  test("`src/foo/bar.ts` in prose is extracted (contains `/`)", () => {
+    const spec = "The module lives at `src/foo/bar.ts`.";
+    const paths = extractPaths(spec).map((p) => p.path);
+    expect(paths).toContain("src/foo/bar.ts");
+  });
+
+  test("`README.md` in prose is extracted (extension match)", () => {
+    const spec = "See the top-level `README.md`.";
+    const paths = extractPaths(spec).map((p) => p.path);
+    expect(paths).toContain("README.md");
+  });
+
+  test.each([
+    "file.json",
+    "setup.sh",
+    "lib.sql",
+    "main.py",
+    "lib.rs",
+    "app.go",
+    "config.yaml",
+    "manifest.yml",
+    "Cargo.toml",
+    "index.js",
+  ])("`%s` (extension match) is extracted", (name) => {
+    const spec = `See \`${name}\`.`;
+    const paths = extractPaths(spec).map((p) => p.path);
+    expect(paths).toContain(name);
+  });
+});
+
+describe("extractPaths — inclusion rule (c): bulleted lines under Files/Layout/Storage", () => {
+  test("bulleted path under `## Files` is extracted", () => {
+    const spec = [
+      "## Files",
+      "",
+      "- `src/one.ts` — entry",
+      "- `src/two.ts` — helper",
+    ].join("\n");
+    const paths = extractPaths(spec).map((p) => p.path);
+    expect(paths).toContain("src/one.ts");
+    expect(paths).toContain("src/two.ts");
+  });
+
+  test("bulleted path under `### Layout` is extracted", () => {
+    const spec = ["### Layout", "", "- src/module/entry.ts"].join("\n");
+    const paths = extractPaths(spec).map((p) => p.path);
+    expect(paths).toContain("src/module/entry.ts");
+  });
+
+  test("bulleted path under a `Storage` suffix-insensitive header", () => {
+    const spec = [
+      "### State Storage",
+      "",
+      "- .samospec/state.json",
+    ].join("\n");
+    const paths = extractPaths(spec).map((p) => p.path);
+    expect(paths).toContain(".samospec/state.json");
+  });
+
+  test("header resets on next `## Heading` (bullets no longer under Files)", () => {
+    const spec = [
+      "## Files",
+      "",
+      "- `a.ts`",
+      "",
+      "## Some Other Section",
+      "",
+      "- reminder.example", // should NOT be treated as a path
+    ].join("\n");
+    const paths = extractPaths(spec).map((p) => p.path);
+    expect(paths).toContain("a.ts");
+    expect(paths).not.toContain("reminder.example");
+  });
+});
+
+describe("extractPaths — exclusion rules (MUST NOT extract)", () => {
+  test("bare dotted strings in prose are not paths", () => {
+    const spec = [
+      "We use things like e.g. defaults.",
+      "Version v1.2.3 is pinned.",
+      "See example.com for details.",
+      "A qualified name foo.bar.baz is just prose.",
+      "AU domain example.com.au also plain.",
+    ].join("\n");
+    const paths = extractPaths(spec).map((p) => p.path);
+    expect(paths).not.toContain("e.g");
+    expect(paths).not.toContain("v1.2.3");
+    expect(paths).not.toContain("example.com");
+    expect(paths).not.toContain("foo.bar.baz");
+    expect(paths).not.toContain("example.com.au");
+    expect(paths.length).toBe(0);
+  });
+
+  test("URLs inside prose are not paths", () => {
+    const spec = [
+      "See https://github.com/foo/bar for source.",
+      "Or http://example.org/docs for docs.",
+    ].join("\n");
+    const paths = extractPaths(spec);
+    expect(paths.length).toBe(0);
+  });
+
+  test("version-number-like strings never extracted even when backticked", () => {
+    const spec = "Version `v1.2.3`, tag `0.1.0`, and `1.0` release.";
+    const paths = extractPaths(spec);
+    expect(paths.length).toBe(0);
+  });
+
+  test("URLs inside backticks are not paths", () => {
+    const spec = "See `https://github.com/foo/bar`.";
+    const paths = extractPaths(spec);
+    expect(paths.length).toBe(0);
+  });
+
+  test("a bare backtick without a `/` and without a known extension is not a path", () => {
+    const spec = "The `iterate` command is one word.";
+    const paths = extractPaths(spec);
+    expect(paths.length).toBe(0);
+  });
+});
+
+describe("extractCommands — language-tag filter", () => {
+  test("`bash` fenced block yields first tokens per line", () => {
+    const spec = [
+      "```bash",
+      "samospec iterate",
+      "git log --oneline",
+      "rm -rf /tmp/foo",
+      "```",
+    ].join("\n");
+    const commands = extractCommands(spec).map((c) => c.command);
+    expect(commands).toEqual(["samospec", "git", "rm"]);
+  });
+
+  test("`sh` fenced block is scanned", () => {
+    const spec = ["```sh", "foobar --flag", "```"].join("\n");
+    const commands = extractCommands(spec).map((c) => c.command);
+    expect(commands).toEqual(["foobar"]);
+  });
+
+  test("`shell` fenced block is scanned", () => {
+    const spec = ["```shell", "bun test", "```"].join("\n");
+    const commands = extractCommands(spec).map((c) => c.command);
+    expect(commands).toEqual(["bun"]);
+  });
+
+  test("language-less fence is NOT scanned", () => {
+    const spec = ["```", "foobar --flag", "```"].join("\n");
+    expect(extractCommands(spec)).toEqual([]);
+  });
+
+  test("`ts` fence is NOT scanned", () => {
+    const spec = ["```ts", "import foo from 'bar';", "```"].join("\n");
+    expect(extractCommands(spec)).toEqual([]);
+  });
+
+  test("`js` fence is NOT scanned", () => {
+    const spec = ["```js", "const x = 1;", "```"].join("\n");
+    expect(extractCommands(spec)).toEqual([]);
+  });
+
+  test("blank lines, comments and prompt prefixes are skipped", () => {
+    const spec = [
+      "```bash",
+      "",
+      "# a comment",
+      "$ samospec new foo",
+      "git status",
+      "```",
+    ].join("\n");
+    const commands = extractCommands(spec).map((c) => c.command);
+    // We keep the first non-prompt, non-comment token.
+    expect(commands).toContain("samospec");
+    expect(commands).toContain("git");
+    expect(commands).not.toContain("#");
+    expect(commands).not.toContain("$");
+  });
+
+  test("line numbers correspond to source positions", () => {
+    const spec = ["prose", "```bash", "samospec new", "```"].join("\n");
+    const commands = extractCommands(spec);
+    expect(commands[0]).toEqual({ command: "samospec", line: 3 });
+  });
+});
+
+describe("extractBranchRefs — <word>/<slug> matches", () => {
+  test("`samospec/refunds` in prose is extracted", () => {
+    const spec = "Check branch `samospec/refunds` before publishing.";
+    const refs = extractBranchRefs(spec).map((r) => r.branch);
+    expect(refs).toContain("samospec/refunds");
+  });
+
+  test("`main` alone in prose is extracted as a branch candidate", () => {
+    const spec = "Merges land on `main` after review.";
+    const refs = extractBranchRefs(spec).map((r) => r.branch);
+    expect(refs).toContain("main");
+  });
+
+  test("feature/xyz backticked is extracted", () => {
+    const spec = "Work lives on `feature/xyz`.";
+    const refs = extractBranchRefs(spec).map((r) => r.branch);
+    expect(refs).toContain("feature/xyz");
+  });
+
+  test("paths are NOT re-reported as branches", () => {
+    const spec = "See `src/foo.ts` for details.";
+    const refs = extractBranchRefs(spec).map((r) => r.branch);
+    expect(refs).not.toContain("src/foo.ts");
+  });
+
+  test("URLs are NOT extracted as branches", () => {
+    const spec = "See https://github.com/foo/bar.";
+    expect(extractBranchRefs(spec)).toEqual([]);
+  });
+});
+
+describe("extractAdapterRefs — model / adapter name patterns", () => {
+  test("claude-opus-4-7 is extracted", () => {
+    const spec = "Lead runs on `claude-opus-4-7` at effort max.";
+    const names = extractAdapterRefs(spec).map((a) => a.model);
+    expect(names).toContain("claude-opus-4-7");
+  });
+
+  test("gpt-5.1-codex-max is extracted", () => {
+    const spec = "Reviewer A uses `gpt-5.1-codex-max`.";
+    const names = extractAdapterRefs(spec).map((a) => a.model);
+    expect(names).toContain("gpt-5.1-codex-max");
+  });
+
+  test("claude-sonnet-4-6 and gpt-5.1-codex are extracted", () => {
+    const spec = [
+      "Fallback 1 `claude-sonnet-4-6`, fallback 2 `gpt-5.1-codex`.",
+    ].join("\n");
+    const names = extractAdapterRefs(spec).map((a) => a.model);
+    expect(names).toContain("claude-sonnet-4-6");
+    expect(names).toContain("gpt-5.1-codex");
+  });
+
+  test("plain prose without model-like names is empty", () => {
+    const spec = "Nothing of interest here.";
+    expect(extractAdapterRefs(spec)).toEqual([]);
+  });
+});

--- a/tests/publish/lint.test.ts
+++ b/tests/publish/lint.test.ts
@@ -128,7 +128,9 @@ describe("publishLint — soft warnings: unknown commands", () => {
       "```",
     ].join("\n");
     const report = publishLint(spec, baseRepoState({ repoRoot: fx.dir }));
-    const soft = report.softWarnings.filter((w) => w.kind === "unknown-command");
+    const soft = report.softWarnings.filter(
+      (w) => w.kind === "unknown-command",
+    );
     const cmds = soft.map((w) => w.message);
     expect(cmds.some((m) => m.includes("rm"))).toBe(true);
     expect(cmds.some((m) => m.includes("samospec"))).toBe(false);
@@ -189,7 +191,9 @@ describe("publishLint — soft warnings: unknown commands", () => {
       "```",
     ].join("\n");
     const report = publishLint(spec, baseRepoState({ repoRoot: fx.dir }));
-    const soft = report.softWarnings.filter((w) => w.kind === "unknown-command");
+    const soft = report.softWarnings.filter(
+      (w) => w.kind === "unknown-command",
+    );
     expect(soft.length).toBe(0);
   });
 });
@@ -334,11 +338,9 @@ describe("publishLint — report shape", () => {
       expect(typeof w.message).toBe("string");
     }
     for (const w of report.softWarnings) {
-      expect([
-        "unknown-command",
-        "ghost-branch",
-        "adapter-drift",
-      ]).toContain(w.kind);
+      expect(["unknown-command", "ghost-branch", "adapter-drift"]).toContain(
+        w.kind,
+      );
     }
     // Missing-path extracted + unknown-command `zzzz` both present.
     expect(report.hardWarnings.length).toBeGreaterThan(0);

--- a/tests/publish/lint.test.ts
+++ b/tests/publish/lint.test.ts
@@ -1,0 +1,364 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Tests for `src/publish/lint.ts` — the publishLint orchestrator that
+ * combines extractors with repo state. Per SPEC §14: hard warnings for
+ * missing-on-disk paths, soft warnings for unknown commands, ghost
+ * branches, and adapter/model drift. `$PATH` is NOT consulted.
+ *
+ * Red-first: the module does not exist yet.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { publishLint } from "../../src/publish/lint.ts";
+import type { RepoState } from "../../src/publish/lint-types.ts";
+
+interface Fixture {
+  readonly dir: string;
+  readonly cleanup: () => void;
+  readonly write: (relPath: string, contents: string) => void;
+}
+
+function mkFixture(): Fixture {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-publish-lint-"));
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+    write: (rel, contents) => {
+      const full = join(dir, rel);
+      mkdirSync(join(full, ".."), { recursive: true });
+      writeFileSync(full, contents);
+    },
+  };
+}
+
+function baseRepoState(overrides: Partial<RepoState> = {}): RepoState {
+  return {
+    repoRoot: "/nonexistent-should-be-overridden",
+    branches: [],
+    protectedBranches: [],
+    adapterModels: [],
+    config: {},
+    ...overrides,
+  };
+}
+
+describe("publishLint — hard warnings: missing file paths", () => {
+  let fx: Fixture;
+  beforeEach(() => {
+    fx = mkFixture();
+  });
+  afterEach(() => {
+    fx.cleanup();
+  });
+
+  test("HARD: spec references `src/foo/bar.ts` in a ts fence but it is missing on disk", () => {
+    const spec = [
+      "## Implementation",
+      "",
+      "```ts",
+      "// see src/foo/bar.ts",
+      "```",
+    ].join("\n");
+    const report = publishLint(spec, baseRepoState({ repoRoot: fx.dir }));
+    const msgs = report.hardWarnings.map((w) => w.message);
+    expect(msgs.join("\n")).toContain("src/foo/bar.ts");
+    expect(report.hardWarnings.length).toBeGreaterThan(0);
+    // Should carry a location with the line number.
+    const finding = report.hardWarnings.find((w) =>
+      w.message.includes("src/foo/bar.ts"),
+    );
+    expect(finding?.location?.line).toBeGreaterThan(0);
+    expect(finding?.kind).toBe("missing-path");
+  });
+
+  test("no hard warning when the referenced path exists on disk", () => {
+    fx.write("src/foo/bar.ts", "// exists\n");
+    const spec = "See `src/foo/bar.ts` for reference.";
+    const report = publishLint(spec, baseRepoState({ repoRoot: fx.dir }));
+    expect(report.hardWarnings).toEqual([]);
+  });
+
+  test("excluded-path examples do NOT raise hard warnings", () => {
+    const spec = [
+      "Version v1.2.3 shipped.",
+      "See https://github.com/foo/bar.",
+      "Use e.g. a flag.",
+      "Qualified foo.bar.baz and domain example.com.au appear.",
+    ].join("\n");
+    const report = publishLint(spec, baseRepoState({ repoRoot: fx.dir }));
+    expect(report.hardWarnings).toEqual([]);
+  });
+
+  test("same missing path referenced twice yields exactly one hard warning", () => {
+    const spec = [
+      "`src/missing.ts` appears here.",
+      "",
+      "```text",
+      "src/missing.ts",
+      "```",
+    ].join("\n");
+    const report = publishLint(spec, baseRepoState({ repoRoot: fx.dir }));
+    const msgs = report.hardWarnings.filter((w) =>
+      w.message.includes("src/missing.ts"),
+    );
+    expect(msgs.length).toBe(1);
+  });
+});
+
+describe("publishLint — soft warnings: unknown commands", () => {
+  let fx: Fixture;
+  beforeEach(() => {
+    fx = mkFixture();
+  });
+  afterEach(() => {
+    fx.cleanup();
+  });
+
+  test("unknown `rm` is SOFT; default-allowlisted `samospec`/`git` are NOT warned", () => {
+    const spec = [
+      "```bash",
+      "samospec iterate",
+      "git log --oneline",
+      "rm -rf /",
+      "```",
+    ].join("\n");
+    const report = publishLint(spec, baseRepoState({ repoRoot: fx.dir }));
+    const soft = report.softWarnings.filter((w) => w.kind === "unknown-command");
+    const cmds = soft.map((w) => w.message);
+    expect(cmds.some((m) => m.includes("rm"))).toBe(true);
+    expect(cmds.some((m) => m.includes("samospec"))).toBe(false);
+    expect(cmds.some((m) => m.includes("git"))).toBe(false);
+  });
+
+  test("adding `rm` to `publish_lint.allowed_commands` silences that soft warning", () => {
+    const spec = ["```bash", "rm -rf /tmp/foo", "```"].join("\n");
+    const report = publishLint(
+      spec,
+      baseRepoState({
+        repoRoot: fx.dir,
+        config: { publish_lint: { allowed_commands: ["rm"] } },
+      }),
+    );
+    const soft = report.softWarnings.filter(
+      (w) => w.kind === "unknown-command" && w.message.includes("rm"),
+    );
+    expect(soft.length).toBe(0);
+  });
+
+  test("$PATH is NOT consulted: an on-PATH binary still raises a soft warning", () => {
+    // Create a fake binary in a temp PATH directory and prepend it to PATH.
+    const pathDir = mkdtempSync(join(tmpdir(), "samospec-fake-path-"));
+    try {
+      const fakeBin = join(pathDir, "foobar");
+      writeFileSync(fakeBin, "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+      const originalPath = process.env["PATH"];
+      process.env["PATH"] = `${pathDir}:${originalPath ?? ""}`;
+      try {
+        const spec = ["```bash", "foobar --run", "```"].join("\n");
+        const report = publishLint(spec, baseRepoState({ repoRoot: fx.dir }));
+        const foobarSoft = report.softWarnings.filter((w) =>
+          w.message.includes("foobar"),
+        );
+        expect(foobarSoft.length).toBe(1);
+        expect(foobarSoft[0]?.kind).toBe("unknown-command");
+      } finally {
+        if (originalPath === undefined) {
+          delete process.env["PATH"];
+        } else {
+          process.env["PATH"] = originalPath;
+        }
+      }
+    } finally {
+      rmSync(pathDir, { recursive: true, force: true });
+    }
+  });
+
+  test("commands outside bash/sh/shell fences are NOT flagged", () => {
+    const spec = [
+      "```ts",
+      "// rm -rf /",
+      "```",
+      "",
+      "```",
+      "rm -rf /",
+      "```",
+    ].join("\n");
+    const report = publishLint(spec, baseRepoState({ repoRoot: fx.dir }));
+    const soft = report.softWarnings.filter((w) => w.kind === "unknown-command");
+    expect(soft.length).toBe(0);
+  });
+});
+
+describe("publishLint — soft warnings: ghost branches", () => {
+  let fx: Fixture;
+  beforeEach(() => {
+    fx = mkFixture();
+  });
+  afterEach(() => {
+    fx.cleanup();
+  });
+
+  test("`samospec/refunds` ghost branch is SOFT when not in repoState.branches", () => {
+    const spec = "The flow lives on `samospec/refunds`.";
+    const report = publishLint(
+      spec,
+      baseRepoState({
+        repoRoot: fx.dir,
+        branches: ["main"],
+      }),
+    );
+    const soft = report.softWarnings.filter((w) => w.kind === "ghost-branch");
+    expect(soft.map((s) => s.message).join(" ")).toContain("samospec/refunds");
+  });
+
+  test("known branch in repoState.branches → NO warning", () => {
+    const spec = "The flow lives on `samospec/refunds`.";
+    const report = publishLint(
+      spec,
+      baseRepoState({
+        repoRoot: fx.dir,
+        branches: ["main", "samospec/refunds"],
+      }),
+    );
+    const soft = report.softWarnings.filter((w) => w.kind === "ghost-branch");
+    expect(soft).toEqual([]);
+  });
+
+  test("branch in `protectedBranches` list is treated as known", () => {
+    const spec = "Merges on `main`.";
+    const report = publishLint(
+      spec,
+      baseRepoState({
+        repoRoot: fx.dir,
+        branches: [],
+        protectedBranches: ["main"],
+      }),
+    );
+    const soft = report.softWarnings.filter(
+      (w) => w.kind === "ghost-branch" && w.message.includes("main"),
+    );
+    expect(soft).toEqual([]);
+  });
+
+  test("path-looking refs like `src/foo.ts` are NOT reported as branches", () => {
+    fx.write("src/foo.ts", "// present\n");
+    const spec = "See `src/foo.ts`.";
+    const report = publishLint(
+      spec,
+      baseRepoState({ repoRoot: fx.dir, branches: [] }),
+    );
+    const soft = report.softWarnings.filter((w) => w.kind === "ghost-branch");
+    expect(soft).toEqual([]);
+  });
+});
+
+describe("publishLint — soft warnings: adapter/model drift", () => {
+  let fx: Fixture;
+  beforeEach(() => {
+    fx = mkFixture();
+  });
+  afterEach(() => {
+    fx.cleanup();
+  });
+
+  test("drift: spec mentions `claude-opus-4-6` but state.json has `claude-opus-4-7`", () => {
+    const spec = "Lead runs on `claude-opus-4-6`.";
+    const report = publishLint(
+      spec,
+      baseRepoState({
+        repoRoot: fx.dir,
+        adapterModels: ["claude-opus-4-7", "gpt-5.1-codex-max"],
+      }),
+    );
+    const soft = report.softWarnings.filter((w) => w.kind === "adapter-drift");
+    expect(soft.length).toBe(1);
+    expect(soft[0]?.message).toContain("claude-opus-4-6");
+  });
+
+  test("spec model matches resolved adapters → NO drift warning", () => {
+    const spec = "Lead runs on `claude-opus-4-7`.";
+    const report = publishLint(
+      spec,
+      baseRepoState({
+        repoRoot: fx.dir,
+        adapterModels: ["claude-opus-4-7"],
+      }),
+    );
+    const soft = report.softWarnings.filter((w) => w.kind === "adapter-drift");
+    expect(soft).toEqual([]);
+  });
+});
+
+describe("publishLint — report shape", () => {
+  let fx: Fixture;
+  beforeEach(() => {
+    fx = mkFixture();
+  });
+  afterEach(() => {
+    fx.cleanup();
+  });
+
+  test("empty spec yields empty report", () => {
+    const report = publishLint("", baseRepoState({ repoRoot: fx.dir }));
+    expect(report).toEqual({ hardWarnings: [], softWarnings: [] });
+  });
+
+  test("whitespace-only spec yields empty report", () => {
+    const report = publishLint(
+      "   \n   \n\t\n",
+      baseRepoState({ repoRoot: fx.dir }),
+    );
+    expect(report).toEqual({ hardWarnings: [], softWarnings: [] });
+  });
+
+  test("hard and soft warnings are separated and kinds are fixed", () => {
+    const spec = [
+      "Path: `src/does-not-exist.ts`.",
+      "",
+      "```bash",
+      "zzzz --flag",
+      "```",
+    ].join("\n");
+    const report = publishLint(
+      spec,
+      baseRepoState({ repoRoot: fx.dir, branches: [] }),
+    );
+    // Shape invariants: arrays + well-known kinds.
+    for (const w of report.hardWarnings) {
+      expect(["missing-path"]).toContain(w.kind);
+      expect(typeof w.message).toBe("string");
+    }
+    for (const w of report.softWarnings) {
+      expect([
+        "unknown-command",
+        "ghost-branch",
+        "adapter-drift",
+      ]).toContain(w.kind);
+    }
+    // Missing-path extracted + unknown-command `zzzz` both present.
+    expect(report.hardWarnings.length).toBeGreaterThan(0);
+    const softKinds = report.softWarnings.map((w) => w.kind);
+    expect(softKinds).toContain("unknown-command");
+  });
+
+  test("location info present when derivable for hard warnings", () => {
+    const spec = [
+      "preamble line 1",
+      "preamble line 2",
+      "missing `src/gone.ts` reference",
+    ].join("\n");
+    const report = publishLint(
+      spec,
+      baseRepoState({ repoRoot: fx.dir, branches: [] }),
+    );
+    const hard = report.hardWarnings.find((w) =>
+      w.message.includes("src/gone.ts"),
+    );
+    expect(hard?.location?.line).toBe(3);
+  });
+});


### PR DESCRIPTION
Closes #33.

## Summary

- Implements the standalone publish-lint module per SPEC §14 \"Hallucinated repo facts (publish lint, broadened)\" — consumed by Issue #32's `samospec publish` stub after both land.
- Hard warnings: missing file paths (definitely wrong, surfaced prominently in the PR body).
- Soft warnings: unknown command, ghost branch, adapter/model drift (heuristic).
- Command allowlist is hardcoded + user-extensible via `.samospec/config.json` `publish_lint.allowed_commands`; `$PATH` is **not** consulted (SPEC §14 security note — user-controlled).
- Branch/path precedence: a `<word>/<slug>` token without a known file extension prefers the branch interpretation so the two warning channels never double-count the same token.

## Files

- `src/publish/lint-types.ts` — `RepoState`, `LintFinding`, `PublishLintReport`
- `src/publish/lint-extractors.ts` — pure path / command / branch / adapter-name extractors
- `src/publish/lint.ts` — orchestrator
- `src/cli/init.ts` — `DEFAULT_CONFIG` seeds `publish_lint.allowed_commands: []`
- `tests/publish/lint-extractors.test.ts`, `tests/publish/lint.test.ts`

## Checklist (from Issue #33 acceptance criteria)

- [x] `publishLint(spec, repoState)` signature + `PublishLintReport` shape
- [x] Hard warning: missing path, with `LintFinding.location.line`
- [x] Path inclusion rules (a) fenced, (b) backticked `/`-containing or known extension, (c) bullets under `Files` / `Layout` / `Storage` (suffix-insensitive)
- [x] Path exclusions: URLs, version-number strings, bare dotted prose (`e.g.`, `foo.bar.baz`, `example.com.au`)
- [x] Soft warning: unknown command from `bash` / `sh` / `shell` fences
- [x] Default allowlist `[samospec, git, gh, glab, bun, node, claude, codex]`; user extension via config
- [x] `\$PATH` NOT consulted — fake-binary test in PATH still produces the warning
- [x] Soft warning: ghost branch (skipped for file-path-looking tokens)
- [x] Soft warning: adapter/model drift against `state.json.adapters`
- [x] Init default config gains `publish_lint.allowed_commands: []`
- [x] Hard vs soft separated in report; location line recorded when derivable
- [x] Empty spec → `{ hardWarnings: [], softWarnings: [] }`

## Out of scope (per assignment)

- Integration with `samospec publish` (Issue #32 owns `src/cli/publish.ts`)
- `--no-lint` flag (Issue #32)
- Writing `publish-lint.json` to disk (Issue #32's concern)
- Doctor changes (Issue #34)

## Test plan

- [x] `bun test tests/publish/` — 59/59 green
- [x] `bun test` — 1025/1025 green
- [x] `bun run lint` — no issues
- [x] `bun run typecheck` — clean
- [x] `bun run format:check` — pass

## Testing evidence

```
bun test tests/publish/
  59 pass
  0 fail
  83 expect() calls
```

Corpus-driven coverage:

- Inclusion: 10 path extensions tested via `test.each`; ts/bash/sh/shell/text/language-less fence behavior; 3 section-header shapes including suffix-insensitive `State Storage`; header reset on next `##`.
- Exclusion: version `v1.2.3` / `0.1.0` / `1.0` in prose and in backticks; URLs in prose and in backticks; 5 bare-dotted-prose patterns; bareword like `iterate` not a path.
- Commands: `bash`/`sh`/`shell` vs `ts`/`js`/no-tag; blank/comment/prompt handling; line numbers.
- Branches: `samospec/refunds`, `main`, `feature/xyz`; skip for path-looking tokens; skip for URLs.
- Adapters: `claude-opus-4-7`, `gpt-5.1-codex-max`, `claude-sonnet-4-6`, `gpt-5.1-codex`.
- `\$PATH`-not-trusted: fake `foobar` binary in PATH still yields a soft warning.
- Allowlist: `publish_lint.allowed_commands: [\"rm\"]` silences the `rm` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)