### PR TITLE
feat: Sprint 4 #32 — samospec publish

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import {
 } from "./cli/iterate.ts";
 import { describePrCapability } from "./git/push-consent.ts";
 import { runNew, type ChoiceResolvers } from "./cli/new.ts";
+import { runPublish } from "./cli/publish.ts";
 import {
   PERSONA_FORM_RE,
   extractSkill,
@@ -50,6 +51,8 @@ const USAGE =
   "  iterate [<slug>] [--rounds N] [--no-push] [--remote <name>]\n" +
   "                              Run review rounds until a stopping condition fires.\n" +
   "  status [<slug>]             Print phase, round, cost, wall-clock, and next action.\n" +
+  "  publish [<slug>] [--no-lint] [--remote <name>]\n" +
+  "                              Promote to blueprints/<slug>/SPEC.md, commit, push, open PR.\n" +
   "  version                     Print the samospec version and exit.\n";
 
 /**
@@ -114,6 +117,10 @@ export async function runCli(argv: readonly string[]): Promise<CliResult> {
 
   if (command === "status") {
     return runStatusCommand(rest);
+  }
+
+  if (command === "publish") {
+    return runPublishCommand(rest);
   }
 
   return {
@@ -486,5 +493,57 @@ async function runStatusCommand(rest: readonly string[]) {
     slug: parsed.slug,
     now: new Date().toISOString(),
     adapters: bindings,
+  });
+}
+
+// ---------- publish ----------
+
+interface PublishArgs {
+  readonly slug: string;
+  readonly noLint: boolean;
+  readonly remote: string;
+}
+
+function parsePublishArgs(argv: readonly string[]): PublishArgs | string {
+  let slug: string | null = null;
+  let noLint = false;
+  let remote = "origin";
+  for (let i = 0; i < argv.length; i += 1) {
+    const t = argv[i];
+    if (t === undefined) continue;
+    if (t === "--no-lint") {
+      noLint = true;
+      continue;
+    }
+    if (t === "--remote") {
+      const v = argv[i + 1];
+      i += 1;
+      if (v !== undefined && v.length > 0) remote = v;
+      continue;
+    }
+    if (t.startsWith("--remote=")) {
+      remote = t.slice("--remote=".length);
+      continue;
+    }
+    if (t.startsWith("--")) continue;
+    slug ??= t;
+  }
+  if (slug === null || slug.length === 0) {
+    return "samospec publish: missing <slug>";
+  }
+  return { slug, noLint, remote };
+}
+
+async function runPublishCommand(rest: readonly string[]) {
+  const parsed = parsePublishArgs(rest);
+  if (typeof parsed === "string") {
+    return { exitCode: 1, stdout: "", stderr: `${parsed}\n\n${USAGE}` };
+  }
+  return runPublish({
+    cwd: process.cwd(),
+    slug: parsed.slug,
+    now: new Date().toISOString(),
+    remote: parsed.remote,
+    noLint: parsed.noLint,
   });
 }

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -1,0 +1,507 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §5 Phase 7 + §8 + §9 + §10 — `samospec publish`.
+ *
+ * Promotes the committed working SPEC.md to `blueprints/<slug>/SPEC.md`,
+ * creates the publish commit on the current `samospec/<slug>` branch
+ * (never a protected branch — safety invariant), pushes to the remote
+ * if consent is granted, opens a PR via `gh` preferred over `glab`, and
+ * records the advance in state.json.
+ *
+ * Flow:
+ *   1. Preconditions (exit 1 on miss):
+ *      - `.samospec/spec/<slug>/state.json` exists.
+ *      - `state.round_state === "committed"`.
+ *      - `state.published_at` is absent (republish error message).
+ *   2. Safety invariant: refuse if current branch is protected (exit 2).
+ *   3. Copy SPEC.md → `blueprints/<slug>/SPEC.md`.
+ *   4. Advance state: set `published_at`, `published_version`,
+ *      `phase = "publish"` (§5 Phase 7), write via writeState.
+ *   5. `specCommit` with action `publish`, version stripped to `X.Y` when
+ *      the stored triple is `X.Y.0` (SPEC §8 grammar).
+ *   6. Push per consent (existing #31 helpers).
+ *   7. Open PR: compose body from TLDR + changelog + meta + lint seam.
+ *   8. On PR open success: write the URL back into state.json.
+ *
+ * Scope guards:
+ *   - NO lint rule implementation (Issue #33).
+ *   - NO force push, no amend — the existing git helpers forbid it.
+ *   - NO destructive ops.
+ *
+ * Exit codes (SPEC §10):
+ *   - 0 success.
+ *   - 1 preconditions (no spec / not committed / already published).
+ *   - 2 push failure or protected-branch refusal.
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { currentBranch } from "../git/branch.ts";
+import { specCommit } from "../git/commit.ts";
+import { ProtectedBranchError } from "../git/errors.ts";
+import { isProtected } from "../git/protected.ts";
+import {
+  loadPersistedConsent,
+  probePrCapability,
+  type PrCapabilityProbe,
+} from "../git/push-consent.ts";
+import { pushBranch, type PushBranchResult } from "../git/push.ts";
+import { formatVersionLabel } from "../loop/version.ts";
+import { writeState } from "../state/store.ts";
+import { stateSchema, type State } from "../state/types.ts";
+import { specPaths } from "./new.ts";
+import { buildPrBody } from "../publish/body.ts";
+import { promoteSpecToBlueprint } from "../publish/blueprints.ts";
+import {
+  publishLintStub,
+  type PublishLint,
+  type PublishLintReport,
+} from "../publish/lint-stub.ts";
+import {
+  buildCompareUrl,
+  openPullRequest,
+  type OpenPrResult,
+} from "../publish/pr.ts";
+
+export interface PublishInput {
+  readonly cwd: string;
+  readonly slug: string;
+  readonly now: string;
+  readonly remote: string;
+  /** Override env forwarded to `gh` / `glab` — test shims use this. */
+  readonly env?: NodeJS.ProcessEnv;
+  /** `--no-lint` — skip the lint call entirely. */
+  readonly noLint?: boolean;
+  /** Lint injection seam. Defaults to the stub (Issue #33 replaces). */
+  readonly lint?: PublishLint;
+  /** PR-capability probe override — tests use a deterministic probe. */
+  readonly probePrCapability?: () => PrCapabilityProbe;
+}
+
+export interface PublishResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function runPublish(input: PublishInput): Promise<PublishResult> {
+  // NOTE: the body is synchronous today — all I/O is `fs` sync and
+  // `spawnSync`. The function is typed `async` so the runCli dispatch
+  // shape stays uniform with `runIterate` / `runNew` / etc., and so a
+  // future push-consent prompt can slot in without a signature change.
+  const outLines: string[] = [];
+  const errLines: string[] = [];
+  const notice = (s: string): void => {
+    outLines.push(s);
+  };
+  const error = (s: string): void => {
+    errLines.push(s);
+  };
+
+  const paths = specPaths(input.cwd, input.slug);
+
+  // -- preconditions --
+  if (!existsSync(paths.statePath)) {
+    error(
+      `samospec: no spec found for slug '${input.slug}'. ` +
+        `Run \`samospec new ${input.slug}\` first.`,
+    );
+    return finish(1, outLines, errLines);
+  }
+
+  const stateParsed = stateSchema.safeParse(
+    JSON.parse(readFileSync(paths.statePath, "utf8")) as unknown,
+  );
+  if (!stateParsed.success) {
+    error(
+      `samospec: state.json at ${paths.statePath} is malformed: ${stateParsed.error.message}`,
+    );
+    return finish(1, outLines, errLines);
+  }
+  const state: State = stateParsed.data;
+
+  // Republish check (must come BEFORE the committed-state check so the
+  // message is actionable: we don't want to confuse users who already
+  // advanced past `committed` via publish).
+  if (state.published_at !== undefined) {
+    error(
+      `samospec: '${input.slug}' is already published at ${state.published_at}. ` +
+        `Use \`samospec iterate ${input.slug}\` to run more rounds, then republish.`,
+    );
+    return finish(1, outLines, errLines);
+  }
+
+  if (state.round_state !== "committed") {
+    error(
+      `samospec: '${input.slug}' is at round_state '${state.round_state}', ` +
+        `expected 'committed'. Complete at least a v0.1 draft via ` +
+        `\`samospec new ${input.slug}\` or \`samospec iterate ${input.slug}\` first.`,
+    );
+    return finish(1, outLines, errLines);
+  }
+
+  if (!existsSync(paths.specPath)) {
+    error(
+      `samospec: SPEC.md for '${input.slug}' is missing — run ` +
+        `\`samospec resume ${input.slug}\` first.`,
+    );
+    return finish(1, outLines, errLines);
+  }
+
+  // -- safety invariant (SPEC §8 + Sprint 1 #3): refuse up-front on a
+  // protected branch BEFORE mutating any files or state. This keeps
+  // the filesystem unchanged if the user ran publish from the wrong
+  // branch by accident.
+  const preBranch = currentBranch(input.cwd);
+  if (isProtected(preBranch, { repoPath: input.cwd })) {
+    error(
+      `samospec: cannot commit on protected branch '${preBranch}'. ` +
+        `Check out samospec/${input.slug} and re-run.`,
+    );
+    return finish(2, outLines, errLines);
+  }
+
+  // -- promote blueprint --
+  // SPEC §9: `blueprints/<slug>/SPEC.md` is a promoted snapshot; never
+  // hand-edited. `promoteSpecToBlueprint` is idempotent.
+  const blueprintPath = promoteSpecToBlueprint({
+    cwd: input.cwd,
+    slug: input.slug,
+  });
+
+  // -- advance state --
+  const publishedVersion = formatVersionLabel(state.version); // `v0.2`
+  const commitVersion = stripLeadingV(publishedVersion); // `0.2`
+  const advancedState: State = {
+    ...state,
+    phase: "publish",
+    published_at: input.now,
+    published_version: publishedVersion,
+    updated_at: input.now,
+  };
+  writeState(paths.statePath, advancedState);
+
+  // -- commit on the samospec/<slug> branch --
+  // specCommit refuses on protected branches (SPEC §8 safety invariant).
+  try {
+    specCommit({
+      repoPath: input.cwd,
+      slug: input.slug,
+      action: "publish",
+      version: commitVersion,
+      paths: [
+        path.relative(input.cwd, blueprintPath),
+        path.relative(input.cwd, paths.statePath),
+      ],
+    });
+    notice(`committed spec(${input.slug}): publish ${publishedVersion}.`);
+  } catch (err) {
+    if (err instanceof ProtectedBranchError) {
+      error(
+        `samospec: cannot commit on protected branch '${err.branchName}'. ` +
+          `Check out samospec/${input.slug} and re-run.`,
+      );
+      return finish(2, outLines, errLines);
+    }
+    throw err;
+  }
+
+  // -- push --
+  const branch = currentBranch(input.cwd);
+  const remoteUrl = resolveRemoteUrl(input.cwd, input.remote);
+  const defaultBranch = resolveDefaultBranch(input.cwd, input.remote);
+  let pushResult: PushBranchResult | null = null;
+  if (remoteUrl !== null) {
+    const consent = loadPersistedConsent({
+      repoPath: input.cwd,
+      remoteUrl,
+    });
+    // Honor consent: accepted → push; refused or unresolved → skip.
+    const granted = consent === true;
+    pushResult = safePushBranch({
+      repoPath: input.cwd,
+      remote: input.remote,
+      branch,
+      granted,
+      noPush: false,
+    });
+    switch (pushResult.state) {
+      case "pushed":
+        notice(`pushed to ${input.remote}.`);
+        break;
+      case "skipped-refused":
+        error(
+          `samospec: push skipped — consent refused. ` +
+            `PR cannot be opened without remote push.`,
+        );
+        break;
+      case "skipped-no-push":
+        // Not reachable (noPush is always false here), kept for
+        // exhaustiveness.
+        break;
+      case "failed":
+        error(
+          `samospec: push to ${input.remote} failed: ${pushResult.message ?? "(no detail)"}.`,
+        );
+        return finish(2, outLines, errLines);
+    }
+  }
+
+  // -- compose PR body --
+  // Read TLDR + changelog fresh (both committed by iterate / new).
+  const tldr = existsSync(paths.tldrPath)
+    ? readFileSync(paths.tldrPath, "utf8")
+    : `# TL;DR\n\nSee SPEC.md.\n`;
+  const changelog = existsSync(paths.changelogPath)
+    ? readFileSync(paths.changelogPath, "utf8")
+    : `# changelog\n`;
+
+  // -- lint seam --
+  let lintReport: PublishLintReport = { hardWarnings: [], softWarnings: [] };
+  if (input.noLint !== true) {
+    const lint: PublishLint = input.lint ?? publishLintStub;
+    lintReport = lint({
+      specBody: readFileSync(paths.specPath, "utf8"),
+      repoPath: input.cwd,
+      slug: input.slug,
+    });
+  }
+
+  const degradedResolution = summarizeDegraded(state);
+  const exitReason = state.exit?.reason ?? "committed";
+  const body = buildPrBody({
+    slug: input.slug,
+    version: publishedVersion,
+    tldr,
+    changelog,
+    roundCount: state.round_index,
+    exitReason,
+    degradedResolution,
+    lintReport,
+  });
+
+  // -- PR open (or compare URL) --
+  // Only attempt to open a PR when the push actually landed; otherwise
+  // there is no source branch on the remote for gh/glab to target.
+  let prResult: OpenPrResult | null = null;
+  if (pushResult?.state === "pushed" && remoteUrl !== null) {
+    const capability = (input.probePrCapability ?? defaultProbe(input))();
+    const bodyFile = writeTempBody(body);
+    try {
+      prResult = openPullRequest({
+        capability,
+        title: `spec(${input.slug}): publish ${publishedVersion}`,
+        bodyFile,
+        branch,
+        defaultBranch,
+        remoteUrl,
+        ...(input.env !== undefined ? { env: input.env } : {}),
+        cwd: input.cwd,
+      });
+    } finally {
+      cleanupTempBody(bodyFile);
+    }
+    handlePrResult(prResult, notice, error);
+  } else if (remoteUrl !== null) {
+    // Push was skipped; surface a compare URL so the user can open the
+    // PR after they push manually.
+    const compareUrl = buildCompareUrl({
+      remoteUrl,
+      defaultBranch,
+      branch,
+    });
+    if (compareUrl !== null) {
+      notice(`Open a PR manually after pushing: ${compareUrl}`);
+    }
+  }
+
+  // -- persist PR URL on success --
+  if (
+    prResult !== null &&
+    prResult.kind === "opened" &&
+    prResult.url !== undefined
+  ) {
+    const withUrl: State = {
+      ...advancedState,
+      published_pr_url: prResult.url,
+      updated_at: input.now,
+    };
+    writeState(paths.statePath, withUrl);
+  }
+
+  return finish(0, outLines, errLines);
+}
+
+// ---------- helpers ----------
+
+function finish(
+  exitCode: number,
+  outLines: readonly string[],
+  errLines: readonly string[],
+): PublishResult {
+  return {
+    exitCode,
+    stdout: outLines.length > 0 ? `${outLines.join("\n")}\n` : "",
+    stderr: errLines.length > 0 ? `${errLines.join("\n")}\n` : "",
+  };
+}
+
+function stripLeadingV(label: string): string {
+  return label.startsWith("v") ? label.slice(1) : label;
+}
+
+function safePushBranch(args: {
+  readonly repoPath: string;
+  readonly remote: string;
+  readonly branch: string;
+  readonly granted: boolean;
+  readonly noPush: boolean;
+}): PushBranchResult {
+  try {
+    return pushBranch(args);
+  } catch (err) {
+    return {
+      state: "failed",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function resolveRemoteUrl(cwd: string, remote: string): string | null {
+  const res = spawnSync("git", ["remote", "get-url", remote], {
+    cwd,
+    encoding: "utf8",
+  });
+  if ((res.status ?? 1) !== 0) return null;
+  const url = (res.stdout ?? "").trim();
+  return url.length > 0 ? url : null;
+}
+
+function resolveDefaultBranch(cwd: string, remote: string): string {
+  const head = spawnSync(
+    "git",
+    ["symbolic-ref", "--quiet", `refs/remotes/${remote}/HEAD`],
+    { cwd, encoding: "utf8" },
+  );
+  if ((head.status ?? 1) === 0) {
+    const ref = (head.stdout ?? "").trim();
+    const prefix = `refs/remotes/${remote}/`;
+    if (ref.startsWith(prefix)) return ref.slice(prefix.length);
+  }
+  const cfg = spawnSync("git", ["config", "--get", "init.defaultBranch"], {
+    cwd,
+    encoding: "utf8",
+  });
+  if ((cfg.status ?? 1) === 0) {
+    const v = (cfg.stdout ?? "").trim();
+    if (v.length > 0) return v;
+  }
+  return "main";
+}
+
+function summarizeDegraded(state: State): string | null {
+  if (!state.coupled_fallback) return null;
+  const lead = state.adapters?.lead;
+  if (lead?.effort_used !== undefined && lead.effort_requested !== undefined) {
+    if (lead.effort_used !== lead.effort_requested) {
+      return (
+        `Lead ran at effort '${lead.effort_used}' ` +
+        `(requested '${lead.effort_requested}').`
+      );
+    }
+  }
+  return "Coupled fallback active — one or more adapters ran below policy.";
+}
+
+function defaultProbe(input: PublishInput): () => PrCapabilityProbe {
+  return () =>
+    probePrCapability({
+      gh: () => {
+        const res = spawnSync("gh", ["auth", "status"], {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            GIT_TERMINAL_PROMPT: "0",
+            ...(input.env ?? {}),
+          },
+        });
+        return {
+          status: res.status ?? 1,
+          stdout: res.stdout ?? "",
+          stderr: res.stderr ?? "",
+        };
+      },
+      glab: () => {
+        const res = spawnSync("glab", ["auth", "status"], {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            GIT_TERMINAL_PROMPT: "0",
+            ...(input.env ?? {}),
+          },
+        });
+        return {
+          status: res.status ?? 1,
+          stdout: res.stdout ?? "",
+          stderr: res.stderr ?? "",
+        };
+      },
+    });
+}
+
+function writeTempBody(body: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "samospec-publish-body-"));
+  const file = path.join(dir, "body.md");
+  writeFileSync(file, body, "utf8");
+  return file;
+}
+
+function cleanupTempBody(file: string): void {
+  try {
+    rmSync(path.dirname(file), { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+function handlePrResult(
+  prResult: OpenPrResult,
+  notice: (s: string) => void,
+  error: (s: string) => void,
+): void {
+  switch (prResult.kind) {
+    case "opened":
+      if (prResult.url !== undefined) {
+        notice(`PR opened via ${prResult.tool}: ${prResult.url}`);
+      } else {
+        notice(`PR opened via ${prResult.tool}.`);
+      }
+      return;
+    case "compare-url":
+      notice(`Open a PR manually: ${prResult.url}`);
+      return;
+    case "failed":
+      error(
+        `samospec: ${prResult.tool} pr create failed: ${prResult.message}.`,
+      );
+      return;
+    case "no-compare-url":
+      error(`samospec: ${prResult.reason}`);
+      return;
+    default: {
+      const _never: never = prResult;
+      void _never;
+    }
+  }
+}

--- a/src/publish/blueprints.ts
+++ b/src/publish/blueprints.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §5 Phase 7 + §9 — blueprint promotion.
+ *
+ * Copies `.samospec/spec/<slug>/SPEC.md` → `blueprints/<slug>/SPEC.md`,
+ * creating `blueprints/<slug>/` when missing. The blueprint is a
+ * promoted snapshot — SPEC §9 states it is **never hand-edited**. Any
+ * revisions go back through `samospec iterate` + `samospec publish`
+ * (the v1.1 plan includes a distinct `samospec tag` for release
+ * markers; out of scope here).
+ *
+ * This helper is idempotent by design: a stray manual re-run overwrites
+ * the existing blueprint with the current working SPEC.md. `runPublish`
+ * itself rejects republish via the `published_*` fields in state.json;
+ * the safety net here is only for callers wiring the primitive
+ * directly.
+ */
+
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+
+export interface PromoteOpts {
+  readonly cwd: string;
+  readonly slug: string;
+}
+
+/**
+ * Copy the working SPEC.md into `blueprints/<slug>/`. Returns the
+ * absolute destination path so callers can stage it before committing.
+ *
+ * Throws if the source SPEC.md is missing — the caller is expected to
+ * have validated the phase is `committed` before invoking this; a
+ * missing source means the preconditions check above was bypassed.
+ */
+export function promoteSpecToBlueprint(opts: PromoteOpts): string {
+  const src = path.join(opts.cwd, ".samospec", "spec", opts.slug, "SPEC.md");
+  if (!existsSync(src)) {
+    throw new Error(
+      `SPEC.md not found at ${src}. ` +
+        `Run \`samospec resume ${opts.slug}\` to produce a draft before publishing.`,
+    );
+  }
+  const dir = path.join(opts.cwd, "blueprints", opts.slug);
+  mkdirSync(dir, { recursive: true });
+  const dest = path.join(dir, "SPEC.md");
+  copyFileSync(src, dest);
+  return dest;
+}

--- a/src/publish/body.ts
+++ b/src/publish/body.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §5 Phase 7 — PR body composition.
+ *
+ * The PR body contains, in order:
+ *   1. Heading: `spec(<slug>): publish <version>`.
+ *   2. Spec summary: the TLDR.md body (as the reviewer's first read).
+ *   3. Meta: rounds run, exit reason, degraded resolution if any.
+ *   4. Changelog since v0.1 (verbatim from changelog.md).
+ *   5. Publish-lint:
+ *      - Hard warnings surfaced prominently (non-blocking per SPEC §14).
+ *      - Soft warnings in a collapsible `<details>` section.
+ *
+ * Markdown uses `- ` list items per CLAUDE.md. Timestamps remain in
+ * the changelog's ISO form.
+ */
+
+import type { PublishLintReport } from "./lint-stub.ts";
+
+export interface BuildPrBodyOpts {
+  readonly slug: string;
+  /** `vX.Y` or `vX.Y.Z`. */
+  readonly version: string;
+  /** Raw TLDR.md body from `.samospec/spec/<slug>/TLDR.md`. */
+  readonly tldr: string;
+  /** Raw changelog.md body. */
+  readonly changelog: string;
+  readonly roundCount: number;
+  readonly exitReason: string;
+  /** Summary string if any adapter is running under a degraded
+   *  resolution; `null` otherwise. */
+  readonly degradedResolution: string | null;
+  readonly lintReport: PublishLintReport;
+}
+
+export function buildPrBody(opts: BuildPrBodyOpts): string {
+  const out: string[] = [];
+  out.push(`# spec(${opts.slug}): publish ${opts.version}`);
+  out.push("");
+
+  out.push("## Spec summary");
+  out.push("");
+  out.push(opts.tldr.trimEnd());
+  out.push("");
+
+  out.push("## Publish meta");
+  out.push("");
+  out.push(`- Rounds run: ${String(opts.roundCount)}`);
+  out.push(`- Final exit reason: ${opts.exitReason}`);
+  if (opts.degradedResolution !== null && opts.degradedResolution.length > 0) {
+    out.push(`- Degraded resolution: ${opts.degradedResolution}`);
+  }
+  out.push("");
+
+  out.push("## Changelog since v0.1");
+  out.push("");
+  out.push(opts.changelog.trimEnd());
+  out.push("");
+
+  out.push("## Publish lint");
+  out.push("");
+  const hard = opts.lintReport.hardWarnings;
+  if (hard.length === 0) {
+    out.push("- Hard warnings: none.");
+  } else {
+    out.push("### Hard warnings");
+    out.push("");
+    for (const f of hard) {
+      out.push(`- \`${f.id}\` — ${f.message}`);
+    }
+  }
+  out.push("");
+
+  const soft = opts.lintReport.softWarnings;
+  if (soft.length === 0) {
+    out.push("- Soft warnings: none.");
+  } else {
+    out.push("<details>");
+    out.push("<summary>Soft warnings</summary>");
+    out.push("");
+    for (const f of soft) {
+      out.push(`- \`${f.id}\` — ${f.message}`);
+    }
+    out.push("");
+    out.push("</details>");
+  }
+  out.push("");
+
+  return out.join("\n");
+}

--- a/src/publish/lint-stub.ts
+++ b/src/publish/lint-stub.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §14 — publish-lint seam (stub for Issue #32).
+ *
+ * Issue #33 will implement the actual lint rules (paths, commands,
+ * branch names, adapter/model names). This module exports:
+ *
+ *   - `PublishLintReport` — the shape every lint implementation must
+ *     return, so callers (including `samospec publish` and any future
+ *     dogfood scorecard) can render findings uniformly.
+ *   - `publishLintStub` — a no-op implementation that returns empty
+ *     hard + soft warnings. Wiring `samospec publish` against the stub
+ *     lets us ship the publish flow independently of #33.
+ *
+ * Scope guard (per Issue #32): do NOT implement real lint rules here.
+ */
+
+export interface PublishLintFinding {
+  /** Short machine-readable id, e.g. `unknown-path`. */
+  readonly id: string;
+  /** Human-readable message surfaced in the PR body. */
+  readonly message: string;
+}
+
+export interface PublishLintReport {
+  /** Surfaced prominently in the PR body. Non-blocking per SPEC §14. */
+  readonly hardWarnings: readonly PublishLintFinding[];
+  /** Surfaced in a collapsible `<details>` section. */
+  readonly softWarnings: readonly PublishLintFinding[];
+}
+
+export interface PublishLintOpts {
+  /** Raw SPEC.md body. Rules in #33 will parse this. */
+  readonly specBody: string;
+  /** Absolute repo root. Path checks resolve under this. */
+  readonly repoPath: string;
+  /** Spec slug — used to scope branch-name checks in #33. */
+  readonly slug: string;
+}
+
+export type PublishLint = (opts: PublishLintOpts) => PublishLintReport;
+
+/**
+ * Default lint seam: returns an empty report. Replaced by Issue #33.
+ * Kept deterministic so tests can rely on it.
+ */
+export const publishLintStub: PublishLint = () => ({
+  hardWarnings: [],
+  softWarnings: [],
+});

--- a/src/publish/pr.ts
+++ b/src/publish/pr.ts
@@ -1,0 +1,261 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §5 Phase 7 + §10 — PR opening via `gh` / `glab` with a
+ * compare-URL fallback.
+ *
+ * Contract:
+ *   - When `capability.tool === "gh"` (probed via
+ *     src/git/push-consent.ts `probePrCapability`), invoke
+ *     `gh pr create --title ... --body-file ... --base ... --head ...`.
+ *   - When `capability.tool === "glab"`, invoke
+ *     `glab mr create --title ... --description-file ... ...` (glab
+ *     uses `--description` for the body; we pass the file via the
+ *     `-F`-equivalent long flag below).
+ *   - When `capability.available === false`, return the compare URL so
+ *     the caller can print it.
+ *
+ * Tests inject stub runners; the default production runner execs the
+ * chosen tool with silenced stdin. No `GIT_TERMINAL_PROMPT` games
+ * because `gh` / `glab` have their own credential flows — but we still
+ * propagate the invocation's env so PATH-shimmed test scripts work.
+ */
+
+import { spawnSync } from "node:child_process";
+
+import type { PrCapabilityProbe } from "../git/push-consent.ts";
+
+export interface PrRunnerResult {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export type PrRunner = (argv: readonly string[]) => PrRunnerResult;
+
+export interface OpenPrOpts {
+  readonly capability: PrCapabilityProbe;
+  readonly title: string;
+  readonly bodyFile: string;
+  readonly branch: string;
+  readonly defaultBranch: string;
+  readonly remoteUrl: string;
+  /** Override PATH / cwd for subprocess execs. */
+  readonly env?: NodeJS.ProcessEnv;
+  readonly cwd?: string;
+  /** Injection seams — tests pass fake runners. */
+  readonly gh?: PrRunner;
+  readonly glab?: PrRunner;
+}
+
+export type OpenPrResult =
+  | {
+      readonly kind: "opened";
+      readonly tool: "gh" | "glab";
+      /** Parsed PR URL from the tool's stdout, when available. */
+      readonly url?: string;
+    }
+  | {
+      readonly kind: "compare-url";
+      readonly url: string;
+    }
+  | {
+      readonly kind: "failed";
+      readonly tool: "gh" | "glab";
+      readonly message: string;
+    }
+  | {
+      readonly kind: "no-compare-url";
+      readonly reason: string;
+    };
+
+export function openPullRequest(opts: OpenPrOpts): OpenPrResult {
+  const compareUrl = buildCompareUrl({
+    remoteUrl: opts.remoteUrl,
+    defaultBranch: opts.defaultBranch,
+    branch: opts.branch,
+  });
+
+  if (!opts.capability.available) {
+    if (compareUrl === null) {
+      return {
+        kind: "no-compare-url",
+        reason:
+          `Cannot derive a compare URL for remote '${opts.remoteUrl}'. ` +
+          `Open a PR manually from branch '${opts.branch}' → '${opts.defaultBranch}'.`,
+      };
+    }
+    return { kind: "compare-url", url: compareUrl };
+  }
+
+  // gh preferred when both are authenticated (probe enforces this).
+  if (opts.capability.tool === "gh") {
+    const run = opts.gh ?? defaultGhRunner(opts);
+    const res = run([
+      "pr",
+      "create",
+      "--title",
+      opts.title,
+      "--body-file",
+      opts.bodyFile,
+      "--base",
+      opts.defaultBranch,
+      "--head",
+      opts.branch,
+    ]);
+    if (res.status !== 0) {
+      return {
+        kind: "failed",
+        tool: "gh",
+        message: (res.stderr ?? "").trim() || (res.stdout ?? "").trim(),
+      };
+    }
+    const url = extractFirstUrl(res.stdout);
+    return url !== null
+      ? { kind: "opened", tool: "gh", url }
+      : { kind: "opened", tool: "gh" };
+  }
+
+  if (opts.capability.tool === "glab") {
+    const run = opts.glab ?? defaultGlabRunner(opts);
+    const res = run([
+      "mr",
+      "create",
+      "--title",
+      opts.title,
+      "--description-file",
+      opts.bodyFile,
+      "--target-branch",
+      opts.defaultBranch,
+      "--source-branch",
+      opts.branch,
+      "--yes",
+    ]);
+    if (res.status !== 0) {
+      return {
+        kind: "failed",
+        tool: "glab",
+        message: (res.stderr ?? "").trim() || (res.stdout ?? "").trim(),
+      };
+    }
+    const url = extractFirstUrl(res.stdout);
+    return url !== null
+      ? { kind: "opened", tool: "glab", url }
+      : { kind: "opened", tool: "glab" };
+  }
+
+  if (compareUrl === null) {
+    return {
+      kind: "no-compare-url",
+      reason: `Unknown capability tool and no compare URL derivable.`,
+    };
+  }
+  return { kind: "compare-url", url: compareUrl };
+}
+
+function defaultGhRunner(opts: OpenPrOpts): PrRunner {
+  return (argv) => {
+    const res = spawnSync("gh", argv as string[], {
+      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+        ...(opts.env ?? {}),
+      },
+    });
+    return {
+      status: res.status ?? 1,
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? "",
+    };
+  };
+}
+
+function defaultGlabRunner(opts: OpenPrOpts): PrRunner {
+  return (argv) => {
+    const res = spawnSync("glab", argv as string[], {
+      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+        ...(opts.env ?? {}),
+      },
+    });
+    return {
+      status: res.status ?? 1,
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? "",
+    };
+  };
+}
+
+function extractFirstUrl(stdout: string): string | null {
+  const match = /https?:\/\/\S+/.exec(stdout);
+  return match === null ? null : match[0];
+}
+
+// ---------- compare URL derivation ----------
+
+export interface CompareUrlOpts {
+  readonly remoteUrl: string;
+  readonly defaultBranch: string;
+  readonly branch: string;
+}
+
+/**
+ * Derive a web-compare URL from a GitHub/GitLab remote URL. Returns
+ * `null` for unrecognized hosts. Handles both `git@host:owner/repo.git`
+ * and `https://host/owner/repo.git` shapes.
+ */
+export function buildCompareUrl(opts: CompareUrlOpts): string | null {
+  const parsed = parseRemote(opts.remoteUrl);
+  if (parsed === null) return null;
+
+  if (parsed.host.endsWith("github.com")) {
+    return (
+      `https://${parsed.host}/${parsed.owner}/${parsed.repo}/compare/` +
+      `${opts.defaultBranch}...${opts.branch}`
+    );
+  }
+  if (parsed.host.endsWith("gitlab.com")) {
+    // GitLab's "new MR" URL carries the source + target via query params.
+    return (
+      `https://${parsed.host}/${parsed.owner}/${parsed.repo}/-/merge_requests/new` +
+      `?merge_request[source_branch]=${opts.branch}` +
+      `&merge_request[target_branch]=${opts.defaultBranch}`
+    );
+  }
+  return null;
+}
+
+interface ParsedRemote {
+  readonly host: string;
+  readonly owner: string;
+  readonly repo: string;
+}
+
+function parseRemote(url: string): ParsedRemote | null {
+  // ssh form: git@host:owner/repo(.git)?
+  const ssh = /^git@([^:]+):([^/]+)\/(.+?)(?:\.git)?$/.exec(url);
+  if (ssh !== null) {
+    const host = ssh[1];
+    const owner = ssh[2];
+    const repo = ssh[3];
+    if (host !== undefined && owner !== undefined && repo !== undefined) {
+      return { host, owner, repo };
+    }
+  }
+  // https form: https://host/owner/repo(.git)?
+  const https = /^https?:\/\/([^/]+)\/([^/]+)\/(.+?)(?:\.git)?$/.exec(url);
+  if (https !== null) {
+    const host = https[1];
+    const owner = https[2];
+    const repo = https[3];
+    if (host !== undefined && owner !== undefined && repo !== undefined) {
+      return { host, owner, repo };
+    }
+  }
+  return null;
+}

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -111,6 +111,14 @@ const adapterResolutionSchema = z
   })
   .strict();
 
+// SPEC §5 Phase 7 + Issue #32 — label like `v0.2`, `v1.3.1`.
+const publishedVersionSchema = z
+  .string()
+  .regex(
+    /^v\d+\.\d+(?:\.\d+)?$/,
+    "published_version must look like 'vX.Y' or 'vX.Y.Z'",
+  );
+
 export const stateSchema = z
   .object({
     slug: z.string().min(1),
@@ -134,6 +142,12 @@ export const stateSchema = z
       .partial()
       .strict()
       .optional(),
+    // SPEC §5 Phase 7 + Issue #32 — `samospec publish` advance.
+    published_at: isoTimestampSchema.optional(),
+    published_version: publishedVersionSchema.optional(),
+    /** Absent when neither `gh` nor `glab` was authenticated; set from
+     * the tool's stdout URL when the PR was opened successfully. */
+    published_pr_url: z.string().min(1).optional(),
     created_at: isoTimestampSchema,
     updated_at: isoTimestampSchema,
   })

--- a/tests/cli/publish.test.ts
+++ b/tests/cli/publish.test.ts
@@ -1,0 +1,591 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §5 Phase 7 + §8 + §9 + §10 — `samospec publish` end-to-end.
+ *
+ * Exercises the full publish flow against a real temp bare remote and
+ * a scripted `gh`/`glab` PATH shim:
+ *
+ *   - Preconditions: no spec → exit 1; spec NOT in committed state → exit 1.
+ *   - Safety invariant: commit lands on `samospec/<slug>`, never `main`.
+ *   - Copy: SPEC.md promoted to `blueprints/<slug>/SPEC.md`.
+ *   - Commit grammar: `spec(<slug>): publish v<version>`.
+ *   - Consent-honoring push: accepted → `pushed`, refused → local-only + warning.
+ *   - PR open via `gh` shim: exact argv, body assembled from TLDR + changelog.
+ *   - Compare-URL fallback: neither `gh` nor `glab` authenticated → prints URL.
+ *   - `--no-lint` skips the lint call (mock throws to prove it's never called).
+ *   - Republish: second `publish` on the same slug exits 1.
+ *   - State advance: `published_at` + `published_version` recorded on success.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { runPublish } from "../../src/cli/publish.ts";
+import { writeState } from "../../src/state/store.ts";
+import type { State } from "../../src/state/types.ts";
+
+let tmp: string;
+let bare: string;
+let shim: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-publish-"));
+  bare = mkdtempSync(path.join(tmpdir(), "samospec-publish-bare-"));
+  shim = mkdtempSync(path.join(tmpdir(), "samospec-publish-shim-"));
+  spawnSync("git", ["init", "--bare", "--initial-branch", "main"], {
+    cwd: bare,
+  });
+  initRepo(tmp, bare);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  rmSync(bare, { recursive: true, force: true });
+  rmSync(shim, { recursive: true, force: true });
+});
+
+function initRepo(cwd: string, bareUrl: string): void {
+  spawnSync("git", ["init", "-q", "--initial-branch", "main"], { cwd });
+  spawnSync("git", ["config", "user.email", "test@example.com"], { cwd });
+  spawnSync("git", ["config", "user.name", "Test"], { cwd });
+  spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd });
+  writeFileSync(path.join(cwd, "README.md"), "seed\n", "utf8");
+  spawnSync("git", ["add", "README.md"], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "seed"], { cwd });
+  spawnSync("git", ["remote", "add", "origin", bareUrl], { cwd });
+  // Push seed to remote so origin has a `main` ref.
+  spawnSync("git", ["push", "-q", "origin", "main"], { cwd });
+  spawnSync("git", ["checkout", "-q", "-b", "samospec/refunds"], { cwd });
+}
+
+function seedCommittedSpec(
+  cwd: string,
+  slug: string,
+  opts?: { readonly overrides?: Partial<State> },
+): void {
+  const slugDir = path.join(cwd, ".samospec", "spec", slug);
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(
+    path.join(slugDir, "SPEC.md"),
+    [
+      "# SPEC",
+      "",
+      "## Goal",
+      "",
+      "Deliver a refunds policy that is reviewable and actionable.",
+      "",
+      "## Scope",
+      "",
+      "- refund window",
+      "- edge cases",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "TLDR.md"),
+    [
+      "# TL;DR",
+      "",
+      "## Goal",
+      "",
+      "Deliver a refunds policy that is reviewable and actionable.",
+      "",
+      "## Scope summary",
+      "",
+      "- Scope",
+      "",
+      "## Next action",
+      "",
+      "resume with `samospec resume refunds`",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "decisions.md"),
+    "# decisions\n\n- r01: accepted 2, rejected 1, deferred 0\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "changelog.md"),
+    [
+      "# changelog",
+      "",
+      "## v0.1 — 2026-04-19T12:00:00Z",
+      "",
+      "- initial draft",
+      "",
+      "## v0.2 — 2026-04-19T12:30:00Z",
+      "",
+      "- Round 1 reviews applied (decisions — accepted: 2, rejected: 1, deferred: 0).",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  // Commit these so the working tree is clean.
+  spawnSync("git", ["add", "-A"], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "spec(refunds): refine v0.2"], {
+    cwd,
+  });
+  const state: State = {
+    slug,
+    phase: "review_loop",
+    round_index: 1,
+    version: "0.2.0",
+    persona: { skill: "refunds", accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: "2026-04-19T12:00:00Z",
+    updated_at: "2026-04-19T12:30:00Z",
+    ...(opts?.overrides ?? {}),
+  };
+  writeState(path.join(slugDir, "state.json"), state);
+  // Re-commit after state mutation so working tree is clean.
+  spawnSync("git", ["add", "-A"], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "chore: seed state"], { cwd });
+}
+
+/**
+ * Create a PATH shim directory with stub executables. Each tool is given
+ * a small bash script that:
+ *   - exits 0 on `auth status`
+ *   - records argv to a log and exits 0 on `pr create` / equivalent
+ *
+ * Caller decides which tools to stub. Returns the resulting PATH value.
+ */
+function scriptShim(args: {
+  readonly gh?: boolean;
+  readonly glab?: boolean;
+  readonly ghAuthExit?: number;
+  readonly glabAuthExit?: number;
+}): { readonly PATH: string; readonly argvLog: string } {
+  const bin = path.join(shim, "bin");
+  mkdirSync(bin, { recursive: true });
+  const argvLog = path.join(shim, "argv.log");
+  writeFileSync(argvLog, "", "utf8");
+
+  if (args.gh === true) {
+    const ghExit = args.ghAuthExit ?? 0;
+    const ghScript = [
+      "#!/usr/bin/env bash",
+      'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then',
+      `  exit ${String(ghExit)}`,
+      "fi",
+      `echo "gh $*" >> "${argvLog}"`,
+      "exit 0",
+      "",
+    ].join("\n");
+    const ghPath = path.join(bin, "gh");
+    writeFileSync(ghPath, ghScript, "utf8");
+    chmodSync(ghPath, 0o755);
+  }
+  if (args.glab === true) {
+    const glabExit = args.glabAuthExit ?? 0;
+    const glabScript = [
+      "#!/usr/bin/env bash",
+      'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then',
+      `  exit ${String(glabExit)}`,
+      "fi",
+      `echo "glab $*" >> "${argvLog}"`,
+      "exit 0",
+      "",
+    ].join("\n");
+    const glabPath = path.join(bin, "glab");
+    writeFileSync(glabPath, glabScript, "utf8");
+    chmodSync(glabPath, 0o755);
+  }
+  // Keep git available; we don't stub git.
+  const systemPath = process.env.PATH ?? "";
+  return { PATH: `${bin}:${systemPath}`, argvLog };
+}
+
+function seedConfig(cwd: string, value: unknown): void {
+  const cfgDir = path.join(cwd, ".samospec");
+  mkdirSync(cfgDir, { recursive: true });
+  writeFileSync(
+    path.join(cfgDir, "config.json"),
+    JSON.stringify(value, null, 2),
+    "utf8",
+  );
+}
+
+describe("samospec publish — preconditions (SPEC §10)", () => {
+  test("exits 1 when no spec directory exists for the slug", async () => {
+    const result = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/no spec/i);
+  });
+
+  test("exits 1 when the spec is NOT in committed round state", async () => {
+    seedCommittedSpec(tmp, "refunds", {
+      overrides: { round_state: "planned" },
+    });
+    const result = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/committed/i);
+  });
+});
+
+describe("samospec publish — copy + commit (SPEC §5 Phase 7 + §8 + §9)", () => {
+  test("copies SPEC.md to blueprints/<slug>/SPEC.md", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    const { PATH } = scriptShim({ gh: true });
+    await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    const promoted = path.join(tmp, "blueprints", "refunds", "SPEC.md");
+    expect(existsSync(promoted)).toBe(true);
+    const body = readFileSync(promoted, "utf8");
+    expect(body).toMatch(/^# SPEC/);
+    expect(body).toContain("Deliver a refunds policy");
+  });
+
+  test(
+    "commit message is exactly `spec(<slug>): publish v<version>` " +
+      "on the samospec/<slug> branch (NOT main)",
+    async () => {
+      seedCommittedSpec(tmp, "refunds");
+      const { PATH } = scriptShim({ gh: true });
+      const result = await runPublish({
+        cwd: tmp,
+        slug: "refunds",
+        now: "2026-04-19T13:00:00Z",
+        remote: "origin",
+        env: { PATH },
+      });
+      expect(result.exitCode).toBe(0);
+      const branch = spawnSync(
+        "git",
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+        { cwd: tmp, encoding: "utf8" },
+      ).stdout.trim();
+      expect(branch).toBe("samospec/refunds");
+      const lastMsg = spawnSync("git", ["log", "-1", "--format=%s"], {
+        cwd: tmp,
+        encoding: "utf8",
+      }).stdout.trim();
+      expect(lastMsg).toBe("spec(refunds): publish v0.2");
+      // main must not have any samospec commits.
+      const mainLog = spawnSync(
+        "git",
+        ["log", "--format=%s", "main"],
+        { cwd: tmp, encoding: "utf8" },
+      ).stdout;
+      expect(mainLog).not.toContain("spec(refunds): publish");
+    },
+  );
+
+  test("refuses to commit on a protected branch (safety invariant)", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    spawnSync("git", ["checkout", "-q", "main"], { cwd: tmp });
+    const { PATH } = scriptShim({ gh: true });
+    const result = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toMatch(/protected/i);
+  });
+});
+
+describe("samospec publish — push consent (SPEC §8)", () => {
+  test("push respected when consent accepted (accepts via persisted config)", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    const remoteUrl = spawnSync(
+      "git",
+      ["remote", "get-url", "origin"],
+      { cwd: tmp, encoding: "utf8" },
+    ).stdout.trim();
+    seedConfig(tmp, {
+      schema_version: 1,
+      git: { push_consent: { [remoteUrl]: true } },
+    });
+    const { PATH } = scriptShim({ gh: true });
+    const result = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    expect(result.exitCode).toBe(0);
+    // Bare remote should now have the samospec/refunds ref.
+    const bareRefs = spawnSync(
+      "git",
+      ["--git-dir", bare, "branch"],
+      { encoding: "utf8" },
+    ).stdout;
+    expect(bareRefs).toContain("samospec/refunds");
+  });
+
+  test("consent refused → local commit only + warning, still prints compare URL", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    const remoteUrl = spawnSync(
+      "git",
+      ["remote", "get-url", "origin"],
+      { cwd: tmp, encoding: "utf8" },
+    ).stdout.trim();
+    seedConfig(tmp, {
+      schema_version: 1,
+      git: { push_consent: { [remoteUrl]: false } },
+    });
+    const { PATH } = scriptShim({ gh: true });
+    const result = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    // Local commit succeeded.
+    const lastMsg = spawnSync("git", ["log", "-1", "--format=%s"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
+    expect(lastMsg).toBe("spec(refunds): publish v0.2");
+    expect(result.stderr).toMatch(/PR cannot be opened without remote push/i);
+    // Bare remote has NO samospec ref.
+    const bareRefs = spawnSync(
+      "git",
+      ["--git-dir", bare, "branch"],
+      { encoding: "utf8" },
+    ).stdout;
+    expect(bareRefs).not.toContain("samospec/refunds");
+  });
+});
+
+describe("samospec publish — PR opening (SPEC §5 Phase 7 + §10)", () => {
+  test("invokes `gh` pr create when gh is authenticated", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    const remoteUrl = spawnSync(
+      "git",
+      ["remote", "get-url", "origin"],
+      { cwd: tmp, encoding: "utf8" },
+    ).stdout.trim();
+    seedConfig(tmp, {
+      schema_version: 1,
+      git: { push_consent: { [remoteUrl]: true } },
+    });
+    const { PATH, argvLog } = scriptShim({ gh: true });
+    const result = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    expect(result.exitCode).toBe(0);
+    const log = readFileSync(argvLog, "utf8");
+    expect(log).toContain("gh pr create");
+    expect(log).toMatch(/--title/);
+    expect(log).toContain("spec(refunds): publish v0.2");
+  });
+
+  test(
+    "prefers `gh` over `glab` when both are present and authenticated",
+    async () => {
+      seedCommittedSpec(tmp, "refunds");
+      const remoteUrl = spawnSync(
+        "git",
+        ["remote", "get-url", "origin"],
+        { cwd: tmp, encoding: "utf8" },
+      ).stdout.trim();
+      seedConfig(tmp, {
+        schema_version: 1,
+        git: { push_consent: { [remoteUrl]: true } },
+      });
+      const { PATH, argvLog } = scriptShim({ gh: true, glab: true });
+      await runPublish({
+        cwd: tmp,
+        slug: "refunds",
+        now: "2026-04-19T13:00:00Z",
+        remote: "origin",
+        env: { PATH },
+      });
+      const log = readFileSync(argvLog, "utf8");
+      expect(log).toContain("gh pr create");
+      expect(log).not.toContain("glab mr create");
+    },
+  );
+
+  test("compare-URL fallback when neither gh nor glab is authenticated", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    const remoteUrl = spawnSync(
+      "git",
+      ["remote", "get-url", "origin"],
+      { cwd: tmp, encoding: "utf8" },
+    ).stdout.trim();
+    seedConfig(tmp, {
+      schema_version: 1,
+      git: { push_consent: { [remoteUrl]: true } },
+    });
+    // neither gh nor glab on PATH
+    const bin = path.join(shim, "bin");
+    mkdirSync(bin, { recursive: true });
+    const minimalPath = `${bin}:${process.env.PATH ?? ""}`;
+    const result = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH: minimalPath },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/compare/);
+    expect(result.stdout).toMatch(/samospec\/refunds/);
+  });
+});
+
+describe("samospec publish — lint seam (SPEC §5 Phase 7 + §14)", () => {
+  test(
+    "`--no-lint` skips the lint call (mock lint throws if called)",
+    async () => {
+      seedCommittedSpec(tmp, "refunds");
+      const remoteUrl = spawnSync(
+        "git",
+        ["remote", "get-url", "origin"],
+        { cwd: tmp, encoding: "utf8" },
+      ).stdout.trim();
+      seedConfig(tmp, {
+        schema_version: 1,
+        git: { push_consent: { [remoteUrl]: true } },
+      });
+      const { PATH } = scriptShim({ gh: true });
+      const result = await runPublish({
+        cwd: tmp,
+        slug: "refunds",
+        now: "2026-04-19T13:00:00Z",
+        remote: "origin",
+        env: { PATH },
+        noLint: true,
+        lint: () => {
+          throw new Error("lint must not run under --no-lint");
+        },
+      });
+      expect(result.exitCode).toBe(0);
+    },
+  );
+
+  test(
+    "default lint seam returns empty findings and publish succeeds",
+    async () => {
+      seedCommittedSpec(tmp, "refunds");
+      const remoteUrl = spawnSync(
+        "git",
+        ["remote", "get-url", "origin"],
+        { cwd: tmp, encoding: "utf8" },
+      ).stdout.trim();
+      seedConfig(tmp, {
+        schema_version: 1,
+        git: { push_consent: { [remoteUrl]: true } },
+      });
+      const { PATH } = scriptShim({ gh: true });
+      const result = await runPublish({
+        cwd: tmp,
+        slug: "refunds",
+        now: "2026-04-19T13:00:00Z",
+        remote: "origin",
+        env: { PATH },
+      });
+      expect(result.exitCode).toBe(0);
+    },
+  );
+});
+
+describe("samospec publish — state advance (SPEC §7)", () => {
+  test("state.json gains published_at + published_version on success", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    const remoteUrl = spawnSync(
+      "git",
+      ["remote", "get-url", "origin"],
+      { cwd: tmp, encoding: "utf8" },
+    ).stdout.trim();
+    seedConfig(tmp, {
+      schema_version: 1,
+      git: { push_consent: { [remoteUrl]: true } },
+    });
+    const { PATH } = scriptShim({ gh: true });
+    const result = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    expect(result.exitCode).toBe(0);
+    const stateRaw = readFileSync(
+      path.join(tmp, ".samospec", "spec", "refunds", "state.json"),
+      "utf8",
+    );
+    const state = JSON.parse(stateRaw) as Record<string, unknown>;
+    expect(state["published_at"]).toBe("2026-04-19T13:00:00Z");
+    expect(state["published_version"]).toBe("v0.2");
+  });
+
+  test("second publish on the same slug exits 1 (republish error)", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    const remoteUrl = spawnSync(
+      "git",
+      ["remote", "get-url", "origin"],
+      { cwd: tmp, encoding: "utf8" },
+    ).stdout.trim();
+    seedConfig(tmp, {
+      schema_version: 1,
+      git: { push_consent: { [remoteUrl]: true } },
+    });
+    const { PATH } = scriptShim({ gh: true });
+    const first = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    expect(first.exitCode).toBe(0);
+    const second = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:05:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    expect(second.exitCode).toBe(1);
+    expect(second.stderr).toMatch(/already published/i);
+    expect(second.stderr).toMatch(/iterate/);
+  });
+});

--- a/tests/cli/publish.test.ts
+++ b/tests/cli/publish.test.ts
@@ -64,7 +64,15 @@ function initRepo(cwd: string, bareUrl: string): void {
   writeFileSync(path.join(cwd, "README.md"), "seed\n", "utf8");
   spawnSync("git", ["add", "README.md"], { cwd });
   spawnSync("git", ["commit", "-q", "-m", "seed"], { cwd });
-  spawnSync("git", ["remote", "add", "origin", bareUrl], { cwd });
+  // Use a GitHub-shaped remote URL for fetch (so buildCompareUrl can
+  // derive a compare URL) with a pushurl override pointing at the
+  // real bare so tests exercise actual pushes.
+  spawnSync(
+    "git",
+    ["remote", "add", "origin", "git@github.com:NikolayS/samospec-test.git"],
+    { cwd },
+  );
+  spawnSync("git", ["config", "remote.origin.pushurl", bareUrl], { cwd });
   // Push seed to remote so origin has a `main` ref.
   spawnSync("git", ["push", "-q", "origin", "main"], { cwd });
   spawnSync("git", ["checkout", "-q", "-b", "samospec/refunds"], { cwd });
@@ -212,8 +220,9 @@ function scriptShim(args: {
     writeFileSync(glabPath, glabScript, "utf8");
     chmodSync(glabPath, 0o755);
   }
-  // Keep git available; we don't stub git.
-  const systemPath = process.env.PATH ?? "";
+  // Keep system utilities (bash, git, env) available; we only stub the
+  // specific PR tools (gh/glab) via the shim bin dir taking precedence.
+  const systemPath = process.env["PATH"] ?? "";
   return { PATH: `${bin}:${systemPath}`, argvLog };
 }
 
@@ -286,11 +295,10 @@ describe("samospec publish — copy + commit (SPEC §5 Phase 7 + §8 + §9)", ()
         env: { PATH },
       });
       expect(result.exitCode).toBe(0);
-      const branch = spawnSync(
-        "git",
-        ["rev-parse", "--abbrev-ref", "HEAD"],
-        { cwd: tmp, encoding: "utf8" },
-      ).stdout.trim();
+      const branch = spawnSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+        cwd: tmp,
+        encoding: "utf8",
+      }).stdout.trim();
       expect(branch).toBe("samospec/refunds");
       const lastMsg = spawnSync("git", ["log", "-1", "--format=%s"], {
         cwd: tmp,
@@ -298,18 +306,26 @@ describe("samospec publish — copy + commit (SPEC §5 Phase 7 + §8 + §9)", ()
       }).stdout.trim();
       expect(lastMsg).toBe("spec(refunds): publish v0.2");
       // main must not have any samospec commits.
-      const mainLog = spawnSync(
-        "git",
-        ["log", "--format=%s", "main"],
-        { cwd: tmp, encoding: "utf8" },
-      ).stdout;
+      const mainLog = spawnSync("git", ["log", "--format=%s", "main"], {
+        cwd: tmp,
+        encoding: "utf8",
+      }).stdout;
       expect(mainLog).not.toContain("spec(refunds): publish");
     },
   );
 
   test("refuses to commit on a protected branch (safety invariant)", async () => {
+    // Seed the spec on samospec/refunds, then cherry-pick the state
+    // commit onto main so the preconditions are satisfied on main as
+    // well — the safety invariant then guards the commit step.
     seedCommittedSpec(tmp, "refunds");
     spawnSync("git", ["checkout", "-q", "main"], { cwd: tmp });
+    spawnSync("git", ["checkout", "samospec/refunds", "--", ".samospec"], {
+      cwd: tmp,
+    });
+    spawnSync("git", ["commit", "-q", "-m", "chore: seed state on main"], {
+      cwd: tmp,
+    });
     const { PATH } = scriptShim({ gh: true });
     const result = await runPublish({
       cwd: tmp,
@@ -326,11 +342,10 @@ describe("samospec publish — copy + commit (SPEC §5 Phase 7 + §8 + §9)", ()
 describe("samospec publish — push consent (SPEC §8)", () => {
   test("push respected when consent accepted (accepts via persisted config)", async () => {
     seedCommittedSpec(tmp, "refunds");
-    const remoteUrl = spawnSync(
-      "git",
-      ["remote", "get-url", "origin"],
-      { cwd: tmp, encoding: "utf8" },
-    ).stdout.trim();
+    const remoteUrl = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
     seedConfig(tmp, {
       schema_version: 1,
       git: { push_consent: { [remoteUrl]: true } },
@@ -345,21 +360,18 @@ describe("samospec publish — push consent (SPEC §8)", () => {
     });
     expect(result.exitCode).toBe(0);
     // Bare remote should now have the samospec/refunds ref.
-    const bareRefs = spawnSync(
-      "git",
-      ["--git-dir", bare, "branch"],
-      { encoding: "utf8" },
-    ).stdout;
+    const bareRefs = spawnSync("git", ["--git-dir", bare, "branch"], {
+      encoding: "utf8",
+    }).stdout;
     expect(bareRefs).toContain("samospec/refunds");
   });
 
   test("consent refused → local commit only + warning, still prints compare URL", async () => {
     seedCommittedSpec(tmp, "refunds");
-    const remoteUrl = spawnSync(
-      "git",
-      ["remote", "get-url", "origin"],
-      { cwd: tmp, encoding: "utf8" },
-    ).stdout.trim();
+    const remoteUrl = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
     seedConfig(tmp, {
       schema_version: 1,
       git: { push_consent: { [remoteUrl]: false } },
@@ -380,11 +392,9 @@ describe("samospec publish — push consent (SPEC §8)", () => {
     expect(lastMsg).toBe("spec(refunds): publish v0.2");
     expect(result.stderr).toMatch(/PR cannot be opened without remote push/i);
     // Bare remote has NO samospec ref.
-    const bareRefs = spawnSync(
-      "git",
-      ["--git-dir", bare, "branch"],
-      { encoding: "utf8" },
-    ).stdout;
+    const bareRefs = spawnSync("git", ["--git-dir", bare, "branch"], {
+      encoding: "utf8",
+    }).stdout;
     expect(bareRefs).not.toContain("samospec/refunds");
   });
 });
@@ -392,11 +402,10 @@ describe("samospec publish — push consent (SPEC §8)", () => {
 describe("samospec publish — PR opening (SPEC §5 Phase 7 + §10)", () => {
   test("invokes `gh` pr create when gh is authenticated", async () => {
     seedCommittedSpec(tmp, "refunds");
-    const remoteUrl = spawnSync(
-      "git",
-      ["remote", "get-url", "origin"],
-      { cwd: tmp, encoding: "utf8" },
-    ).stdout.trim();
+    const remoteUrl = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
     seedConfig(tmp, {
       schema_version: 1,
       git: { push_consent: { [remoteUrl]: true } },
@@ -416,54 +425,53 @@ describe("samospec publish — PR opening (SPEC §5 Phase 7 + §10)", () => {
     expect(log).toContain("spec(refunds): publish v0.2");
   });
 
-  test(
-    "prefers `gh` over `glab` when both are present and authenticated",
-    async () => {
-      seedCommittedSpec(tmp, "refunds");
-      const remoteUrl = spawnSync(
-        "git",
-        ["remote", "get-url", "origin"],
-        { cwd: tmp, encoding: "utf8" },
-      ).stdout.trim();
-      seedConfig(tmp, {
-        schema_version: 1,
-        git: { push_consent: { [remoteUrl]: true } },
-      });
-      const { PATH, argvLog } = scriptShim({ gh: true, glab: true });
-      await runPublish({
-        cwd: tmp,
-        slug: "refunds",
-        now: "2026-04-19T13:00:00Z",
-        remote: "origin",
-        env: { PATH },
-      });
-      const log = readFileSync(argvLog, "utf8");
-      expect(log).toContain("gh pr create");
-      expect(log).not.toContain("glab mr create");
-    },
-  );
-
-  test("compare-URL fallback when neither gh nor glab is authenticated", async () => {
+  test("prefers `gh` over `glab` when both are present and authenticated", async () => {
     seedCommittedSpec(tmp, "refunds");
-    const remoteUrl = spawnSync(
-      "git",
-      ["remote", "get-url", "origin"],
-      { cwd: tmp, encoding: "utf8" },
-    ).stdout.trim();
+    const remoteUrl = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
     seedConfig(tmp, {
       schema_version: 1,
       git: { push_consent: { [remoteUrl]: true } },
     });
-    // neither gh nor glab on PATH
-    const bin = path.join(shim, "bin");
-    mkdirSync(bin, { recursive: true });
-    const minimalPath = `${bin}:${process.env.PATH ?? ""}`;
+    const { PATH, argvLog } = scriptShim({ gh: true, glab: true });
+    await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    const log = readFileSync(argvLog, "utf8");
+    expect(log).toContain("gh pr create");
+    expect(log).not.toContain("glab mr create");
+  });
+
+  test("compare-URL fallback when neither gh nor glab is authenticated", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    const remoteUrl = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
+    seedConfig(tmp, {
+      schema_version: 1,
+      git: { push_consent: { [remoteUrl]: true } },
+    });
+    // Script gh + glab shims that both return non-zero on `auth status`
+    // so probePrCapability returns { available: false }.
+    const { PATH } = scriptShim({
+      gh: true,
+      glab: true,
+      ghAuthExit: 1,
+      glabAuthExit: 1,
+    });
     const result = await runPublish({
       cwd: tmp,
       slug: "refunds",
       now: "2026-04-19T13:00:00Z",
       remote: "origin",
-      env: { PATH: minimalPath },
+      env: { PATH },
     });
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toMatch(/compare/);
@@ -472,69 +480,60 @@ describe("samospec publish — PR opening (SPEC §5 Phase 7 + §10)", () => {
 });
 
 describe("samospec publish — lint seam (SPEC §5 Phase 7 + §14)", () => {
-  test(
-    "`--no-lint` skips the lint call (mock lint throws if called)",
-    async () => {
-      seedCommittedSpec(tmp, "refunds");
-      const remoteUrl = spawnSync(
-        "git",
-        ["remote", "get-url", "origin"],
-        { cwd: tmp, encoding: "utf8" },
-      ).stdout.trim();
-      seedConfig(tmp, {
-        schema_version: 1,
-        git: { push_consent: { [remoteUrl]: true } },
-      });
-      const { PATH } = scriptShim({ gh: true });
-      const result = await runPublish({
-        cwd: tmp,
-        slug: "refunds",
-        now: "2026-04-19T13:00:00Z",
-        remote: "origin",
-        env: { PATH },
-        noLint: true,
-        lint: () => {
-          throw new Error("lint must not run under --no-lint");
-        },
-      });
-      expect(result.exitCode).toBe(0);
-    },
-  );
+  test("`--no-lint` skips the lint call (mock lint throws if called)", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    const remoteUrl = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
+    seedConfig(tmp, {
+      schema_version: 1,
+      git: { push_consent: { [remoteUrl]: true } },
+    });
+    const { PATH } = scriptShim({ gh: true });
+    const result = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH },
+      noLint: true,
+      lint: () => {
+        throw new Error("lint must not run under --no-lint");
+      },
+    });
+    expect(result.exitCode).toBe(0);
+  });
 
-  test(
-    "default lint seam returns empty findings and publish succeeds",
-    async () => {
-      seedCommittedSpec(tmp, "refunds");
-      const remoteUrl = spawnSync(
-        "git",
-        ["remote", "get-url", "origin"],
-        { cwd: tmp, encoding: "utf8" },
-      ).stdout.trim();
-      seedConfig(tmp, {
-        schema_version: 1,
-        git: { push_consent: { [remoteUrl]: true } },
-      });
-      const { PATH } = scriptShim({ gh: true });
-      const result = await runPublish({
-        cwd: tmp,
-        slug: "refunds",
-        now: "2026-04-19T13:00:00Z",
-        remote: "origin",
-        env: { PATH },
-      });
-      expect(result.exitCode).toBe(0);
-    },
-  );
+  test("default lint seam returns empty findings and publish succeeds", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    const remoteUrl = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
+    seedConfig(tmp, {
+      schema_version: 1,
+      git: { push_consent: { [remoteUrl]: true } },
+    });
+    const { PATH } = scriptShim({ gh: true });
+    const result = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    expect(result.exitCode).toBe(0);
+  });
 });
 
 describe("samospec publish — state advance (SPEC §7)", () => {
   test("state.json gains published_at + published_version on success", async () => {
     seedCommittedSpec(tmp, "refunds");
-    const remoteUrl = spawnSync(
-      "git",
-      ["remote", "get-url", "origin"],
-      { cwd: tmp, encoding: "utf8" },
-    ).stdout.trim();
+    const remoteUrl = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
     seedConfig(tmp, {
       schema_version: 1,
       git: { push_consent: { [remoteUrl]: true } },
@@ -559,11 +558,10 @@ describe("samospec publish — state advance (SPEC §7)", () => {
 
   test("second publish on the same slug exits 1 (republish error)", async () => {
     seedCommittedSpec(tmp, "refunds");
-    const remoteUrl = spawnSync(
-      "git",
-      ["remote", "get-url", "origin"],
-      { cwd: tmp, encoding: "utf8" },
-    ).stdout.trim();
+    const remoteUrl = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
     seedConfig(tmp, {
       schema_version: 1,
       git: { push_consent: { [remoteUrl]: true } },

--- a/tests/publish/blueprints.test.ts
+++ b/tests/publish/blueprints.test.ts
@@ -1,0 +1,77 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §5 Phase 7 + §9 — blueprint promotion.
+ *
+ *   - Copies `.samospec/spec/<slug>/SPEC.md` → `blueprints/<slug>/SPEC.md`.
+ *   - Creates `blueprints/<slug>/` when missing.
+ *   - Overwrites an existing promoted blueprint on republish (though
+ *     runPublish itself blocks republish; the copy primitive remains
+ *     idempotent so a manual re-run is not a footgun).
+ *   - Returns the absolute destination path so callers can stage it.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { promoteSpecToBlueprint } from "../../src/publish/blueprints.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-blueprints-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("promoteSpecToBlueprint", () => {
+  test("copies SPEC.md, creating blueprints/<slug>/ when missing", () => {
+    const slugDir = path.join(tmp, ".samospec", "spec", "refunds");
+    mkdirSync(slugDir, { recursive: true });
+    writeFileSync(
+      path.join(slugDir, "SPEC.md"),
+      "# SPEC\n\nv0.2 body\n",
+      "utf8",
+    );
+    const dest = promoteSpecToBlueprint({
+      cwd: tmp,
+      slug: "refunds",
+    });
+    expect(dest).toBe(path.join(tmp, "blueprints", "refunds", "SPEC.md"));
+    expect(existsSync(dest)).toBe(true);
+    expect(readFileSync(dest, "utf8")).toBe("# SPEC\n\nv0.2 body\n");
+  });
+
+  test("overwrites an existing blueprint file idempotently", () => {
+    const slugDir = path.join(tmp, ".samospec", "spec", "refunds");
+    mkdirSync(slugDir, { recursive: true });
+    writeFileSync(path.join(slugDir, "SPEC.md"), "NEW\n", "utf8");
+
+    const blueprintDir = path.join(tmp, "blueprints", "refunds");
+    mkdirSync(blueprintDir, { recursive: true });
+    writeFileSync(path.join(blueprintDir, "SPEC.md"), "OLD\n", "utf8");
+
+    const dest = promoteSpecToBlueprint({ cwd: tmp, slug: "refunds" });
+    expect(readFileSync(dest, "utf8")).toBe("NEW\n");
+  });
+
+  test("throws when the source SPEC.md is missing", () => {
+    mkdirSync(path.join(tmp, ".samospec", "spec", "refunds"), {
+      recursive: true,
+    });
+    expect(() =>
+      promoteSpecToBlueprint({ cwd: tmp, slug: "refunds" }),
+    ).toThrow(/SPEC\.md/);
+  });
+});

--- a/tests/publish/blueprints.test.ts
+++ b/tests/publish/blueprints.test.ts
@@ -70,8 +70,8 @@ describe("promoteSpecToBlueprint", () => {
     mkdirSync(path.join(tmp, ".samospec", "spec", "refunds"), {
       recursive: true,
     });
-    expect(() =>
-      promoteSpecToBlueprint({ cwd: tmp, slug: "refunds" }),
-    ).toThrow(/SPEC\.md/);
+    expect(() => promoteSpecToBlueprint({ cwd: tmp, slug: "refunds" })).toThrow(
+      /SPEC\.md/,
+    );
   });
 });

--- a/tests/publish/body.test.ts
+++ b/tests/publish/body.test.ts
@@ -1,0 +1,151 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §5 Phase 7 — PR body composition.
+ *
+ * The body includes: spec summary (from TLDR.md), changelog since v0.1
+ * (from changelog.md), round count, final exit reason, degraded
+ * resolution summary (if any), hard + soft lint warnings.
+ *
+ * The rendered markdown uses `- ` list items (per CLAUDE.md) and clearly
+ * labeled sections so reviewers can scan at a glance.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { buildPrBody } from "../../src/publish/body.ts";
+
+const BASE_TLDR = [
+  "# TL;DR",
+  "",
+  "## Goal",
+  "",
+  "Deliver a refunds policy.",
+  "",
+  "## Scope summary",
+  "",
+  "- refund window",
+  "",
+  "## Next action",
+  "",
+  "resume with `samospec resume refunds`",
+  "",
+].join("\n");
+
+const BASE_CHANGELOG = [
+  "# changelog",
+  "",
+  "## v0.1 — 2026-04-19T12:00:00Z",
+  "",
+  "- initial draft",
+  "",
+  "## v0.2 — 2026-04-19T12:30:00Z",
+  "",
+  "- Round 1 reviews applied.",
+  "",
+].join("\n");
+
+describe("buildPrBody", () => {
+  test("includes spec summary (TLDR), round count, and exit reason", () => {
+    const body = buildPrBody({
+      slug: "refunds",
+      version: "v0.2",
+      tldr: BASE_TLDR,
+      changelog: BASE_CHANGELOG,
+      roundCount: 1,
+      exitReason: "ready",
+      degradedResolution: null,
+      lintReport: { hardWarnings: [], softWarnings: [] },
+    });
+    expect(body).toContain("refunds");
+    expect(body).toContain("v0.2");
+    expect(body).toContain("Deliver a refunds policy");
+    expect(body).toMatch(/Rounds run:\s*1/i);
+    expect(body).toMatch(/exit reason:\s*ready/i);
+  });
+
+  test("includes every changelog entry since v0.1", () => {
+    const body = buildPrBody({
+      slug: "refunds",
+      version: "v0.2",
+      tldr: BASE_TLDR,
+      changelog: BASE_CHANGELOG,
+      roundCount: 1,
+      exitReason: "ready",
+      degradedResolution: null,
+      lintReport: { hardWarnings: [], softWarnings: [] },
+    });
+    expect(body).toContain("v0.1");
+    expect(body).toContain("v0.2");
+    expect(body).toContain("initial draft");
+    expect(body).toContain("Round 1 reviews applied");
+  });
+
+  test("renders a degraded-resolution summary when present", () => {
+    const body = buildPrBody({
+      slug: "refunds",
+      version: "v0.2",
+      tldr: BASE_TLDR,
+      changelog: BASE_CHANGELOG,
+      roundCount: 2,
+      exitReason: "ready",
+      degradedResolution: "lead fell back to claude-sonnet-4-6",
+      lintReport: { hardWarnings: [], softWarnings: [] },
+    });
+    expect(body).toMatch(/degraded/i);
+    expect(body).toContain("lead fell back to claude-sonnet-4-6");
+  });
+
+  test(
+    "renders hard warnings prominently and soft warnings in a " +
+      "collapsible section",
+    () => {
+      const body = buildPrBody({
+        slug: "refunds",
+        version: "v0.2",
+        tldr: BASE_TLDR,
+        changelog: BASE_CHANGELOG,
+        roundCount: 1,
+        exitReason: "ready",
+        degradedResolution: null,
+        lintReport: {
+          hardWarnings: [
+            {
+              id: "unknown-path",
+              message: "References `src/refunds.ts` which does not exist.",
+            },
+          ],
+          softWarnings: [
+            {
+              id: "unknown-command",
+              message: "`curl` is not in the allowlist.",
+            },
+          ],
+        },
+      });
+      // Hard warnings: labeled section, surfaced outside any details tag.
+      expect(body).toMatch(/Hard warnings/i);
+      expect(body).toContain("unknown-path");
+      expect(body).toContain("src/refunds.ts");
+      // Soft warnings: wrapped in <details> so reviewers can expand.
+      expect(body).toContain("<details>");
+      expect(body).toContain("</details>");
+      expect(body).toContain("unknown-command");
+    },
+  );
+
+  test("uses `- ` markdown list items throughout", () => {
+    const body = buildPrBody({
+      slug: "refunds",
+      version: "v0.2",
+      tldr: BASE_TLDR,
+      changelog: BASE_CHANGELOG,
+      roundCount: 1,
+      exitReason: "ready",
+      degradedResolution: null,
+      lintReport: { hardWarnings: [], softWarnings: [] },
+    });
+    // No bare `*` bullets anywhere.
+    expect(body).not.toMatch(/^\*\s/m);
+  });
+});

--- a/tests/publish/lint-stub.test.ts
+++ b/tests/publish/lint-stub.test.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §14 — publish-lint seam (stub).
+ *
+ * Issue #33 will fill this in. For Issue #32 the seam exists and returns
+ * an empty report so `samospec publish` does not regress on the basis of
+ * an unimplemented downstream module.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { publishLintStub } from "../../src/publish/lint-stub.ts";
+
+describe("publishLintStub", () => {
+  test("returns empty hard + soft warnings", () => {
+    const report = publishLintStub({
+      specBody: "# SPEC\n\nbody\n",
+      repoPath: "/tmp/noop",
+      slug: "demo",
+    });
+    expect(report.hardWarnings).toEqual([]);
+    expect(report.softWarnings).toEqual([]);
+  });
+
+  test("is deterministic across calls", () => {
+    const a = publishLintStub({
+      specBody: "# SPEC\n",
+      repoPath: "/tmp/noop",
+      slug: "demo",
+    });
+    const b = publishLintStub({
+      specBody: "# SPEC\n",
+      repoPath: "/tmp/noop",
+      slug: "demo",
+    });
+    expect(a).toEqual(b);
+  });
+});

--- a/tests/publish/pr.test.ts
+++ b/tests/publish/pr.test.ts
@@ -31,7 +31,9 @@ describe("buildCompareUrl", () => {
         defaultBranch: "main",
         branch: "samospec/refunds",
       }),
-    ).toBe("https://github.com/NikolayS/samospec/compare/main...samospec/refunds");
+    ).toBe(
+      "https://github.com/NikolayS/samospec/compare/main...samospec/refunds",
+    );
   });
 
   test("derives a compare URL from an https GitHub remote (strips .git)", () => {
@@ -41,7 +43,9 @@ describe("buildCompareUrl", () => {
         defaultBranch: "main",
         branch: "samospec/refunds",
       }),
-    ).toBe("https://github.com/NikolayS/samospec/compare/main...samospec/refunds");
+    ).toBe(
+      "https://github.com/NikolayS/samospec/compare/main...samospec/refunds",
+    );
   });
 
   test("derives a merge_requests/new URL for GitLab remotes", () => {
@@ -83,7 +87,9 @@ describe("openPullRequest", () => {
       glab: fakeRunner("glab", calls),
     });
     expect(result.kind).toBe("opened");
-    expect(result.tool).toBe("gh");
+    if (result.kind === "opened") {
+      expect(result.tool).toBe("gh");
+    }
     expect(calls.some((c) => c.startsWith("gh pr create"))).toBe(true);
     expect(calls.some((c) => c.startsWith("glab"))).toBe(false);
   });
@@ -101,7 +107,9 @@ describe("openPullRequest", () => {
       glab: fakeRunner("glab", calls),
     });
     expect(result.kind).toBe("opened");
-    expect(result.tool).toBe("glab");
+    if (result.kind === "opened") {
+      expect(result.tool).toBe("glab");
+    }
     expect(calls.some((c) => c.startsWith("glab mr create"))).toBe(true);
   });
 
@@ -118,9 +126,11 @@ describe("openPullRequest", () => {
       glab: fakeRunner("glab", calls),
     });
     expect(result.kind).toBe("compare-url");
-    expect(result.url).toBe(
-      "https://github.com/NikolayS/samospec/compare/main...samospec/refunds",
-    );
+    if (result.kind === "compare-url") {
+      expect(result.url).toBe(
+        "https://github.com/NikolayS/samospec/compare/main...samospec/refunds",
+      );
+    }
     expect(calls.length).toBe(0);
   });
 

--- a/tests/publish/pr.test.ts
+++ b/tests/publish/pr.test.ts
@@ -1,0 +1,181 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §5 Phase 7 + §10 — PR opening with `gh`/`glab` preference and
+ * compare-URL fallback.
+ *
+ *   - `gh` preferred over `glab` when both authenticated.
+ *   - `glab` used when only glab is authenticated.
+ *   - Neither authenticated → returns compare URL derived from remote URL.
+ *   - The body is passed via stdin-equivalent `--body-file` to avoid argv
+ *     overflow on large PR bodies.
+ *   - Title = `spec(<slug>): publish v<version>` (matches SPEC §8 grammar).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { buildCompareUrl, openPullRequest } from "../../src/publish/pr.ts";
+
+function fakeRunner(name: string, outputs: string[]) {
+  return (argv: readonly string[]) => {
+    outputs.push(`${name} ${argv.join(" ")}`);
+    return { status: 0, stdout: "", stderr: "" };
+  };
+}
+
+describe("buildCompareUrl", () => {
+  test("derives an https compare URL from an ssh GitHub remote", () => {
+    expect(
+      buildCompareUrl({
+        remoteUrl: "git@github.com:NikolayS/samospec.git",
+        defaultBranch: "main",
+        branch: "samospec/refunds",
+      }),
+    ).toBe("https://github.com/NikolayS/samospec/compare/main...samospec/refunds");
+  });
+
+  test("derives a compare URL from an https GitHub remote (strips .git)", () => {
+    expect(
+      buildCompareUrl({
+        remoteUrl: "https://github.com/NikolayS/samospec.git",
+        defaultBranch: "main",
+        branch: "samospec/refunds",
+      }),
+    ).toBe("https://github.com/NikolayS/samospec/compare/main...samospec/refunds");
+  });
+
+  test("derives a merge_requests/new URL for GitLab remotes", () => {
+    expect(
+      buildCompareUrl({
+        remoteUrl: "git@gitlab.com:group/project.git",
+        defaultBranch: "main",
+        branch: "samospec/refunds",
+      }),
+    ).toBe(
+      "https://gitlab.com/group/project/-/merge_requests/new" +
+        "?merge_request[source_branch]=samospec/refunds" +
+        "&merge_request[target_branch]=main",
+    );
+  });
+
+  test("returns null for an unrecognized remote URL", () => {
+    expect(
+      buildCompareUrl({
+        remoteUrl: "ssh://git@bitbucket.org/team/repo.git",
+        defaultBranch: "main",
+        branch: "samospec/refunds",
+      }),
+    ).toBe(null);
+  });
+});
+
+describe("openPullRequest", () => {
+  test("prefers gh when both gh and glab are authenticated", () => {
+    const calls: string[] = [];
+    const result = openPullRequest({
+      capability: { available: true, tool: "gh" },
+      title: "spec(refunds): publish v0.2",
+      bodyFile: "/tmp/body.md",
+      branch: "samospec/refunds",
+      defaultBranch: "main",
+      remoteUrl: "git@github.com:NikolayS/samospec.git",
+      gh: fakeRunner("gh", calls),
+      glab: fakeRunner("glab", calls),
+    });
+    expect(result.kind).toBe("opened");
+    expect(result.tool).toBe("gh");
+    expect(calls.some((c) => c.startsWith("gh pr create"))).toBe(true);
+    expect(calls.some((c) => c.startsWith("glab"))).toBe(false);
+  });
+
+  test("uses glab when only glab is authenticated", () => {
+    const calls: string[] = [];
+    const result = openPullRequest({
+      capability: { available: true, tool: "glab" },
+      title: "spec(refunds): publish v0.2",
+      bodyFile: "/tmp/body.md",
+      branch: "samospec/refunds",
+      defaultBranch: "main",
+      remoteUrl: "git@gitlab.com:group/project.git",
+      gh: fakeRunner("gh", calls),
+      glab: fakeRunner("glab", calls),
+    });
+    expect(result.kind).toBe("opened");
+    expect(result.tool).toBe("glab");
+    expect(calls.some((c) => c.startsWith("glab mr create"))).toBe(true);
+  });
+
+  test("falls back to compare URL when neither is authenticated", () => {
+    const calls: string[] = [];
+    const result = openPullRequest({
+      capability: { available: false },
+      title: "spec(refunds): publish v0.2",
+      bodyFile: "/tmp/body.md",
+      branch: "samospec/refunds",
+      defaultBranch: "main",
+      remoteUrl: "git@github.com:NikolayS/samospec.git",
+      gh: fakeRunner("gh", calls),
+      glab: fakeRunner("glab", calls),
+    });
+    expect(result.kind).toBe("compare-url");
+    expect(result.url).toBe(
+      "https://github.com/NikolayS/samospec/compare/main...samospec/refunds",
+    );
+    expect(calls.length).toBe(0);
+  });
+
+  test("passes --title and --body-file to gh pr create", () => {
+    const calls: string[] = [];
+    openPullRequest({
+      capability: { available: true, tool: "gh" },
+      title: "spec(refunds): publish v0.2",
+      bodyFile: "/tmp/body.md",
+      branch: "samospec/refunds",
+      defaultBranch: "main",
+      remoteUrl: "git@github.com:NikolayS/samospec.git",
+      gh: fakeRunner("gh", calls),
+      glab: fakeRunner("glab", calls),
+    });
+    const invocation = calls.find((c) => c.startsWith("gh pr create"));
+    expect(invocation).toBeDefined();
+    expect(invocation).toContain("--title spec(refunds): publish v0.2");
+    expect(invocation).toContain("--body-file /tmp/body.md");
+    expect(invocation).toContain("--base main");
+    expect(invocation).toContain("--head samospec/refunds");
+  });
+
+  test("passes --title and --description to glab mr create", () => {
+    const calls: string[] = [];
+    openPullRequest({
+      capability: { available: true, tool: "glab" },
+      title: "spec(refunds): publish v0.2",
+      bodyFile: "/tmp/body.md",
+      branch: "samospec/refunds",
+      defaultBranch: "main",
+      remoteUrl: "git@gitlab.com:group/project.git",
+      gh: fakeRunner("gh", calls),
+      glab: fakeRunner("glab", calls),
+    });
+    const invocation = calls.find((c) => c.startsWith("glab mr create"));
+    expect(invocation).toBeDefined();
+    expect(invocation).toContain("--title");
+    // glab uses --description with a file via `-F`-style or inline; the
+    // helper exposes whichever variant it picked via the call log. We
+    // only assert the body file path appears somewhere in the argv.
+    expect(invocation).toContain("/tmp/body.md");
+  });
+
+  test("returns 'failed' kind when the chosen tool exits non-zero", () => {
+    const result = openPullRequest({
+      capability: { available: true, tool: "gh" },
+      title: "spec(refunds): publish v0.2",
+      bodyFile: "/tmp/body.md",
+      branch: "samospec/refunds",
+      defaultBranch: "main",
+      remoteUrl: "git@github.com:NikolayS/samospec.git",
+      gh: () => ({ status: 1, stdout: "", stderr: "gh: not authenticated" }),
+      glab: () => ({ status: 0, stdout: "", stderr: "" }),
+    });
+    expect(result.kind).toBe("failed");
+  });
+});

--- a/tests/state/types.test.ts
+++ b/tests/state/types.test.ts
@@ -128,6 +128,38 @@ describe("state/types — state.json zod schema (SPEC §5, §7)", () => {
     });
     expect(parsed.exit?.code).toBe(4);
   });
+
+  // SPEC §5 Phase 7 + Issue #32 — publish state advance.
+  test("accepts published_at + published_version + published_pr_url", () => {
+    const parsed = stateSchema.parse({
+      ...minimalState,
+      published_at: "2026-04-19T13:00:00Z",
+      published_version: "v0.2",
+      published_pr_url: "https://github.com/demo/demo/pull/1",
+    });
+    expect(parsed.published_at).toBe("2026-04-19T13:00:00Z");
+    expect(parsed.published_version).toBe("v0.2");
+    expect(parsed.published_pr_url).toBe("https://github.com/demo/demo/pull/1");
+  });
+
+  test("allows published_pr_url to be absent (compare-URL fallback)", () => {
+    const parsed = stateSchema.parse({
+      ...minimalState,
+      published_at: "2026-04-19T13:00:00Z",
+      published_version: "v0.2",
+    });
+    expect(parsed.published_pr_url).toBeUndefined();
+  });
+
+  test("rejects published_version that does not start with `v`", () => {
+    expect(() =>
+      stateSchema.parse({
+        ...minimalState,
+        published_at: "2026-04-19T13:00:00Z",
+        published_version: "0.2",
+      }),
+    ).toThrow();
+  });
 });
 
 describe("state/types — round.json zod schema (SPEC §7)", () => {


### PR DESCRIPTION
## Summary

Implements `samospec publish` per SPEC §5 Phase 7 + §8 + §9 + §10 — the command that promotes the working `SPEC.md` to `blueprints/<slug>/SPEC.md`, commits on the `samospec/<slug>` branch, pushes per consent, and opens a PR via `gh` (preferred) or `glab` with a compare-URL fallback.

Closes #32.

- New `src/cli/publish.ts` wires preconditions, safety invariant, blueprint promotion, state advance, commit grammar, consent-honoring push, PR open, and URL persistence.
- New `src/publish/` modules: `blueprints.ts` (copy primitive), `pr.ts` (runner + compare URL), `body.ts` (PR body composition), `lint-stub.ts` (seam for Issue #33).
- Extends `stateSchema` with `published_at`, `published_version`, `published_pr_url?`.
- Republish is blocked (exit 1) with a message pointing at `samospec iterate`.
- `--no-lint` skips the lint seam entirely.
- Integrates with Sprint 4 #31 push-consent (uses `loadPersistedConsent` + `pushBranch`).

## Checklist

- [x] Tests added (red-first; red commit c95b940, green commit ae69084)
- [x] `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun test` all pass locally (1003 tests, 37 new)
- [ ] CI is green on the PR branch
- [x] No real secrets, tokens, or API keys
- [x] Copyright header present on every new source file

## Testing evidence

Full suite locally:

- `bun test` → 1003 pass / 0 fail / 8381 expect() calls across 88 files.
- 37 new tests across `tests/cli/publish.test.ts`, `tests/publish/{blueprints,body,lint-stub,pr}.test.ts`, and `tests/state/types.test.ts`.

End-to-end demo on a temp bare remote + `gh` shim:

```
$ samospec publish refunds
committed spec(refunds): publish v0.2.
pushed to origin.
PR opened via gh: https://github.com/NikolayS/samospec-demo/pull/42
```

After the command:

- `git log -1 --format=%s` → `spec(refunds): publish v0.2` on `samospec/refunds` (bare remote now has the branch).
- `blueprints/refunds/SPEC.md` exists with the promoted body.
- `state.json` gained `published_at`, `published_version: v0.2`, `published_pr_url`.
- A second run exits 1: `already published at ... Use samospec iterate ...`.

Compare-URL fallback (neither `gh` nor `glab` authenticated):

```
$ samospec publish refunds
committed spec(refunds): publish v0.2.
pushed to origin.
Open a PR manually: https://github.com/NikolayS/samospec-demo2/compare/main...samospec/refunds
```

## Out-of-scope / follow-ups

- Publish-lint rules (`src/publish/lint-stub.ts` → Issue #33 replaces).
- Docs changes (Issue #34).
- Dogfood scorecard integration (Issue #34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)