### PR TITLE
fix: bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samospec",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Git-native CLI that turns a rough idea into a reviewed, versioned specification document.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Version string in `package.json` was not bumped before tagging v0.1.1
- `samospec version` incorrectly reports `0.1.0` after installing the v0.1.1 hotfix

## Test plan
- `bun remove -g samospec && bun install -g github:NikolayS/samospec#v0.1.1`
- `samospec version` should now report `0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)