### PR TITLE
fix: #64 reviewer-failure convergence guard + #70 codex OAuth preflight label

### DIFF
--- a/src/loop/stopping.ts
+++ b/src/loop/stopping.ts
@@ -8,15 +8,17 @@
  *
  * Conditions (priority order in classifyAllStops):
  *   1. Max rounds reached (budget.max_iterations default 10).
- *   2. Lead ready=true (structured signal).
- *   3. Semantic convergence: two consecutive low-delta rounds with
+ *   2. Reviewer availability zero (both seats exhausted + user decline).
+ *      Checked BEFORE ready/convergence (#64): when no reviewer produced
+ *      output, the lead's ready signal must be suppressed.
+ *   3. Lead ready=true (structured signal).
+ *   4. Semantic convergence: two consecutive low-delta rounds with
  *      diff ≤ convergence.min_delta_lines (default 20) AND no new
  *      findings in non-summary categories for either round.
- *   4. Repeat-findings halt: ≥5 findings AND ≥80% of findings have a
+ *   5. Repeat-findings halt: ≥5 findings AND ≥80% of findings have a
  *      trigram-Jaccard (normalized, same-category) match against the
  *      prior round ≥ 0.8 — reason "lead-ignoring-critiques".
- *   5. User SIGINT.
- *   6. Reviewer availability zero (both seats exhausted + user decline).
+ *   6. User SIGINT.
  *   7. Budget hit (tokens / cost / wall-clock).
  *   8. lead_terminal state reachable from any round.
  *
@@ -271,7 +273,21 @@ export function classifyAllStops(
       convergence: conv,
     };
   }
-  // 2. Ready.
+  // 2. Reviewer availability zero — checked BEFORE ready / semantic-
+  //    convergence (#64). When all reviewers failed, a spec has received
+  //    zero review input; allowing ready=true or convergence to fire would
+  //    produce a silently un-reviewed output. Surface the availability
+  //    problem immediately so the caller can prompt the user.
+  if (input.reviewerAvailability <= 0) {
+    return {
+      stop: true,
+      reason: "reviewers-exhausted",
+      suggestDownshift: conv.suggestDownshift,
+      repeatFindings: repeat,
+      convergence: conv,
+    };
+  }
+  // 3. Ready.
   if (input.leadReady) {
     return {
       stop: true,
@@ -281,7 +297,7 @@ export function classifyAllStops(
       convergence: conv,
     };
   }
-  // 3. Semantic convergence.
+  // 4. Semantic convergence.
   if (conv.converged) {
     return {
       stop: true,
@@ -291,7 +307,7 @@ export function classifyAllStops(
       convergence: conv,
     };
   }
-  // 4. Repeat-findings halt.
+  // 5. Repeat-findings halt.
   if (repeat.halt) {
     return {
       stop: true,
@@ -301,21 +317,11 @@ export function classifyAllStops(
       convergence: conv,
     };
   }
-  // 5. SIGINT.
+  // 6. SIGINT.
   if (input.sigintReceived) {
     return {
       stop: true,
       reason: "sigint",
-      suggestDownshift: conv.suggestDownshift,
-      repeatFindings: repeat,
-      convergence: conv,
-    };
-  }
-  // 6. Reviewer availability zero.
-  if (input.reviewerAvailability <= 0) {
-    return {
-      stop: true,
-      reason: "reviewers-exhausted",
       suggestDownshift: conv.suggestDownshift,
       repeatFindings: repeat,
       convergence: conv,

--- a/tests/adapter/codex-chatgpt-auth-detection.test.ts
+++ b/tests/adapter/codex-chatgpt-auth-detection.test.ts
@@ -9,12 +9,7 @@
 // when the binary is present but OPENAI_API_KEY is unset.
 
 import { afterAll, describe, expect, test } from "bun:test";
-import {
-  chmodSync,
-  mkdtempSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -47,77 +42,62 @@ afterAll(() => {
 
 // ---------- tests ----------
 
-describe(
-  "#70 — CodexAdapter.auth_status(): ChatGPT OAuth (no OPENAI_API_KEY)",
-  () => {
-    test(
-      "no OPENAI_API_KEY + binary installed → subscription_auth: true",
-      async () => {
-        const { dir } = makeFakeBinaryDir("codex");
-        // Host env without OPENAI_API_KEY — simulates ChatGPT OAuth mode.
-        const host: Record<string, string | undefined> = {
-          PATH: dir,
-          HOME: "/tmp",
-          // OPENAI_API_KEY deliberately absent.
-        };
-        const adapter = new CodexAdapter({ host });
-        const status = await adapter.auth_status();
+describe("#70 — CodexAdapter.auth_status(): ChatGPT OAuth (no OPENAI_API_KEY)", () => {
+  test("no OPENAI_API_KEY + binary installed → subscription_auth: true", async () => {
+    const { dir } = makeFakeBinaryDir("codex");
+    // Host env without OPENAI_API_KEY — simulates ChatGPT OAuth mode.
+    const host: Record<string, string | undefined> = {
+      PATH: dir,
+      HOME: "/tmp",
+      // OPENAI_API_KEY deliberately absent.
+    };
+    const adapter = new CodexAdapter({ host });
+    const status = await adapter.auth_status();
 
-        expect(status.authenticated).toBe(true);
-        // KEY assertion: must be true when no API key is set.
-        expect(status.subscription_auth).toBe(true);
-      },
-    );
+    expect(status.authenticated).toBe(true);
+    // KEY assertion: must be true when no API key is set.
+    expect(status.subscription_auth).toBe(true);
+  });
 
-    test(
-      "OPENAI_API_KEY set + binary installed → subscription_auth: false",
-      async () => {
-        const { dir } = makeFakeBinaryDir("codex");
-        const host: Record<string, string | undefined> = {
-          PATH: dir,
-          HOME: "/tmp",
-          OPENAI_API_KEY: "sk-test-not-a-real-key",
-        };
-        const adapter = new CodexAdapter({ host });
-        const status = await adapter.auth_status();
+  test("OPENAI_API_KEY set + binary installed → subscription_auth: false", async () => {
+    const { dir } = makeFakeBinaryDir("codex");
+    const host: Record<string, string | undefined> = {
+      PATH: dir,
+      HOME: "/tmp",
+      OPENAI_API_KEY: "sk-test-not-a-real-key",
+    };
+    const adapter = new CodexAdapter({ host });
+    const status = await adapter.auth_status();
 
-        expect(status.authenticated).toBe(true);
-        // With API key set, subscription_auth must be false.
-        expect(status.subscription_auth).toBe(false);
-      },
-    );
+    expect(status.authenticated).toBe(true);
+    // With API key set, subscription_auth must be false.
+    expect(status.subscription_auth).toBe(false);
+  });
 
-    test(
-      "OPENAI_API_KEY empty string + binary installed → subscription_auth: true",
-      async () => {
-        const { dir } = makeFakeBinaryDir("codex");
-        const host: Record<string, string | undefined> = {
-          PATH: dir,
-          HOME: "/tmp",
-          OPENAI_API_KEY: "",
-        };
-        const adapter = new CodexAdapter({ host });
-        const status = await adapter.auth_status();
+  test("OPENAI_API_KEY empty string + binary installed → subscription_auth: true", async () => {
+    const { dir } = makeFakeBinaryDir("codex");
+    const host: Record<string, string | undefined> = {
+      PATH: dir,
+      HOME: "/tmp",
+      OPENAI_API_KEY: "",
+    };
+    const adapter = new CodexAdapter({ host });
+    const status = await adapter.auth_status();
 
-        expect(status.authenticated).toBe(true);
-        // Empty string is not a valid API key — treated as absent.
-        expect(status.subscription_auth).toBe(true);
-      },
-    );
+    expect(status.authenticated).toBe(true);
+    // Empty string is not a valid API key — treated as absent.
+    expect(status.subscription_auth).toBe(true);
+  });
 
-    test(
-      "binary not installed → authenticated: false, subscription_auth absent/false",
-      async () => {
-        const host: Record<string, string | undefined> = {
-          PATH: "/no/such/path",
-          HOME: "/tmp",
-        };
-        const adapter = new CodexAdapter({ host });
-        const status = await adapter.auth_status();
+  test("binary not installed → authenticated: false, subscription_auth absent/false", async () => {
+    const host: Record<string, string | undefined> = {
+      PATH: "/no/such/path",
+      HOME: "/tmp",
+    };
+    const adapter = new CodexAdapter({ host });
+    const status = await adapter.auth_status();
 
-        expect(status.authenticated).toBe(false);
-        expect(status.subscription_auth).toBeFalsy();
-      },
-    );
-  },
-);
+    expect(status.authenticated).toBe(false);
+    expect(status.subscription_auth).toBeFalsy();
+  });
+});

--- a/tests/adapter/codex-chatgpt-auth-detection.test.ts
+++ b/tests/adapter/codex-chatgpt-auth-detection.test.ts
@@ -1,0 +1,123 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED tests for Issue #70: Codex adapter auth_status() must return
+// subscription_auth: true when OPENAI_API_KEY is absent (ChatGPT OAuth).
+//
+// The bug: under ChatGPT OAuth (no OPENAI_API_KEY), reviewer_a was shown
+// with a dollar estimate in preflight instead of "unknown — OAuth".
+// Root cause: auth_status() was not reliably returning subscription_auth
+// when the binary is present but OPENAI_API_KEY is unset.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { CodexAdapter } from "../../src/adapter/codex.ts";
+
+const TMP: string[] = [];
+
+function makeFakeBinaryDir(name: string): {
+  dir: string;
+  binary: string;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-codex70-bin-"));
+  TMP.push(dir);
+  const binary = join(dir, name);
+  // Script that echoes a version string (used by probeVersion).
+  writeFileSync(binary, `#!/usr/bin/env bash\necho "0.99.0"\n`);
+  chmodSync(binary, 0o755);
+  return { dir, binary };
+}
+
+afterAll(() => {
+  for (const d of TMP) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+});
+
+// ---------- tests ----------
+
+describe(
+  "#70 — CodexAdapter.auth_status(): ChatGPT OAuth (no OPENAI_API_KEY)",
+  () => {
+    test(
+      "no OPENAI_API_KEY + binary installed → subscription_auth: true",
+      async () => {
+        const { dir } = makeFakeBinaryDir("codex");
+        // Host env without OPENAI_API_KEY — simulates ChatGPT OAuth mode.
+        const host: Record<string, string | undefined> = {
+          PATH: dir,
+          HOME: "/tmp",
+          // OPENAI_API_KEY deliberately absent.
+        };
+        const adapter = new CodexAdapter({ host });
+        const status = await adapter.auth_status();
+
+        expect(status.authenticated).toBe(true);
+        // KEY assertion: must be true when no API key is set.
+        expect(status.subscription_auth).toBe(true);
+      },
+    );
+
+    test(
+      "OPENAI_API_KEY set + binary installed → subscription_auth: false",
+      async () => {
+        const { dir } = makeFakeBinaryDir("codex");
+        const host: Record<string, string | undefined> = {
+          PATH: dir,
+          HOME: "/tmp",
+          OPENAI_API_KEY: "sk-test-not-a-real-key",
+        };
+        const adapter = new CodexAdapter({ host });
+        const status = await adapter.auth_status();
+
+        expect(status.authenticated).toBe(true);
+        // With API key set, subscription_auth must be false.
+        expect(status.subscription_auth).toBe(false);
+      },
+    );
+
+    test(
+      "OPENAI_API_KEY empty string + binary installed → subscription_auth: true",
+      async () => {
+        const { dir } = makeFakeBinaryDir("codex");
+        const host: Record<string, string | undefined> = {
+          PATH: dir,
+          HOME: "/tmp",
+          OPENAI_API_KEY: "",
+        };
+        const adapter = new CodexAdapter({ host });
+        const status = await adapter.auth_status();
+
+        expect(status.authenticated).toBe(true);
+        // Empty string is not a valid API key — treated as absent.
+        expect(status.subscription_auth).toBe(true);
+      },
+    );
+
+    test(
+      "binary not installed → authenticated: false, subscription_auth absent/false",
+      async () => {
+        const host: Record<string, string | undefined> = {
+          PATH: "/no/such/path",
+          HOME: "/tmp",
+        };
+        const adapter = new CodexAdapter({ host });
+        const status = await adapter.auth_status();
+
+        expect(status.authenticated).toBe(false);
+        expect(status.subscription_auth).toBeFalsy();
+      },
+    );
+  },
+);

--- a/tests/loop/reviewer-failure-convergence.test.ts
+++ b/tests/loop/reviewer-failure-convergence.test.ts
@@ -1,0 +1,266 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED tests for Issue #64: reviewer failures silently allow premature
+// convergence. When both reviewers fail, the lead must NOT be allowed to
+// declare ready=true — the round should be marked as a failure and the
+// ready signal ignored.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type { CritiqueOutput } from "../../src/adapter/types.ts";
+import type { Adapter, ReviseInput, ReviseOutput } from "../../src/adapter/types.ts";
+import {
+  roundDirsFor,
+  runRound,
+} from "../../src/loop/round.ts";
+import type { StopReason } from "../../src/loop/stopping.ts";
+import { classifyAllStops } from "../../src/loop/stopping.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-conv64-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+// ---------- fixtures ----------
+
+const SAMPLE_CRITIQUE: CritiqueOutput = {
+  findings: [
+    { category: "ambiguity", text: "vague clause", severity: "minor" },
+  ],
+  summary: "one finding",
+  suggested_next_version: "0.2",
+  usage: null,
+  effort_used: "max",
+};
+
+const READY_TRUE_REVISE: ReviseOutput = {
+  spec: "# SPEC\n\nready output",
+  ready: true,
+  rationale: "all good",
+  usage: null,
+  effort_used: "max",
+};
+
+const NOT_READY_REVISE: ReviseOutput = {
+  spec: "# SPEC\n\nstill working",
+  ready: false,
+  rationale: "more work needed",
+  usage: null,
+  effort_used: "max",
+};
+
+/** Create an adapter whose critique() always rejects with the given error. */
+function makeFailingReviewer(msg: string): Adapter {
+  const base = createFakeAdapter();
+  return {
+    ...base,
+    critique: () => Promise.reject(new Error(msg)),
+  };
+}
+
+// ---------- tests: both reviewers fail ----------
+
+describe("#64 — both reviewers fail: ready=true MUST be ignored", () => {
+  test(
+    "when both reviewers fail and lead would return ready=true, " +
+      "outcome.ready is false and roundStopReason is not 'ok'",
+    async () => {
+      // The lead would declare ready=true if called with valid reviews,
+      // but with no valid reviewer output this round, it must be blocked.
+      const lead = createFakeAdapter({ revise: READY_TRUE_REVISE });
+      const revA = makeFailingReviewer("Codex adapter timeout");
+      const revB = makeFailingReviewer('unknown — [{ "code": "invalid_value"');
+
+      const dirs = roundDirsFor(tmp, 1);
+      const outcome = await runRound({
+        now: "2026-04-19T12:00:00Z",
+        roundNumber: 1,
+        dirs,
+        specText: "# SPEC\n\nv0.1",
+        decisionsHistory: [],
+        adapters: { lead, reviewerA: revA, reviewerB: revB },
+      });
+
+      // The bug: before the fix, outcome.ready would be true.
+      // After the fix: round must NOT converge on an all-reviewer-fail.
+      expect(outcome.ready).toBe(false);
+      // The round stop reason must reflect failure, not success.
+      expect(outcome.roundStopReason).not.toBe("ok");
+    },
+  );
+
+  test(
+    "when both reviewers fail, reviewersExhausted is true",
+    async () => {
+      const lead = createFakeAdapter({ revise: READY_TRUE_REVISE });
+      const revA = makeFailingReviewer("timeout: codex timed out");
+      const revB = makeFailingReviewer("auth failed");
+
+      const dirs = roundDirsFor(tmp, 1);
+      const outcome = await runRound({
+        now: "2026-04-19T12:00:00Z",
+        roundNumber: 1,
+        dirs,
+        specText: "# SPEC\n\nv0.1",
+        decisionsHistory: [],
+        adapters: { lead, reviewerA: revA, reviewerB: revB },
+      });
+
+      expect(outcome.reviewersExhausted).toBe(true);
+      expect(outcome.seats.reviewer_a.state).not.toBe("ok");
+      expect(outcome.seats.reviewer_b.state).not.toBe("ok");
+    },
+  );
+});
+
+// ---------- tests: partial failure (one reviewer ok) ----------
+
+describe("#64 — partial reviewer failure: ready=true IS accepted", () => {
+  test(
+    "when reviewer_a fails but reviewer_b succeeds, " +
+      "lead's ready=true is accepted",
+    async () => {
+      const lead = createFakeAdapter({ revise: READY_TRUE_REVISE });
+      const revA = makeFailingReviewer("Codex adapter timeout");
+      const revB = createFakeAdapter({ critique: SAMPLE_CRITIQUE });
+
+      const dirs = roundDirsFor(tmp, 1);
+      const outcome = await runRound({
+        now: "2026-04-19T12:00:00Z",
+        roundNumber: 1,
+        dirs,
+        specText: "# SPEC\n\nv0.1",
+        decisionsHistory: [],
+        adapters: { lead, reviewerA: revA, reviewerB: revB },
+      });
+
+      // Partial review is valid: ready=true should be accepted.
+      expect(outcome.ready).toBe(true);
+      expect(outcome.roundStopReason).toBe("ok");
+    },
+  );
+
+  test(
+    "when reviewer_b fails but reviewer_a succeeds, " +
+      "lead's ready=true is accepted",
+    async () => {
+      const lead = createFakeAdapter({ revise: READY_TRUE_REVISE });
+      const revA = createFakeAdapter({ critique: SAMPLE_CRITIQUE });
+      const revB = makeFailingReviewer("claude auth_failed");
+
+      const dirs = roundDirsFor(tmp, 1);
+      const outcome = await runRound({
+        now: "2026-04-19T12:00:00Z",
+        roundNumber: 1,
+        dirs,
+        specText: "# SPEC\n\nv0.1",
+        decisionsHistory: [],
+        adapters: { lead, reviewerA: revA, reviewerB: revB },
+      });
+
+      expect(outcome.ready).toBe(true);
+      expect(outcome.roundStopReason).toBe("ok");
+    },
+  );
+});
+
+// ---------- tests: all-reviewer-fail stopping condition ----------
+
+describe(
+  "#64 — all-reviewer-fail stopping condition " +
+    "(classifyAllStops with reviewerAvailability=0)",
+  () => {
+    const baseSignals = {
+      findings: [],
+      diffLines: 5,
+      nonSummaryCategoriesWithFindings: 0,
+    };
+
+    test(
+      "classifyAllStops with reviewerAvailability=0 stops with " +
+        "'reviewers-exhausted', NOT 'ready' or 'semantic-convergence'",
+      () => {
+        const result = classifyAllStops({
+          currentRoundIndex: 2,
+          maxRounds: 10,
+          // Lead would declare ready=true, but reviewers are exhausted.
+          leadReady: true,
+          previous: baseSignals,
+          current: baseSignals,
+          reviewerAvailability: 0,
+          budgetOk: true,
+          wallClockOk: true,
+          leadTerminal: false,
+          sigintReceived: false,
+        });
+
+        // Bug: before fix, "ready" would fire at condition #2 before
+        // reviewerAvailability check at condition #6. After fix, when
+        // all reviewers failed, "ready" should NOT be a valid stop cause.
+        expect(result.stop).toBe(true);
+        expect(result.reason).not.toBe("ready");
+        expect(result.reason).not.toBe("semantic-convergence");
+        // Should stop for the reviewer-exhausted reason instead.
+        expect(result.reason).toBe("reviewers-exhausted");
+      },
+    );
+
+    test(
+      "when all reviewers fail across max rounds (max-rounds stop), " +
+        "the stop reason is 'max-rounds', not 'ready'",
+      () => {
+        const result = classifyAllStops({
+          currentRoundIndex: 10,
+          maxRounds: 10,
+          leadReady: true,
+          previous: baseSignals,
+          current: baseSignals,
+          reviewerAvailability: 0,
+          budgetOk: true,
+          wallClockOk: true,
+          leadTerminal: false,
+          sigintReceived: false,
+        });
+
+        expect(result.stop).toBe(true);
+        // max-rounds fires first (condition #1) — that's fine.
+        // The key is that the stop reason is not 'ready'.
+        expect(result.reason).not.toBe("ready");
+      },
+    );
+
+    test(
+      "runRound with both reviewers failing across retry returns " +
+        "roundStopReason='both_seats_failed_even_after_retry'",
+      async () => {
+        const lead = createFakeAdapter({ revise: NOT_READY_REVISE });
+        const revA = makeFailingReviewer("timeout every time");
+        const revB = makeFailingReviewer("timeout every time");
+
+        const dirs = roundDirsFor(tmp, 2);
+        const outcome = await runRound({
+          now: "2026-04-19T12:00:00Z",
+          roundNumber: 2,
+          dirs,
+          specText: "# SPEC\n\nv0.2",
+          decisionsHistory: [],
+          adapters: { lead, reviewerA: revA, reviewerB: revB },
+        });
+
+        expect(outcome.roundStopReason).toBe(
+          "both_seats_failed_even_after_retry",
+        );
+        expect(outcome.ready).toBe(false);
+      },
+    );
+  },
+);

--- a/tests/loop/reviewer-failure-convergence.test.ts
+++ b/tests/loop/reviewer-failure-convergence.test.ts
@@ -11,13 +11,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
-import type { CritiqueOutput } from "../../src/adapter/types.ts";
-import type { Adapter, ReviseInput, ReviseOutput } from "../../src/adapter/types.ts";
-import {
-  roundDirsFor,
-  runRound,
-} from "../../src/loop/round.ts";
-import type { StopReason } from "../../src/loop/stopping.ts";
+import type {
+  Adapter,
+  CritiqueOutput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { roundDirsFor, runRound } from "../../src/loop/round.ts";
 import { classifyAllStops } from "../../src/loop/stopping.ts";
 
 let tmp: string;
@@ -98,28 +97,25 @@ describe("#64 — both reviewers fail: ready=true MUST be ignored", () => {
     },
   );
 
-  test(
-    "when both reviewers fail, reviewersExhausted is true",
-    async () => {
-      const lead = createFakeAdapter({ revise: READY_TRUE_REVISE });
-      const revA = makeFailingReviewer("timeout: codex timed out");
-      const revB = makeFailingReviewer("auth failed");
+  test("when both reviewers fail, reviewersExhausted is true", async () => {
+    const lead = createFakeAdapter({ revise: READY_TRUE_REVISE });
+    const revA = makeFailingReviewer("timeout: codex timed out");
+    const revB = makeFailingReviewer("auth failed");
 
-      const dirs = roundDirsFor(tmp, 1);
-      const outcome = await runRound({
-        now: "2026-04-19T12:00:00Z",
-        roundNumber: 1,
-        dirs,
-        specText: "# SPEC\n\nv0.1",
-        decisionsHistory: [],
-        adapters: { lead, reviewerA: revA, reviewerB: revB },
-      });
+    const dirs = roundDirsFor(tmp, 1);
+    const outcome = await runRound({
+      now: "2026-04-19T12:00:00Z",
+      roundNumber: 1,
+      dirs,
+      specText: "# SPEC\n\nv0.1",
+      decisionsHistory: [],
+      adapters: { lead, reviewerA: revA, reviewerB: revB },
+    });
 
-      expect(outcome.reviewersExhausted).toBe(true);
-      expect(outcome.seats.reviewer_a.state).not.toBe("ok");
-      expect(outcome.seats.reviewer_b.state).not.toBe("ok");
-    },
-  );
+    expect(outcome.reviewersExhausted).toBe(true);
+    expect(outcome.seats.reviewer_a.state).not.toBe("ok");
+    expect(outcome.seats.reviewer_b.state).not.toBe("ok");
+  });
 });
 
 // ---------- tests: partial failure (one reviewer ok) ----------

--- a/tests/policy/preflight-codex-oauth.test.ts
+++ b/tests/policy/preflight-codex-oauth.test.ts
@@ -46,119 +46,111 @@ function mkAdapter(
 // OAuth, reviewer_b uses Claude API key.
 const LEAD_OAUTH = mkAdapter("lead", "claude", true, "lead");
 const REVA_CODEX_OAUTH = mkAdapter("reviewer_a", "codex", true, "reviewer_a");
-const REVB_CLAUDE_APIKEY = mkAdapter("reviewer_b", "claude", false, "reviewer_b");
+const REVB_CLAUDE_APIKEY = mkAdapter(
+  "reviewer_b",
+  "claude",
+  false,
+  "reviewer_b",
+);
 
 // Baseline: all API-key adapters (no OAuth anywhere).
 const LEAD_APIKEY = mkAdapter("lead", "claude", false, "lead");
 const REVA_APIKEY = mkAdapter("reviewer_a", "codex", false, "reviewer_a");
 const REVB_APIKEY = mkAdapter("reviewer_b", "claude", false, "reviewer_b");
 
-describe(
-  "#70 — preflight: reviewer_a Codex under ChatGPT OAuth → OAuth label",
-  () => {
-    test(
-      "reviewer_a with subscription_auth: true shows " +
-        "'unknown — OAuth (no per-token cost visibility)'",
-      () => {
-        const cfg = mkConfig();
-        const r = computePreflight(cfg, [
-          LEAD_OAUTH,
-          REVA_CODEX_OAUTH,
-          REVB_CLAUDE_APIKEY,
-        ]);
-        const perA = r.perAdapter["reviewer_a"];
-        expect(perA).toBeDefined();
-        expect(perA?.usd).toBe(
-          "unknown — OAuth (no per-token cost visibility)",
-        );
-      },
-    );
-
-    test("reviewer_a OAuth: likelyUsd excludes reviewer_a cost", () => {
-      const cfgAll = mkConfig();
-      // Baseline: all API keys → likelyUsd includes reviewer_a.
-      const rAll = computePreflight(cfgAll, [
-        LEAD_APIKEY,
-        REVA_APIKEY,
-        REVB_APIKEY,
-      ]);
-      // OAuth scenario: reviewer_a excluded from likelyUsd.
-      const rOAuth = computePreflight(mkConfig(), [
-        LEAD_APIKEY,
-        REVA_CODEX_OAUTH,
-        REVB_APIKEY,
-      ]);
-      // With OAuth reviewer_a, the likelyUsd should be less than all-API-key.
-      expect(rOAuth.likelyUsd).toBeLessThan(rAll.likelyUsd);
-    });
-
-    test(
-      "pretty-printer for OAuth reviewer_a says 'OAuth' (not dollar amount)",
-      () => {
-        const cfg = mkConfig();
-        const r = computePreflight(cfg, [
-          LEAD_OAUTH,
-          REVA_CODEX_OAUTH,
-          REVB_CLAUDE_APIKEY,
-        ]);
-        const text = formatPreflight(r);
-
-        // Must contain OAuth label in per-adapter section.
-        expect(text).toContain("OAuth");
-        // Must NOT show a dollar amount for reviewer_a when OAuth.
-        // The dollar-sign should appear only in the summary line, not per-adapter.
-        const perAdapterSection = text
-          .split("per-adapter:")[1]
-          ?.split("warnings:")[0];
-        expect(perAdapterSection).toBeDefined();
-        // The per-adapter section for reviewer_a must say "OAuth", not "$N.NN".
-        const reviewerALine = perAdapterSection
-          ?.split("\n")
-          .find((l) => l.includes("reviewer_a"));
-        expect(reviewerALine).toBeDefined();
-        expect(reviewerALine).toContain("OAuth");
-        expect(reviewerALine).not.toMatch(/\$\d+\.\d+/);
-      },
-    );
-
-    test("warnings include mention of OAuth when reviewer_a is OAuth", () => {
-      const cfg = mkConfig();
-      const r = computePreflight(cfg, [
-        LEAD_APIKEY,
-        REVA_CODEX_OAUTH,
-        REVB_APIKEY,
-      ]);
-      const hasOAuthWarn = r.warnings.some((w) => /oauth/i.test(w));
-      expect(hasOAuthWarn).toBe(true);
-    });
-
-    test("full OAuth scenario (all three adapters): likelyUsd is 0", () => {
-      const cfg = mkConfig();
-      const allOAuth = [
-        mkAdapter("lead", "claude", true, "lead"),
-        mkAdapter("reviewer_a", "codex", true, "reviewer_a"),
-        mkAdapter("reviewer_b", "claude", true, "reviewer_b"),
-      ];
-      const r = computePreflight(cfg, allOAuth);
-      expect(r.likelyUsd).toBe(0);
-      for (const [, entry] of Object.entries(r.perAdapter)) {
-        expect(entry.usd).toBe(
-          "unknown — OAuth (no per-token cost visibility)",
-        );
-      }
-    });
-  },
-);
-
-describe("#70 — preflight: API-key reviewer_a unchanged", () => {
+describe("#70 — preflight: reviewer_a Codex under ChatGPT OAuth → OAuth label", () => {
   test(
-    "reviewer_a with subscription_auth: false shows dollar estimate",
+    "reviewer_a with subscription_auth: true shows " +
+      "'unknown — OAuth (no per-token cost visibility)'",
     () => {
       const cfg = mkConfig();
-      const r = computePreflight(cfg, [LEAD_APIKEY, REVA_APIKEY, REVB_APIKEY]);
+      const r = computePreflight(cfg, [
+        LEAD_OAUTH,
+        REVA_CODEX_OAUTH,
+        REVB_CLAUDE_APIKEY,
+      ]);
       const perA = r.perAdapter["reviewer_a"];
       expect(perA).toBeDefined();
-      expect(typeof perA?.usd).toBe("number");
+      expect(perA?.usd).toBe("unknown — OAuth (no per-token cost visibility)");
     },
   );
+
+  test("reviewer_a OAuth: likelyUsd excludes reviewer_a cost", () => {
+    const cfgAll = mkConfig();
+    // Baseline: all API keys → likelyUsd includes reviewer_a.
+    const rAll = computePreflight(cfgAll, [
+      LEAD_APIKEY,
+      REVA_APIKEY,
+      REVB_APIKEY,
+    ]);
+    // OAuth scenario: reviewer_a excluded from likelyUsd.
+    const rOAuth = computePreflight(mkConfig(), [
+      LEAD_APIKEY,
+      REVA_CODEX_OAUTH,
+      REVB_APIKEY,
+    ]);
+    // With OAuth reviewer_a, the likelyUsd should be less than all-API-key.
+    expect(rOAuth.likelyUsd).toBeLessThan(rAll.likelyUsd);
+  });
+
+  test("pretty-printer for OAuth reviewer_a says 'OAuth' (not dollar amount)", () => {
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, [
+      LEAD_OAUTH,
+      REVA_CODEX_OAUTH,
+      REVB_CLAUDE_APIKEY,
+    ]);
+    const text = formatPreflight(r);
+
+    // Must contain OAuth label in per-adapter section.
+    expect(text).toContain("OAuth");
+    // Must NOT show a dollar amount for reviewer_a when OAuth.
+    // The dollar-sign should appear only in the summary line, not per-adapter.
+    const perAdapterSection = text
+      .split("per-adapter:")[1]
+      ?.split("warnings:")[0];
+    expect(perAdapterSection).toBeDefined();
+    // The per-adapter section for reviewer_a must say "OAuth", not "$N.NN".
+    const reviewerALine = perAdapterSection
+      ?.split("\n")
+      .find((l) => l.includes("reviewer_a"));
+    expect(reviewerALine).toBeDefined();
+    expect(reviewerALine).toContain("OAuth");
+    expect(reviewerALine).not.toMatch(/\$\d+\.\d+/);
+  });
+
+  test("warnings include mention of OAuth when reviewer_a is OAuth", () => {
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, [
+      LEAD_APIKEY,
+      REVA_CODEX_OAUTH,
+      REVB_APIKEY,
+    ]);
+    const hasOAuthWarn = r.warnings.some((w) => /oauth/i.test(w));
+    expect(hasOAuthWarn).toBe(true);
+  });
+
+  test("full OAuth scenario (all three adapters): likelyUsd is 0", () => {
+    const cfg = mkConfig();
+    const allOAuth = [
+      mkAdapter("lead", "claude", true, "lead"),
+      mkAdapter("reviewer_a", "codex", true, "reviewer_a"),
+      mkAdapter("reviewer_b", "claude", true, "reviewer_b"),
+    ];
+    const r = computePreflight(cfg, allOAuth);
+    expect(r.likelyUsd).toBe(0);
+    for (const [, entry] of Object.entries(r.perAdapter)) {
+      expect(entry.usd).toBe("unknown — OAuth (no per-token cost visibility)");
+    }
+  });
+});
+
+describe("#70 — preflight: API-key reviewer_a unchanged", () => {
+  test("reviewer_a with subscription_auth: false shows dollar estimate", () => {
+    const cfg = mkConfig();
+    const r = computePreflight(cfg, [LEAD_APIKEY, REVA_APIKEY, REVB_APIKEY]);
+    const perA = r.perAdapter["reviewer_a"];
+    expect(perA).toBeDefined();
+    expect(typeof perA?.usd).toBe("number");
+  });
 });

--- a/tests/policy/preflight-codex-oauth.test.ts
+++ b/tests/policy/preflight-codex-oauth.test.ts
@@ -1,0 +1,164 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED tests for Issue #70: preflight must show "unknown — OAuth" for
+// Codex reviewer_a when running under ChatGPT OAuth (subscription_auth:
+// true), NOT a dollar estimate.
+//
+// The bug (UX report #62 item 6):
+//   reviewer_a: ~75K tokens, $1.88    ← WRONG (should be OAuth label)
+//
+// Fix: when reviewer_a's auth_status returns subscription_auth: true,
+// computePreflight must treat it the same as lead/reviewer_b under OAuth.
+
+import { describe, expect, test } from "bun:test";
+
+import { DEFAULT_CONFIG } from "../../src/cli/init.ts";
+import {
+  computePreflight,
+  formatPreflight,
+  type PreflightAdapter,
+  type PreflightConfig,
+} from "../../src/policy/preflight.ts";
+
+function mkConfig(): PreflightConfig {
+  return {
+    adapters: {
+      lead: { ...DEFAULT_CONFIG.adapters.lead },
+      reviewer_a: { ...DEFAULT_CONFIG.adapters.reviewer_a },
+      reviewer_b: { ...DEFAULT_CONFIG.adapters.reviewer_b },
+    },
+    budget: { ...DEFAULT_CONFIG.budget },
+    calibration: null,
+  };
+}
+
+function mkAdapter(
+  id: string,
+  vendor: string,
+  subscription_auth: boolean,
+  role: "lead" | "reviewer_a" | "reviewer_b",
+): PreflightAdapter {
+  return { id, vendor, role, subscription_auth };
+}
+
+// Canonical adapters for a ChatGPT-OAuth scenario:
+// lead uses Claude subscription (OAuth), reviewer_a uses Codex ChatGPT-
+// OAuth, reviewer_b uses Claude API key.
+const LEAD_OAUTH = mkAdapter("lead", "claude", true, "lead");
+const REVA_CODEX_OAUTH = mkAdapter("reviewer_a", "codex", true, "reviewer_a");
+const REVB_CLAUDE_APIKEY = mkAdapter("reviewer_b", "claude", false, "reviewer_b");
+
+// Baseline: all API-key adapters (no OAuth anywhere).
+const LEAD_APIKEY = mkAdapter("lead", "claude", false, "lead");
+const REVA_APIKEY = mkAdapter("reviewer_a", "codex", false, "reviewer_a");
+const REVB_APIKEY = mkAdapter("reviewer_b", "claude", false, "reviewer_b");
+
+describe(
+  "#70 — preflight: reviewer_a Codex under ChatGPT OAuth → OAuth label",
+  () => {
+    test(
+      "reviewer_a with subscription_auth: true shows " +
+        "'unknown — OAuth (no per-token cost visibility)'",
+      () => {
+        const cfg = mkConfig();
+        const r = computePreflight(cfg, [
+          LEAD_OAUTH,
+          REVA_CODEX_OAUTH,
+          REVB_CLAUDE_APIKEY,
+        ]);
+        const perA = r.perAdapter["reviewer_a"];
+        expect(perA).toBeDefined();
+        expect(perA?.usd).toBe(
+          "unknown — OAuth (no per-token cost visibility)",
+        );
+      },
+    );
+
+    test("reviewer_a OAuth: likelyUsd excludes reviewer_a cost", () => {
+      const cfgAll = mkConfig();
+      // Baseline: all API keys → likelyUsd includes reviewer_a.
+      const rAll = computePreflight(cfgAll, [
+        LEAD_APIKEY,
+        REVA_APIKEY,
+        REVB_APIKEY,
+      ]);
+      // OAuth scenario: reviewer_a excluded from likelyUsd.
+      const rOAuth = computePreflight(mkConfig(), [
+        LEAD_APIKEY,
+        REVA_CODEX_OAUTH,
+        REVB_APIKEY,
+      ]);
+      // With OAuth reviewer_a, the likelyUsd should be less than all-API-key.
+      expect(rOAuth.likelyUsd).toBeLessThan(rAll.likelyUsd);
+    });
+
+    test(
+      "pretty-printer for OAuth reviewer_a says 'OAuth' (not dollar amount)",
+      () => {
+        const cfg = mkConfig();
+        const r = computePreflight(cfg, [
+          LEAD_OAUTH,
+          REVA_CODEX_OAUTH,
+          REVB_CLAUDE_APIKEY,
+        ]);
+        const text = formatPreflight(r);
+
+        // Must contain OAuth label in per-adapter section.
+        expect(text).toContain("OAuth");
+        // Must NOT show a dollar amount for reviewer_a when OAuth.
+        // The dollar-sign should appear only in the summary line, not per-adapter.
+        const perAdapterSection = text
+          .split("per-adapter:")[1]
+          ?.split("warnings:")[0];
+        expect(perAdapterSection).toBeDefined();
+        // The per-adapter section for reviewer_a must say "OAuth", not "$N.NN".
+        const reviewerALine = perAdapterSection
+          ?.split("\n")
+          .find((l) => l.includes("reviewer_a"));
+        expect(reviewerALine).toBeDefined();
+        expect(reviewerALine).toContain("OAuth");
+        expect(reviewerALine).not.toMatch(/\$\d+\.\d+/);
+      },
+    );
+
+    test("warnings include mention of OAuth when reviewer_a is OAuth", () => {
+      const cfg = mkConfig();
+      const r = computePreflight(cfg, [
+        LEAD_APIKEY,
+        REVA_CODEX_OAUTH,
+        REVB_APIKEY,
+      ]);
+      const hasOAuthWarn = r.warnings.some((w) => /oauth/i.test(w));
+      expect(hasOAuthWarn).toBe(true);
+    });
+
+    test("full OAuth scenario (all three adapters): likelyUsd is 0", () => {
+      const cfg = mkConfig();
+      const allOAuth = [
+        mkAdapter("lead", "claude", true, "lead"),
+        mkAdapter("reviewer_a", "codex", true, "reviewer_a"),
+        mkAdapter("reviewer_b", "claude", true, "reviewer_b"),
+      ];
+      const r = computePreflight(cfg, allOAuth);
+      expect(r.likelyUsd).toBe(0);
+      for (const [, entry] of Object.entries(r.perAdapter)) {
+        expect(entry.usd).toBe(
+          "unknown — OAuth (no per-token cost visibility)",
+        );
+      }
+    });
+  },
+);
+
+describe("#70 — preflight: API-key reviewer_a unchanged", () => {
+  test(
+    "reviewer_a with subscription_auth: false shows dollar estimate",
+    () => {
+      const cfg = mkConfig();
+      const r = computePreflight(cfg, [LEAD_APIKEY, REVA_APIKEY, REVB_APIKEY]);
+      const perA = r.perAdapter["reviewer_a"];
+      expect(perA).toBeDefined();
+      expect(typeof perA?.usd).toBe("number");
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- **#64:** Move `reviewerAvailability <= 0` check to priority #2 in `classifyAllStops` (before `ready` and `semantic-convergence`). When all reviewers fail in a round, the lead's `ready=true` signal is now suppressed — the loop exits with `reviewers-exhausted` instead of silently accepting an un-reviewed spec.
- **#70:** `CodexAdapter.auth_status()` already returns `subscription_auth: true` when `OPENAI_API_KEY` is absent, and `computePreflight` already handles `subscription_auth` correctly for all adapters. Added explicit tests to lock this behavior and confirm `reviewer_a` shows `unknown — OAuth (no per-token cost visibility)` in preflight, not a dollar estimate.

Closes #64
Closes #70

## Changes

- `src/loop/stopping.ts`: reorder stop conditions — `reviewers-exhausted` now fires at priority #2 (after `max-rounds`), before `ready` (#3) and `semantic-convergence` (#4)
- `tests/loop/reviewer-failure-convergence.test.ts`: RED→GREEN tests for #64
- `tests/adapter/codex-chatgpt-auth-detection.test.ts`: explicit auth_status() coverage for ChatGPT OAuth path
- `tests/policy/preflight-codex-oauth.test.ts`: explicit preflight coverage for Codex OAuth reviewer_a label

## Test plan

- [x] `bun test` — 1237 pass, 0 fail
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run typecheck` — clean
- [x] RED test confirmed failing before fix (classifyAllStops returned "ready" when reviewerAvailability=0)
- [x] GREEN after single-line priority reorder in stopping.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)