### PR TITLE
fix(publish): push base branch to remote before gh pr create

### DIFF
--- a/src/publish/pr.ts
+++ b/src/publish/pr.ts
@@ -33,6 +33,18 @@ export interface PrRunnerResult {
 
 export type PrRunner = (argv: readonly string[]) => PrRunnerResult;
 
+/**
+ * Returns true when `origin/<base>` exists on the remote (i.e. `git
+ * rev-parse --verify origin/<base>` exits 0). Injected in tests.
+ */
+export type BaseBranchChecker = (base: string) => boolean;
+
+/**
+ * Pushes the base branch to the remote (`git push origin <base>`).
+ * Called only when `hasRemoteBase` returns false. Injected in tests.
+ */
+export type BaseBranchPusher = (base: string) => void;
+
 export interface OpenPrOpts {
   readonly capability: PrCapabilityProbe;
   readonly title: string;
@@ -46,6 +58,16 @@ export interface OpenPrOpts {
   /** Injection seams — tests pass fake runners. */
   readonly gh?: PrRunner;
   readonly glab?: PrRunner;
+  /**
+   * Returns true when origin/<defaultBranch> exists on the remote.
+   * Defaults to the real git rev-parse check. Injected for tests.
+   */
+  readonly hasRemoteBase?: BaseBranchChecker;
+  /**
+   * Pushes <defaultBranch> to origin when the remote ref is absent.
+   * Defaults to `git push origin <base>`. Injected for tests.
+   */
+  readonly pushBaseBranch?: BaseBranchPusher;
 }
 
 export type OpenPrResult =
@@ -87,6 +109,12 @@ export function openPullRequest(opts: OpenPrOpts): OpenPrResult {
     }
     return { kind: "compare-url", url: compareUrl };
   }
+
+  // Issue #66 — ensure the base branch exists on the remote before
+  // calling `gh pr create` / `glab mr create`. GitHub's GraphQL API
+  // returns a cryptic "Base sha can't be blank" error when origin/<base>
+  // is absent, so we push it proactively here.
+  ensureBaseBranchOnRemote(opts);
 
   // gh preferred when both are authenticated (probe enforces this).
   if (opts.capability.tool === "gh") {
@@ -258,4 +286,64 @@ function parseRemote(url: string): ParsedRemote | null {
     }
   }
   return null;
+}
+
+// ---------- base branch remote-presence check (Issue #66) ----------
+
+/**
+ * Check `origin/<base>` via `git rev-parse --verify origin/<base>`.
+ * Returns true when the ref exists on the remote (exit 0).
+ */
+function defaultHasRemoteBase(opts: OpenPrOpts): BaseBranchChecker {
+  return (base: string): boolean => {
+    const res = spawnSync(
+      "git",
+      ["rev-parse", "--verify", `origin/${base}`],
+      {
+        ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GIT_TERMINAL_PROMPT: "0",
+          ...(opts.env ?? {}),
+        },
+      },
+    );
+    return (res.status ?? 1) === 0;
+  };
+}
+
+/**
+ * Push the base branch to origin with `git push origin <base>`.
+ * Logs a notice to stdout so the user is not surprised.
+ */
+function defaultPushBaseBranch(opts: OpenPrOpts): BaseBranchPusher {
+  return (base: string): void => {
+    process.stdout.write(`Pushing base branch to remote...\n`);
+    spawnSync("git", ["push", "origin", base], {
+      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+        ...(opts.env ?? {}),
+      },
+    });
+  };
+}
+
+/**
+ * Ensure origin/<defaultBranch> exists before the PR tool runs.
+ * When the remote ref is absent, push the branch and log a notice.
+ * This prevents GitHub's cryptic "Base sha can't be blank" GraphQL
+ * error (Issue #66).
+ */
+function ensureBaseBranchOnRemote(opts: OpenPrOpts): void {
+  const checker =
+    opts.hasRemoteBase ?? defaultHasRemoteBase(opts);
+  const pusher =
+    opts.pushBaseBranch ?? defaultPushBaseBranch(opts);
+  if (!checker(opts.defaultBranch)) {
+    pusher(opts.defaultBranch);
+  }
 }

--- a/src/publish/pr.ts
+++ b/src/publish/pr.ts
@@ -296,19 +296,15 @@ function parseRemote(url: string): ParsedRemote | null {
  */
 function defaultHasRemoteBase(opts: OpenPrOpts): BaseBranchChecker {
   return (base: string): boolean => {
-    const res = spawnSync(
-      "git",
-      ["rev-parse", "--verify", `origin/${base}`],
-      {
-        ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          GIT_TERMINAL_PROMPT: "0",
-          ...(opts.env ?? {}),
-        },
+    const res = spawnSync("git", ["rev-parse", "--verify", `origin/${base}`], {
+      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+        ...(opts.env ?? {}),
       },
-    );
+    });
     return (res.status ?? 1) === 0;
   };
 }
@@ -339,10 +335,8 @@ function defaultPushBaseBranch(opts: OpenPrOpts): BaseBranchPusher {
  * error (Issue #66).
  */
 function ensureBaseBranchOnRemote(opts: OpenPrOpts): void {
-  const checker =
-    opts.hasRemoteBase ?? defaultHasRemoteBase(opts);
-  const pusher =
-    opts.pushBaseBranch ?? defaultPushBaseBranch(opts);
+  const checker = opts.hasRemoteBase ?? defaultHasRemoteBase(opts);
+  const pusher = opts.pushBaseBranch ?? defaultPushBaseBranch(opts);
   if (!checker(opts.defaultBranch)) {
     pusher(opts.defaultBranch);
   }

--- a/tests/publish/pr.test.ts
+++ b/tests/publish/pr.test.ts
@@ -197,90 +197,81 @@ describe("openPullRequest", () => {
 });
 
 describe("openPullRequest — base branch auto-push (Issue #66)", () => {
-  test(
-    "pushes base branch before gh pr create when base has no remote ref",
-    () => {
-      const calls: string[] = [];
-      const pushedBranches: string[] = [];
+  test("pushes base branch before gh pr create when base has no remote ref", () => {
+    const calls: string[] = [];
+    const pushedBranches: string[] = [];
 
-      const pusher: BaseBranchPusher = (branch) => {
-        pushedBranches.push(branch);
-      };
+    const pusher: BaseBranchPusher = (branch) => {
+      pushedBranches.push(branch);
+    };
 
-      openPullRequest({
-        capability: { available: true, tool: "gh" },
-        title: "spec(vibeify): publish v0.1",
-        bodyFile: "/tmp/body.md",
-        branch: "samospec/vibeify",
-        defaultBranch: "main",
-        remoteUrl: "git@github.com:NikolayS/samospec.git",
-        gh: fakeRunner("gh", calls),
-        glab: fakeRunner("glab", calls),
-        hasRemoteBase: () => false,
-        pushBaseBranch: pusher,
-      });
+    openPullRequest({
+      capability: { available: true, tool: "gh" },
+      title: "spec(vibeify): publish v0.1",
+      bodyFile: "/tmp/body.md",
+      branch: "samospec/vibeify",
+      defaultBranch: "main",
+      remoteUrl: "git@github.com:NikolayS/samospec.git",
+      gh: fakeRunner("gh", calls),
+      glab: fakeRunner("glab", calls),
+      hasRemoteBase: () => false,
+      pushBaseBranch: pusher,
+    });
 
-      expect(pushedBranches).toEqual(["main"]);
-      const prCall = calls.find((c) => c.startsWith("gh pr create"));
-      expect(prCall).toBeDefined();
-    },
-  );
+    expect(pushedBranches).toEqual(["main"]);
+    const prCall = calls.find((c) => c.startsWith("gh pr create"));
+    expect(prCall).toBeDefined();
+  });
 
-  test(
-    "does NOT push base branch when it already has a remote ref",
-    () => {
-      const calls: string[] = [];
-      const pushedBranches: string[] = [];
+  test("does NOT push base branch when it already has a remote ref", () => {
+    const calls: string[] = [];
+    const pushedBranches: string[] = [];
 
-      const pusher: BaseBranchPusher = (branch) => {
-        pushedBranches.push(branch);
-      };
+    const pusher: BaseBranchPusher = (branch) => {
+      pushedBranches.push(branch);
+    };
 
-      openPullRequest({
-        capability: { available: true, tool: "gh" },
-        title: "spec(vibeify): publish v0.1",
-        bodyFile: "/tmp/body.md",
-        branch: "samospec/vibeify",
-        defaultBranch: "main",
-        remoteUrl: "git@github.com:NikolayS/samospec.git",
-        gh: fakeRunner("gh", calls),
-        glab: fakeRunner("glab", calls),
-        hasRemoteBase: () => true,
-        pushBaseBranch: pusher,
-      });
+    openPullRequest({
+      capability: { available: true, tool: "gh" },
+      title: "spec(vibeify): publish v0.1",
+      bodyFile: "/tmp/body.md",
+      branch: "samospec/vibeify",
+      defaultBranch: "main",
+      remoteUrl: "git@github.com:NikolayS/samospec.git",
+      gh: fakeRunner("gh", calls),
+      glab: fakeRunner("glab", calls),
+      hasRemoteBase: () => true,
+      pushBaseBranch: pusher,
+    });
 
-      expect(pushedBranches).toEqual([]);
-      const prCall = calls.find((c) => c.startsWith("gh pr create"));
-      expect(prCall).toBeDefined();
-    },
-  );
+    expect(pushedBranches).toEqual([]);
+    const prCall = calls.find((c) => c.startsWith("gh pr create"));
+    expect(prCall).toBeDefined();
+  });
 
-  test(
-    "pushes base branch before glab mr create when base has no remote ref",
-    () => {
-      const calls: string[] = [];
-      const pushedBranches: string[] = [];
+  test("pushes base branch before glab mr create when base has no remote ref", () => {
+    const calls: string[] = [];
+    const pushedBranches: string[] = [];
 
-      const pusher: BaseBranchPusher = (branch) => {
-        pushedBranches.push(branch);
-      };
+    const pusher: BaseBranchPusher = (branch) => {
+      pushedBranches.push(branch);
+    };
 
-      openPullRequest({
-        capability: { available: true, tool: "glab" },
-        title: "spec(vibeify): publish v0.1",
-        bodyFile: "/tmp/body.md",
-        branch: "samospec/vibeify",
-        defaultBranch: "main",
-        remoteUrl: "git@gitlab.com:group/project.git",
-        gh: fakeRunner("gh", calls),
-        glab: fakeRunner("glab", calls),
-        hasRemoteBase: () => false,
-        pushBaseBranch: pusher,
-      });
+    openPullRequest({
+      capability: { available: true, tool: "glab" },
+      title: "spec(vibeify): publish v0.1",
+      bodyFile: "/tmp/body.md",
+      branch: "samospec/vibeify",
+      defaultBranch: "main",
+      remoteUrl: "git@gitlab.com:group/project.git",
+      gh: fakeRunner("gh", calls),
+      glab: fakeRunner("glab", calls),
+      hasRemoteBase: () => false,
+      pushBaseBranch: pusher,
+    });
 
-      expect(pushedBranches).toEqual(["main"]);
-      const mrCall = calls.find((c) => c.startsWith("glab mr create"));
-      expect(mrCall).toBeDefined();
-    },
-  );
+    expect(pushedBranches).toEqual(["main"]);
+    const mrCall = calls.find((c) => c.startsWith("glab mr create"));
+    expect(mrCall).toBeDefined();
+  });
 });

--- a/tests/publish/pr.test.ts
+++ b/tests/publish/pr.test.ts
@@ -10,11 +10,17 @@
  *   - The body is passed via stdin-equivalent `--body-file` to avoid argv
  *     overflow on large PR bodies.
  *   - Title = `spec(<slug>): publish v<version>` (matches SPEC §8 grammar).
+ *   - Base branch auto-push: when `hasRemoteBase` returns false, push base
+ *     branch to remote before calling `gh pr create` (Issue #66).
  */
 
 import { describe, expect, test } from "bun:test";
 
-import { buildCompareUrl, openPullRequest } from "../../src/publish/pr.ts";
+import {
+  buildCompareUrl,
+  openPullRequest,
+  type BaseBranchPusher,
+} from "../../src/publish/pr.ts";
 
 function fakeRunner(name: string, outputs: string[]) {
   return (argv: readonly string[]) => {
@@ -188,4 +194,93 @@ describe("openPullRequest", () => {
     });
     expect(result.kind).toBe("failed");
   });
+});
+
+describe("openPullRequest — base branch auto-push (Issue #66)", () => {
+  test(
+    "pushes base branch before gh pr create when base has no remote ref",
+    () => {
+      const calls: string[] = [];
+      const pushedBranches: string[] = [];
+
+      const pusher: BaseBranchPusher = (branch) => {
+        pushedBranches.push(branch);
+      };
+
+      openPullRequest({
+        capability: { available: true, tool: "gh" },
+        title: "spec(vibeify): publish v0.1",
+        bodyFile: "/tmp/body.md",
+        branch: "samospec/vibeify",
+        defaultBranch: "main",
+        remoteUrl: "git@github.com:NikolayS/samospec.git",
+        gh: fakeRunner("gh", calls),
+        glab: fakeRunner("glab", calls),
+        hasRemoteBase: () => false,
+        pushBaseBranch: pusher,
+      });
+
+      expect(pushedBranches).toEqual(["main"]);
+      const prCall = calls.find((c) => c.startsWith("gh pr create"));
+      expect(prCall).toBeDefined();
+    },
+  );
+
+  test(
+    "does NOT push base branch when it already has a remote ref",
+    () => {
+      const calls: string[] = [];
+      const pushedBranches: string[] = [];
+
+      const pusher: BaseBranchPusher = (branch) => {
+        pushedBranches.push(branch);
+      };
+
+      openPullRequest({
+        capability: { available: true, tool: "gh" },
+        title: "spec(vibeify): publish v0.1",
+        bodyFile: "/tmp/body.md",
+        branch: "samospec/vibeify",
+        defaultBranch: "main",
+        remoteUrl: "git@github.com:NikolayS/samospec.git",
+        gh: fakeRunner("gh", calls),
+        glab: fakeRunner("glab", calls),
+        hasRemoteBase: () => true,
+        pushBaseBranch: pusher,
+      });
+
+      expect(pushedBranches).toEqual([]);
+      const prCall = calls.find((c) => c.startsWith("gh pr create"));
+      expect(prCall).toBeDefined();
+    },
+  );
+
+  test(
+    "pushes base branch before glab mr create when base has no remote ref",
+    () => {
+      const calls: string[] = [];
+      const pushedBranches: string[] = [];
+
+      const pusher: BaseBranchPusher = (branch) => {
+        pushedBranches.push(branch);
+      };
+
+      openPullRequest({
+        capability: { available: true, tool: "glab" },
+        title: "spec(vibeify): publish v0.1",
+        bodyFile: "/tmp/body.md",
+        branch: "samospec/vibeify",
+        defaultBranch: "main",
+        remoteUrl: "git@gitlab.com:group/project.git",
+        gh: fakeRunner("gh", calls),
+        glab: fakeRunner("glab", calls),
+        hasRemoteBase: () => false,
+        pushBaseBranch: pusher,
+      });
+
+      expect(pushedBranches).toEqual(["main"]);
+      const mrCall = calls.find((c) => c.startsWith("glab mr create"));
+      expect(mrCall).toBeDefined();
+    },
+  );
 });


### PR DESCRIPTION
Fixes #66.

## Summary

- Before calling `gh pr create` / `glab mr create`, check whether `origin/<defaultBranch>` exists via `git rev-parse --verify origin/<base>`.
- If the remote ref is absent, push the base branch with `git push origin <base>` and log `Pushing base branch to remote...` so users know what happened.
- Both `hasRemoteBase` and `pushBaseBranch` are injected seams on `OpenPrOpts` so tests work without a real remote.

## Root cause

GitHub's GraphQL API returns a cryptic multi-part error when the base branch has no commits on the remote:

```
pull request create failed: GraphQL: Head sha can't be blank,
Base sha can't be blank, No commits between main and samospec/vibeify,
Base ref must be a branch (createPullRequest)
```

The base branch is always present locally (it's where the spec branch forked from), but if it was never pushed the remote has no SHA to anchor the PR comparison.

## Test plan

- [x] RED test written first: 3 new tests in `tests/publish/pr.test.ts` under `openPullRequest — base branch auto-push (Issue #66)` confirmed FAILING before implementation
- [x] GREEN: all 13 tests in `tests/publish/pr.test.ts` pass after implementation
- [x] No regressions in `tests/publish/` and `tests/git/` (361 tests, 0 failures)
- [x] `eslint` and `tsc --noEmit` both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)