### PR TITLE
fix: doctor uses real Claude/Codex adapters (#43)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,6 @@ import { ClaudeAdapter } from "./adapter/claude.ts";
 import { ClaudeResolver } from "./adapter/claude-resolver.ts";
 import { ClaudeReviewerBAdapter } from "./adapter/claude-reviewer-b.ts";
 import { CodexAdapter } from "./adapter/codex.ts";
-import { createFakeAdapter } from "./adapter/fake-adapter.ts";
 import type { Adapter } from "./adapter/types.ts";
 import { runInit } from "./cli/init.ts";
 import { runDoctor, type DoctorAdapterBinding } from "./cli/doctor.ts";
@@ -56,16 +55,15 @@ const USAGE =
   "  version                     Print the samospec version and exit.\n";
 
 /**
- * Default adapter bindings for `samospec doctor`. Sprint 1 only ships
- * the fake adapter (real adapters land in Sprint 2+). The fake's
- * default program is tuned to `installed: true` + `authenticated: true`
- * + `subscription_auth: true`, which realistically surfaces every
- * branch of the doctor output when invoked interactively.
+ * Default adapter bindings for `samospec doctor`. Uses the real
+ * ClaudeAdapter and CodexAdapter (shipped in Sprints 2–3) so that
+ * doctor probes the actual installed CLIs on the user's PATH. The
+ * fake adapter is for tests only and must not appear here.
  */
 function defaultAdapterBindings(): readonly DoctorAdapterBinding[] {
   return [
-    { label: "claude", adapter: createFakeAdapter() },
-    { label: "codex", adapter: createFakeAdapter() },
+    { label: "claude", adapter: new ClaudeAdapter() },
+    { label: "codex", adapter: new CodexAdapter() },
   ];
 }
 

--- a/tests/cli/doctor-real-adapter.test.ts
+++ b/tests/cli/doctor-real-adapter.test.ts
@@ -1,0 +1,181 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Regression tests asserting that `samospec doctor` uses real adapters
+ * (ClaudeAdapter + CodexAdapter), not the Sprint 1 FakeAdapter stub.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { readFileSync } from "node:fs";
+
+import { runDoctor } from "../../src/cli/doctor.ts";
+import { runInit } from "../../src/cli/init.ts";
+import { ClaudeAdapter } from "../../src/adapter/claude.ts";
+import { CodexAdapter } from "../../src/adapter/codex.ts";
+
+let tmp: string;
+let fakeHome: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-real-adapter-"));
+  fakeHome = mkdtempSync(
+    path.join(tmpdir(), "samospec-home-real-adapter-"),
+  );
+  runInit({ cwd: tmp });
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  rmSync(fakeHome, { recursive: true, force: true });
+});
+
+// ─── helper: build a shimmed PATH directory ─────────────────────────────────
+
+function makeShimDir(
+  shims: Record<string, string>,
+): { shimDir: string; cleanUp: () => void } {
+  const shimDir = mkdtempSync(path.join(tmpdir(), "samospec-shim-"));
+  for (const [name, script] of Object.entries(shims)) {
+    const p = path.join(shimDir, name);
+    writeFileSync(p, script, { mode: 0o755 });
+    chmodSync(p, 0o755);
+  }
+  return {
+    shimDir,
+    cleanUp: () => rmSync(shimDir, { recursive: true, force: true }),
+  };
+}
+
+// ─── Test 1: PATH shim emitting real-looking version ────────────────────────
+
+describe("doctor-real-adapter / Test 1: PATH shim with real-looking version", () => {
+  test(
+    "output reports installed binary path from shim, not fake-1.0.0",
+    async () => {
+      // Shim claude and codex as real-looking executables.
+      // ClaudeAdapter parses the version from stdout; if it can extract a
+      // semver token, it uses that; otherwise it falls back to the first
+      // line. Either way the INSTALLED status and real PATH are reported
+      // (not fake-1.0.0 / /usr/bin/fake).
+      const claudeVersion = "2.1.114";
+      const codexVersion = "0.120.0";
+
+      const { shimDir, cleanUp } = makeShimDir({
+        claude: `#!/bin/sh\necho "${claudeVersion} (Claude Code)"\n`,
+        codex: `#!/bin/sh\nprintf "codex-cli ${codexVersion}\\n"\n`,
+      });
+
+      try {
+        // Build adapters with the shimmed PATH only (no system PATH).
+        const shimmedEnv: Record<string, string | undefined> = {
+          PATH: shimDir,
+          HOME: fakeHome,
+        };
+        const claudeAdapter = new ClaudeAdapter({ host: shimmedEnv });
+        const codexAdapter = new CodexAdapter({ host: shimmedEnv });
+
+        const result = await runDoctor({
+          cwd: tmp,
+          homeDir: fakeHome,
+          adapters: [
+            { label: "claude", adapter: claudeAdapter },
+            { label: "codex", adapter: codexAdapter },
+          ],
+          isGitRepo: () => true,
+          currentBranch: () => "feature/test",
+          hasRemote: () => false,
+          remoteUrl: () => null,
+          isProtected: () => false,
+          ghRunner: () => ({ status: 0, stdout: "Logged in", stderr: "" }),
+        });
+
+        // The real adapter must report the actual shim path.
+        expect(result.stdout).toContain(shimDir);
+        // Must NOT contain the fake stub data.
+        expect(result.stdout).not.toContain("fake-1.0.0");
+        expect(result.stdout).not.toContain("/usr/bin/fake");
+        expect(result.stdout).not.toContain("fake@example.com");
+      } finally {
+        cleanUp();
+      }
+    },
+  );
+});
+
+// ─── Test 2: empty PATH → both not installed ─────────────────────────────────
+
+describe("doctor-real-adapter / Test 2: empty PATH reports not installed", () => {
+  test(
+    "with no claude/codex on PATH, output reports not installed (not fake-1.0.0)",
+    async () => {
+      // Create an empty PATH directory (no binaries inside).
+      const emptyDir = mkdtempSync(
+        path.join(tmpdir(), "samospec-empty-path-"),
+      );
+      try {
+        const emptyEnv: Record<string, string | undefined> = {
+          PATH: emptyDir,
+        };
+        const claudeAdapter = new ClaudeAdapter({ host: emptyEnv });
+        const codexAdapter = new CodexAdapter({ host: emptyEnv });
+
+        const result = await runDoctor({
+          cwd: tmp,
+          homeDir: fakeHome,
+          adapters: [
+            { label: "claude", adapter: claudeAdapter },
+            { label: "codex", adapter: codexAdapter },
+          ],
+          isGitRepo: () => true,
+          currentBranch: () => "feature/test",
+          hasRemote: () => false,
+          remoteUrl: () => null,
+          isProtected: () => false,
+          ghRunner: () => ({ status: 0, stdout: "Logged in", stderr: "" }),
+        });
+
+        // Must report not installed.
+        expect(result.stdout.toLowerCase()).toContain("not installed");
+        // Must NOT report fake stub data.
+        expect(result.stdout).not.toContain("fake-1.0.0");
+        expect(result.stdout).not.toContain("/usr/bin/fake");
+        expect(result.stdout).not.toContain("fake@example.com");
+      } finally {
+        rmSync(emptyDir, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+// ─── Test 3: import-check — src/cli.ts must not import FakeAdapter ───────────
+
+describe("doctor-real-adapter / Test 3: src/cli.ts does not import fake-adapter", () => {
+  test(
+    "src/cli.ts source does not import createFakeAdapter or FakeAdapter",
+    () => {
+      const cliSrc = path.join(
+        import.meta.dir,
+        "../../src/cli.ts",
+      );
+      const content = readFileSync(cliSrc, "utf8");
+
+      expect(content).not.toContain("createFakeAdapter");
+      expect(content).not.toContain("FakeAdapter");
+    },
+  );
+});

--- a/tests/cli/doctor-real-adapter.test.ts
+++ b/tests/cli/doctor-real-adapter.test.ts
@@ -5,20 +5,8 @@
  * (ClaudeAdapter + CodexAdapter), not the Sprint 1 FakeAdapter stub.
  */
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "bun:test";
-import {
-  chmodSync,
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { readFileSync } from "node:fs";
@@ -33,9 +21,7 @@ let fakeHome: string;
 
 beforeEach(() => {
   tmp = mkdtempSync(path.join(tmpdir(), "samospec-real-adapter-"));
-  fakeHome = mkdtempSync(
-    path.join(tmpdir(), "samospec-home-real-adapter-"),
-  );
+  fakeHome = mkdtempSync(path.join(tmpdir(), "samospec-home-real-adapter-"));
   runInit({ cwd: tmp });
 });
 
@@ -46,9 +32,10 @@ afterEach(() => {
 
 // ─── helper: build a shimmed PATH directory ─────────────────────────────────
 
-function makeShimDir(
-  shims: Record<string, string>,
-): { shimDir: string; cleanUp: () => void } {
+function makeShimDir(shims: Record<string, string>): {
+  shimDir: string;
+  cleanUp: () => void;
+} {
   const shimDir = mkdtempSync(path.join(tmpdir(), "samospec-shim-"));
   for (const [name, script] of Object.entries(shims)) {
     const p = path.join(shimDir, name);
@@ -64,118 +51,104 @@ function makeShimDir(
 // ─── Test 1: PATH shim emitting real-looking version ────────────────────────
 
 describe("doctor-real-adapter / Test 1: PATH shim with real-looking version", () => {
-  test(
-    "output reports installed binary path from shim, not fake-1.0.0",
-    async () => {
-      // Shim claude and codex as real-looking executables.
-      // ClaudeAdapter parses the version from stdout; if it can extract a
-      // semver token, it uses that; otherwise it falls back to the first
-      // line. Either way the INSTALLED status and real PATH are reported
-      // (not fake-1.0.0 / /usr/bin/fake).
-      const claudeVersion = "2.1.114";
-      const codexVersion = "0.120.0";
+  test("output reports installed binary path from shim, not fake-1.0.0", async () => {
+    // Shim claude and codex as real-looking executables.
+    // ClaudeAdapter parses the version from stdout; if it can extract a
+    // semver token, it uses that; otherwise it falls back to the first
+    // line. Either way the INSTALLED status and real PATH are reported
+    // (not fake-1.0.0 / /usr/bin/fake).
+    const claudeVersion = "2.1.114";
+    const codexVersion = "0.120.0";
 
-      const { shimDir, cleanUp } = makeShimDir({
-        claude: `#!/bin/sh\necho "${claudeVersion} (Claude Code)"\n`,
-        codex: `#!/bin/sh\nprintf "codex-cli ${codexVersion}\\n"\n`,
+    const { shimDir, cleanUp } = makeShimDir({
+      claude: `#!/bin/sh\necho "${claudeVersion} (Claude Code)"\n`,
+      codex: `#!/bin/sh\nprintf "codex-cli ${codexVersion}\\n"\n`,
+    });
+
+    try {
+      // Build adapters with the shimmed PATH only (no system PATH).
+      const shimmedEnv: Record<string, string | undefined> = {
+        PATH: shimDir,
+        HOME: fakeHome,
+      };
+      const claudeAdapter = new ClaudeAdapter({ host: shimmedEnv });
+      const codexAdapter = new CodexAdapter({ host: shimmedEnv });
+
+      const result = await runDoctor({
+        cwd: tmp,
+        homeDir: fakeHome,
+        adapters: [
+          { label: "claude", adapter: claudeAdapter },
+          { label: "codex", adapter: codexAdapter },
+        ],
+        isGitRepo: () => true,
+        currentBranch: () => "feature/test",
+        hasRemote: () => false,
+        remoteUrl: () => null,
+        isProtected: () => false,
+        ghRunner: () => ({ status: 0, stdout: "Logged in", stderr: "" }),
       });
 
-      try {
-        // Build adapters with the shimmed PATH only (no system PATH).
-        const shimmedEnv: Record<string, string | undefined> = {
-          PATH: shimDir,
-          HOME: fakeHome,
-        };
-        const claudeAdapter = new ClaudeAdapter({ host: shimmedEnv });
-        const codexAdapter = new CodexAdapter({ host: shimmedEnv });
-
-        const result = await runDoctor({
-          cwd: tmp,
-          homeDir: fakeHome,
-          adapters: [
-            { label: "claude", adapter: claudeAdapter },
-            { label: "codex", adapter: codexAdapter },
-          ],
-          isGitRepo: () => true,
-          currentBranch: () => "feature/test",
-          hasRemote: () => false,
-          remoteUrl: () => null,
-          isProtected: () => false,
-          ghRunner: () => ({ status: 0, stdout: "Logged in", stderr: "" }),
-        });
-
-        // The real adapter must report the actual shim path.
-        expect(result.stdout).toContain(shimDir);
-        // Must NOT contain the fake stub data.
-        expect(result.stdout).not.toContain("fake-1.0.0");
-        expect(result.stdout).not.toContain("/usr/bin/fake");
-        expect(result.stdout).not.toContain("fake@example.com");
-      } finally {
-        cleanUp();
-      }
-    },
-  );
+      // The real adapter must report the actual shim path.
+      expect(result.stdout).toContain(shimDir);
+      // Must NOT contain the fake stub data.
+      expect(result.stdout).not.toContain("fake-1.0.0");
+      expect(result.stdout).not.toContain("/usr/bin/fake");
+      expect(result.stdout).not.toContain("fake@example.com");
+    } finally {
+      cleanUp();
+    }
+  });
 });
 
 // ─── Test 2: empty PATH → both not installed ─────────────────────────────────
 
 describe("doctor-real-adapter / Test 2: empty PATH reports not installed", () => {
-  test(
-    "with no claude/codex on PATH, output reports not installed (not fake-1.0.0)",
-    async () => {
-      // Create an empty PATH directory (no binaries inside).
-      const emptyDir = mkdtempSync(
-        path.join(tmpdir(), "samospec-empty-path-"),
-      );
-      try {
-        const emptyEnv: Record<string, string | undefined> = {
-          PATH: emptyDir,
-        };
-        const claudeAdapter = new ClaudeAdapter({ host: emptyEnv });
-        const codexAdapter = new CodexAdapter({ host: emptyEnv });
+  test("with no claude/codex on PATH, output reports not installed (not fake-1.0.0)", async () => {
+    // Create an empty PATH directory (no binaries inside).
+    const emptyDir = mkdtempSync(path.join(tmpdir(), "samospec-empty-path-"));
+    try {
+      const emptyEnv: Record<string, string | undefined> = {
+        PATH: emptyDir,
+      };
+      const claudeAdapter = new ClaudeAdapter({ host: emptyEnv });
+      const codexAdapter = new CodexAdapter({ host: emptyEnv });
 
-        const result = await runDoctor({
-          cwd: tmp,
-          homeDir: fakeHome,
-          adapters: [
-            { label: "claude", adapter: claudeAdapter },
-            { label: "codex", adapter: codexAdapter },
-          ],
-          isGitRepo: () => true,
-          currentBranch: () => "feature/test",
-          hasRemote: () => false,
-          remoteUrl: () => null,
-          isProtected: () => false,
-          ghRunner: () => ({ status: 0, stdout: "Logged in", stderr: "" }),
-        });
+      const result = await runDoctor({
+        cwd: tmp,
+        homeDir: fakeHome,
+        adapters: [
+          { label: "claude", adapter: claudeAdapter },
+          { label: "codex", adapter: codexAdapter },
+        ],
+        isGitRepo: () => true,
+        currentBranch: () => "feature/test",
+        hasRemote: () => false,
+        remoteUrl: () => null,
+        isProtected: () => false,
+        ghRunner: () => ({ status: 0, stdout: "Logged in", stderr: "" }),
+      });
 
-        // Must report not installed.
-        expect(result.stdout.toLowerCase()).toContain("not installed");
-        // Must NOT report fake stub data.
-        expect(result.stdout).not.toContain("fake-1.0.0");
-        expect(result.stdout).not.toContain("/usr/bin/fake");
-        expect(result.stdout).not.toContain("fake@example.com");
-      } finally {
-        rmSync(emptyDir, { recursive: true, force: true });
-      }
-    },
-  );
+      // Must report not installed.
+      expect(result.stdout.toLowerCase()).toContain("not installed");
+      // Must NOT report fake stub data.
+      expect(result.stdout).not.toContain("fake-1.0.0");
+      expect(result.stdout).not.toContain("/usr/bin/fake");
+      expect(result.stdout).not.toContain("fake@example.com");
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── Test 3: import-check — src/cli.ts must not import FakeAdapter ───────────
 
 describe("doctor-real-adapter / Test 3: src/cli.ts does not import fake-adapter", () => {
-  test(
-    "src/cli.ts source does not import createFakeAdapter or FakeAdapter",
-    () => {
-      const cliSrc = path.join(
-        import.meta.dir,
-        "../../src/cli.ts",
-      );
-      const content = readFileSync(cliSrc, "utf8");
+  test("src/cli.ts source does not import createFakeAdapter or FakeAdapter", () => {
+    const cliSrc = path.join(import.meta.dir, "../../src/cli.ts");
+    const content = readFileSync(cliSrc, "utf8");
 
-      expect(content).not.toContain("createFakeAdapter");
-      expect(content).not.toContain("FakeAdapter");
-    },
-  );
+    expect(content).not.toContain("createFakeAdapter");
+    expect(content).not.toContain("FakeAdapter");
+  });
 });


### PR DESCRIPTION
## Summary

- Removes `createFakeAdapter` import and usage from `src/cli.ts`
- Updates `defaultAdapterBindings()` to return `new ClaudeAdapter()` and `new CodexAdapter()` so `samospec doctor` probes the actual installed CLIs
- Updates JSDoc on `defaultAdapterBindings()` to reflect Sprints 2–3 status
- Adds 3 regression tests in `tests/cli/doctor-real-adapter.test.ts`

Closes #43

## Evidence

### grep: no fake adapter in src/cli.ts

```
$ grep -n 'createFakeAdapter\|FakeAdapter' src/cli.ts
(no output — zero matches)
```

### grep: fake-1.0.0 / fake@example only in fake-adapter.ts itself

```
$ grep -rn 'fake-1.0.0\|fake@example' src/
src/adapter/fake-adapter.ts:44:  version: "fake-1.0.0",
src/adapter/fake-adapter.ts:50:  account: "fake@example.com",
```

### bun test tail (1093 pass, 0 fail)

```
 1093 pass
 0 fail
 8474 expect() calls
Ran 1093 tests across 94 files. [37.47s]
```

### lint / format / typecheck

```
$ bun run lint       → (no output — clean)
$ bun run format:check → All matched files use Prettier code style!
$ bun run typecheck  → (no output — clean)
```

### Manual: samospec doctor on real system (real CLIs on PATH)

```
[OK  ]  CLI availability  claude: installed 2.1.114 at /Users/nik/.local/bin/claude; codex: installed 0.120.0 at /opt/homebrew/bin/codex
[OK  ]  auth              claude: authenticated; codex: authenticated
```

### Manual: samospec doctor with PATH stripped of claude/codex

```
[FAIL]  CLI availability  claude: not installed; codex: not installed
[FAIL]  auth              claude: not authenticated; codex: not authenticated
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)