### PR TITLE
fix: forward USER and LOGNAME for macOS Keychain OAuth (#50)

### DIFF
--- a/src/adapter/spawn.ts
+++ b/src/adapter/spawn.ts
@@ -31,7 +31,14 @@ export const CLAUDE_NON_INTERACTIVE_FLAGS: readonly string[] = [
 
 export const CODEX_NON_INTERACTIVE_FLAGS: readonly string[] = ["exec"];
 
-const BASELINE_ALLOWED_ENV_KEYS: readonly string[] = ["HOME", "PATH", "TMPDIR"];
+const BASELINE_ALLOWED_ENV_KEYS: readonly string[] = [
+  "HOME",
+  "PATH",
+  "TMPDIR",
+  // USER and LOGNAME are required for macOS Keychain OAuth (#50).
+  "USER",
+  "LOGNAME",
+];
 
 export interface BuildMinimalEnvInput {
   readonly host: Readonly<Record<string, string | undefined>>;

--- a/tests/adapter/spawn.test.ts
+++ b/tests/adapter/spawn.test.ts
@@ -58,6 +58,23 @@ describe("buildMinimalEnv (SPEC §7 minimal-env spawn)", () => {
     });
     expect(env["OPENAI_API_KEY"]).toBeUndefined();
   });
+
+  test("forwards USER and LOGNAME for macOS Keychain OAuth (#50)", () => {
+    const env = buildMinimalEnv({
+      host: {
+        HOME: "/home/nik",
+        PATH: "/usr/bin",
+        TMPDIR: "/tmp",
+        USER: "nik",
+        LOGNAME: "nik",
+        SECRET: "s3cr3t",
+      },
+      extraAllowedKeys: [],
+    });
+    expect(env["USER"]).toBe("nik");
+    expect(env["LOGNAME"]).toBe("nik");
+    expect(env["SECRET"]).toBeUndefined();
+  });
 });
 
 describe("non-interactive flag documentation (SPEC §7)", () => {


### PR DESCRIPTION
## Summary

- Adds `USER` and `LOGNAME` to `BASELINE_ALLOWED_ENV_KEYS` in `buildMinimalEnv` (`src/adapter/spawn.ts`)
- Without these vars the macOS Security framework cannot locate the Keychain, causing `claude -p` to exit with _"Not logged in · Please run /login"_ even with valid OAuth credentials stored
- Scope is strictly `USER` + `LOGNAME` only — no other env vars added

Closes #50

## Evidence

**Grep showing the addition:**
```
src/adapter/spawn.ts:38:  // USER and LOGNAME are required for macOS Keychain OAuth (#50).
src/adapter/spawn.ts:39:  "USER",
src/adapter/spawn.ts:40:  "LOGNAME",
```

**Test output (GREEN):**
```
bun test v1.3.5
 9 pass
 0 fail
Ran 9 tests across 1 file.
```

**Full suite:**
```
1150 pass, 0 fail — 1150 tests across 101 files
```

**Lint / format / typecheck:** all clean (no changes to formatted files).

**Manual smoke (confirmed by manager):**
```sh
# Before fix — fails:
echo hi | env -i HOME=... PATH=... TMPDIR=... claude -p --model claude-opus-4-7
# → "Not logged in · Please run /login"

# After fix — works:
echo hi | env -i HOME=... PATH=... TMPDIR=... USER=... LOGNAME=... claude -p ...
# → "Hi! What would you like to work on?"
```

## Test plan

- [x] New test `forwards USER and LOGNAME for macOS Keychain OAuth (#50)` in `tests/adapter/spawn.test.ts` was RED before the fix, GREEN after
- [x] Full 1150-test suite passes
- [x] ESLint, Prettier, tsc --noEmit all clean