### PR TITLE
fix(new): archive existing slug dir when --force is passed (#63)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,10 +46,11 @@ const USAGE =
   "Commands:\n" +
   "  init                        Create or refresh .samo/ in the current repo.\n" +
   "  doctor                      Diagnose CLI availability, auth, git, lock, and config.\n" +
-  "  new <slug> [--idea ...] [--skip <sections>]\n" +
+  "  new <slug> [--idea ...] [--force] [--skip <sections>]\n" +
   "                              Start a new spec (persona + 5-question interview).\n" +
-  "                              --skip omits named baseline sections from the\n" +
-  "                              mandatory template (comma-separated,\n" +
+  "                              --force archives any existing run before starting\n" +
+  "                              fresh. --skip omits named baseline sections from\n" +
+  "                              the mandatory template (comma-separated,\n" +
   "                              case-insensitive). Valid sections: " +
   BASELINE_SECTION_NAMES.join(", ") +
   ".\n" +
@@ -142,6 +143,7 @@ interface NewArgs {
   readonly idea: string;
   readonly explain: boolean;
   readonly skipSections?: readonly string[];
+  readonly force: boolean;
 }
 
 interface ResumeArgs {
@@ -195,12 +197,17 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
   let slug: string | null = null;
   let idea: string | null = null;
   let explain = false;
+  let force = false;
   let skipSections: readonly string[] | undefined;
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
     if (token === undefined) continue;
     if (token === "--explain") {
       explain = true;
+      continue;
+    }
+    if (token === "--force") {
+      force = true;
       continue;
     }
     if (token === "--idea") {
@@ -228,7 +235,7 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
       continue;
     }
     if (token.startsWith("--")) {
-      // Unknown flags ignored (permissive for --force and future flags).
+      // Unknown flags ignored (permissive for future flags).
       continue;
     }
     if (slug === null) {
@@ -243,6 +250,7 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
     slug,
     idea: idea ?? slug,
     explain,
+    force,
     ...(skipSections !== undefined ? { skipSections } : {}),
   };
 }
@@ -346,6 +354,7 @@ async function runNewCommand(rest: readonly string[]) {
       slug: parsed.slug,
       idea: parsed.idea,
       explain: parsed.explain,
+      force: parsed.force,
       resolvers: interactiveResolvers(),
       now: new Date().toISOString(),
       ...(parsed.skipSections !== undefined

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -23,7 +23,13 @@
 //     protected branch (createSpecBranch throws with exit 2; specCommit
 //     additionally refuses).
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 
 import type { Adapter } from "../adapter/types.ts";
@@ -158,9 +164,7 @@ export async function runNew(
       const ts = input.now.replace(/[:.]/g, "-");
       const bakDir = path.join(specsDir, `${input.slug}.bak.${ts}`);
       renameSync(slugDir, bakDir);
-      notice(
-        `archived existing run to .samo/spec/${input.slug}.bak.${ts}/`,
-      );
+      notice(`archived existing run to .samo/spec/${input.slug}.bak.${ts}/`);
     } else {
       errors.push(
         `samospec: .samo/spec/${input.slug}/ already exists. ` +

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -23,7 +23,7 @@
 //     protected branch (createSpecBranch throws with exit 2; specCommit
 //     additionally refuses).
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import type { Adapter } from "../adapter/types.ts";
@@ -31,6 +31,7 @@ import { discoverContext } from "../context/discover.ts";
 import { contextJsonPath } from "../context/provenance.ts";
 import { createSpecBranch } from "../git/branch.ts";
 import { specCommit } from "../git/commit.ts";
+import { ensureHasCommit } from "../git/ensure-has-commit.ts";
 import { ProtectedBranchError, GitLayerUsageError } from "../git/errors.ts";
 import { writeCalibrationSample } from "../policy/calibration.ts";
 import {
@@ -123,6 +124,13 @@ export interface RunNewInput {
    * --skip opt-out). Forwarded into `authorDraft` → `adapter.revise`.
    */
   readonly skipSections?: readonly string[];
+  /**
+   * When true, archive any pre-existing slug directory to
+   * `.samo/spec/<slug>.bak.<timestamp>/` before starting a fresh run
+   * (issue #63). When false or omitted, a pre-existing slug directory
+   * returns exit 1.
+   */
+  readonly force?: boolean;
 }
 
 // ---------- CLI entry ----------
@@ -145,16 +153,26 @@ export async function runNew(
   // Slug collision guard (SPEC §10): refuse any pre-existing slug
   // directory and suggest resume / --force.
   if (existsSync(slugDir)) {
-    errors.push(
-      `samospec: .samo/spec/${input.slug}/ already exists. ` +
-        `Try \`samospec resume ${input.slug}\` or ` +
-        `\`samospec new ${input.slug} --force\` to archive the old run.`,
-    );
-    return {
-      exitCode: 1,
-      stdout: lines.join("\n"),
-      stderr: `${errors.join("\n")}\n`,
-    };
+    if (input.force) {
+      // Archive the old run by renaming to a timestamped backup dir.
+      const ts = input.now.replace(/[:.]/g, "-");
+      const bakDir = path.join(specsDir, `${input.slug}.bak.${ts}`);
+      renameSync(slugDir, bakDir);
+      notice(
+        `archived existing run to .samo/spec/${input.slug}.bak.${ts}/`,
+      );
+    } else {
+      errors.push(
+        `samospec: .samo/spec/${input.slug}/ already exists. ` +
+          `Try \`samospec resume ${input.slug}\` or ` +
+          `\`samospec new ${input.slug} --force\` to archive the old run.`,
+      );
+      return {
+        exitCode: 1,
+        stdout: lines.join("\n"),
+        stderr: `${errors.join("\n")}\n`,
+      };
+    }
   }
 
   // Lockfile acquisition (SPEC §5 Phase 1).
@@ -232,6 +250,19 @@ export async function runNew(
           );
         }
       }
+    }
+
+    // Empty-repo guard (Issue #65): if the repo has no commits yet,
+    // create an empty initial commit so that HEAD is resolvable before
+    // branch operations that require it.
+    try {
+      const initResult = ensureHasCommit({ repoPath: input.cwd });
+      if (initResult.created) {
+        notice("No commits found — created initial commit.");
+      }
+    } catch {
+      // Outside a real git repo (skeleton / non-git tests) this may
+      // fail; ignore and let the branch-creation step report the error.
     }
 
     // Branch creation (SPEC §5 Phase 1 + §8).

--- a/src/git/ensure-has-commit.ts
+++ b/src/git/ensure-has-commit.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { spawnSync } from "node:child_process";
+
+export const INITIAL_COMMIT_MESSAGE =
+  "chore: initial commit (created by samospec)";
+
+export interface EnsureHasCommitOpts {
+  readonly repoPath: string;
+}
+
+export interface EnsureHasCommitResult {
+  /** True if an initial empty commit was created; false if HEAD already existed. */
+  readonly created: boolean;
+}
+
+/**
+ * Checks whether the repo has at least one commit. If not (empty repo /
+ * freshly `git init`), creates an empty initial commit so that operations
+ * that require HEAD (e.g. branch creation) can proceed.
+ *
+ * Logs nothing — the caller is responsible for surfacing the message
+ * "No commits found — created initial commit." when `created` is true.
+ */
+export function ensureHasCommit(
+  opts: EnsureHasCommitOpts,
+): EnsureHasCommitResult {
+  if (hasHead(opts.repoPath)) {
+    return { created: false };
+  }
+
+  runGitOrThrow(
+    [
+      "commit",
+      "--allow-empty",
+      "-m",
+      INITIAL_COMMIT_MESSAGE,
+    ],
+    opts.repoPath,
+  );
+
+  return { created: true };
+}
+
+function hasHead(repoPath: string): boolean {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoPath,
+    encoding: "utf8",
+  });
+  return result.status === 0;
+}
+
+function runGitOrThrow(
+  args: readonly string[],
+  repoPath: string,
+): void {
+  const result = spawnSync("git", args as string[], {
+    cwd: repoPath,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME:
+        process.env["GIT_AUTHOR_NAME"] ?? "samospec",
+      GIT_AUTHOR_EMAIL:
+        process.env["GIT_AUTHOR_EMAIL"] ?? "samospec@localhost",
+      GIT_COMMITTER_NAME:
+        process.env["GIT_COMMITTER_NAME"] ?? "samospec",
+      GIT_COMMITTER_EMAIL:
+        process.env["GIT_COMMITTER_EMAIL"] ?? "samospec@localhost",
+    },
+  });
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed with status ${String(result.status)}: ${
+        result.stderr ?? ""
+      }`,
+    );
+  }
+}

--- a/src/git/ensure-has-commit.ts
+++ b/src/git/ensure-has-commit.ts
@@ -30,12 +30,7 @@ export function ensureHasCommit(
   }
 
   runGitOrThrow(
-    [
-      "commit",
-      "--allow-empty",
-      "-m",
-      INITIAL_COMMIT_MESSAGE,
-    ],
+    ["commit", "--allow-empty", "-m", INITIAL_COMMIT_MESSAGE],
     opts.repoPath,
   );
 
@@ -50,21 +45,15 @@ function hasHead(repoPath: string): boolean {
   return result.status === 0;
 }
 
-function runGitOrThrow(
-  args: readonly string[],
-  repoPath: string,
-): void {
+function runGitOrThrow(args: readonly string[], repoPath: string): void {
   const result = spawnSync("git", args as string[], {
     cwd: repoPath,
     encoding: "utf8",
     env: {
       ...process.env,
-      GIT_AUTHOR_NAME:
-        process.env["GIT_AUTHOR_NAME"] ?? "samospec",
-      GIT_AUTHOR_EMAIL:
-        process.env["GIT_AUTHOR_EMAIL"] ?? "samospec@localhost",
-      GIT_COMMITTER_NAME:
-        process.env["GIT_COMMITTER_NAME"] ?? "samospec",
+      GIT_AUTHOR_NAME: process.env["GIT_AUTHOR_NAME"] ?? "samospec",
+      GIT_AUTHOR_EMAIL: process.env["GIT_AUTHOR_EMAIL"] ?? "samospec@localhost",
+      GIT_COMMITTER_NAME: process.env["GIT_COMMITTER_NAME"] ?? "samospec",
       GIT_COMMITTER_EMAIL:
         process.env["GIT_COMMITTER_EMAIL"] ?? "samospec@localhost",
     },

--- a/tests/cli/new.test.ts
+++ b/tests/cli/new.test.ts
@@ -14,11 +14,14 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
@@ -300,6 +303,69 @@ describe("samospec new — slug collision (SPEC §10)", () => {
   });
 });
 
+// ---------- --force flag (issue #63) ----------
+
+describe("samospec new --force (issue #63)", () => {
+  test("force=true archives existing slug dir and exits 0", async () => {
+    const slugDir = path.join(tmp, ".samo", "spec", "demo");
+    mkdirSync(slugDir, { recursive: true });
+    // Sentinel file to confirm the old dir was archived.
+    writeFileSync(path.join(slugDir, "state.json"), '{"old":true}', "utf8");
+
+    const { adapter } = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([{ id: "q1", text: "framework?" }]),
+    ]);
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "force-test idea",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T12:00:00Z",
+        force: true,
+      },
+      adapter,
+    );
+
+    // Should succeed — not fail with "already exists".
+    expect(result.exitCode).toBe(0);
+
+    // New slug dir must exist with fresh state.
+    const newStatePath = path.join(slugDir, "state.json");
+    expect(existsSync(newStatePath)).toBe(true);
+    const stateRaw = readFileSync(newStatePath, "utf8");
+    const content = JSON.parse(stateRaw) as Record<string, unknown>;
+    expect(content).not.toHaveProperty("old");
+
+    // A bak dir matching the pattern must exist.
+    const specDir = path.join(tmp, ".samo", "spec");
+    const entries = readdirSync(specDir);
+    const bakDirs = entries.filter((e) => e.startsWith("demo.bak."));
+    expect(bakDirs.length).toBe(1);
+  });
+
+  test("force=false + existing dir => exit 1 (unchanged behaviour)", async () => {
+    mkdirSync(path.join(tmp, ".samo", "spec", "demo"), { recursive: true });
+    const { adapter } = makeLeadAdapter([personaJson("CLI engineer")]);
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-19T12:00:00Z",
+        force: false,
+      },
+      adapter,
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toLowerCase()).toMatch(/resume|already exists/);
+  });
+});
+
 // ---------- lock contention ----------
 
 describe("samospec new — repo lock (SPEC §7 lockfile)", () => {
@@ -382,5 +448,62 @@ describe("samospec new — branch creation guarded by flag (scope guard)", () =>
       adapter,
     );
     expect(invoked).toBe(1);
+  });
+});
+
+// ---------- empty-repo guard (Issue #65) ----------
+
+describe("samospec new — empty repo (no commits, Issue #65)", () => {
+  let repoDir: string;
+  let repoCleanup: () => void;
+
+  beforeEach(() => {
+    // Create a fresh git repo with NO commits on a non-protected branch.
+    repoDir = mkdtempSync(path.join(tmpdir(), "samospec-empty-repo-new-"));
+    const gitEnv = {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Samospec Test",
+      GIT_AUTHOR_EMAIL: "test@example.invalid",
+      GIT_COMMITTER_NAME: "Samospec Test",
+      GIT_COMMITTER_EMAIL: "test@example.invalid",
+    };
+    const gitRun = (args: string[]) =>
+      spawnSync("git", args, { cwd: repoDir, encoding: "utf8", env: gitEnv });
+    // Use a non-protected branch name so createSpecBranch doesn't refuse
+    // and the run can complete with exit 0.
+    gitRun(["init", "--initial-branch", "feature/project-setup", repoDir]);
+    gitRun(["config", "user.name", "Samospec Test"]);
+    gitRun(["config", "user.email", "test@example.invalid"]);
+    gitRun(["config", "commit.gpgsign", "false"]);
+    // Deliberately NO commit — HEAD is unresolvable.
+    runInit({ cwd: repoDir });
+    repoCleanup = () => rmSync(repoDir, { recursive: true, force: true });
+  });
+  afterEach(() => repoCleanup());
+
+  test("exits 0 and logs initial-commit notice on empty repo", async () => {
+    const { adapter } = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([{ id: "q1", text: "framework?" }]),
+    ]);
+    const result = await runNew(
+      {
+        cwd: repoDir,
+        slug: "emptydemo",
+        idea: "test empty repo fix",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-20T00:00:00Z",
+      },
+      adapter,
+    );
+
+    // Must not crash with a confusing HEAD error — exit 0 means success.
+    expect(result.exitCode).toBe(0);
+
+    // The notice "No commits found — created initial commit." must appear.
+    expect(result.stdout).toContain(
+      "No commits found — created initial commit.",
+    );
   });
 });

--- a/tests/git/ensure-has-commit.test.ts
+++ b/tests/git/ensure-has-commit.test.ts
@@ -1,0 +1,111 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { ensureHasCommit } from "../../src/git/ensure-has-commit.ts";
+
+// Helper: init a bare git repo with NO commits.
+function createEmptyRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-empty-repo-test-"));
+  const run = (args: string[]) =>
+    spawnSync("git", args, {
+      cwd: dir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "Samospec Test",
+        GIT_AUTHOR_EMAIL: "test@example.invalid",
+        GIT_COMMITTER_NAME: "Samospec Test",
+        GIT_COMMITTER_EMAIL: "test@example.invalid",
+      },
+    });
+
+  run(["init", "--initial-branch", "main", dir]);
+  run(["config", "user.name", "Samospec Test"]);
+  run(["config", "user.email", "test@example.invalid"]);
+  run(["config", "commit.gpgsign", "false"]);
+  // Deliberately no commit — repo has no HEAD.
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("ensureHasCommit — empty repo (no HEAD)", () => {
+  let dir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ({ dir, cleanup } = createEmptyRepo());
+  });
+  afterEach(() => cleanup());
+
+  test("returns { created: true } when repo has no commits", () => {
+    const result = ensureHasCommit({ repoPath: dir });
+    expect(result.created).toBe(true);
+  });
+
+  test("creates a commit so HEAD is now resolvable", () => {
+    ensureHasCommit({ repoPath: dir });
+    const rev = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: dir,
+      encoding: "utf8",
+    });
+    expect(rev.status).toBe(0);
+    expect(rev.stdout.trim()).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  test("commit message is the standard samospec message", () => {
+    ensureHasCommit({ repoPath: dir });
+    const log = spawnSync("git", ["log", "--format=%s", "-1"], {
+      cwd: dir,
+      encoding: "utf8",
+    });
+    expect(log.stdout.trim()).toBe(
+      "chore: initial commit (created by samospec)",
+    );
+  });
+});
+
+describe("ensureHasCommit — repo already has commits", () => {
+  let dir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    // Use createEmptyRepo then add a commit manually.
+    ({ dir, cleanup } = createEmptyRepo());
+    const run = (args: string[]) =>
+      spawnSync("git", args, {
+        cwd: dir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: "Samospec Test",
+          GIT_AUTHOR_EMAIL: "test@example.invalid",
+          GIT_COMMITTER_NAME: "Samospec Test",
+          GIT_COMMITTER_EMAIL: "test@example.invalid",
+        },
+      });
+    run(["commit", "--allow-empty", "-m", "chore: existing commit"]);
+  });
+  afterEach(() => cleanup());
+
+  test("returns { created: false } when repo already has commits", () => {
+    const result = ensureHasCommit({ repoPath: dir });
+    expect(result.created).toBe(false);
+  });
+
+  test("does not add a new commit when HEAD already exists", () => {
+    const before = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: dir,
+      encoding: "utf8",
+    }).stdout.trim();
+    ensureHasCommit({ repoPath: dir });
+    const after = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: dir,
+      encoding: "utf8",
+    }).stdout.trim();
+    expect(after).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #63: `samospec new my-spec --force` had no effect — the flag was parsed but the slug-collision guard returned exit 1 regardless.

- **`src/cli/new.ts`**: Added `force?: boolean` to `RunNewInput`. When `force` is true and the slug directory already exists, it is renamed to `.samo/spec/<slug>.bak.<timestamp>/` before the fresh run proceeds. Also wired `ensureHasCommit` (issue #65) so empty git repos get an initial commit before HEAD-dependent branch operations.
- **`src/cli.ts`**: Parses `--force` in `parseNewArgs`, threads it through `runNewCommand` → `runNew`, and updates the `USAGE` help text.
- **`src/git/ensure-has-commit.ts`**: New helper — creates an empty initial commit when `HEAD` is not yet resolvable (empty repo guard, issue #65).
- **`tests/cli/new.test.ts`**: Added two `--force` tests (RED → GREEN TDD):
  - `force=true` archives the existing dir and exits 0
  - `force=false` + existing dir still exits 1 (unchanged behaviour)
  - Also adds the empty-repo guard test.
- **`tests/git/ensure-has-commit.test.ts`**: Unit tests for the new helper.

## Test evidence

Before (RED):
```
(fail) samospec new --force (issue #63) > force=true archives existing slug dir and exits 0
Expected: 0, Received: 1
```

After (GREEN):
```
bun test tests/cli/new.test.ts
 13 pass
 0 fail
Ran 13 tests across 1 file.
```

Full cli + git test suite:
```
bun test tests/cli/ tests/git/
 526 pass
 0 fail
Ran 526 tests across 37 files.
```

## Test plan

- [ ] CI green on all checks
- [ ] `samospec new <slug>` on a fresh repo: no change to existing behaviour
- [ ] `samospec new <slug>` when slug dir exists, no `--force`: exits 1 with helpful message
- [ ] `samospec new <slug> --force` when slug dir exists: archives old dir, creates fresh run

🤖 Generated with [Claude Code](https://claude.com/claude-code)