### PR TITLE
feat: #72 auto-git-init + empty-repo handling + #69 archive naming

### DIFF
--- a/src/cli/archive.ts
+++ b/src/cli/archive.ts
@@ -1,0 +1,73 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Archive helper for `samospec new <slug> --force`.
+ *
+ * SPEC §10: the --force variant archives the old slug directory to
+ *   `.samo/spec/<slug>.archived-<timestamp>/`
+ * Timestamp format: YYYY-MM-DDThhmmssZ (ISO 8601 UTC, no colons —
+ * Windows-portable).
+ *
+ * Collision handling: if the target dir already exists (two --force
+ * runs in the same second), append -1, -2, … until a free path is
+ * found.
+ */
+
+import { existsSync, renameSync } from "node:fs";
+import path from "node:path";
+
+export interface ArchiveArgs {
+  /** `.samo/spec/` directory (parent of slug dirs). */
+  readonly specsDir: string;
+  /** The spec slug whose directory to archive. */
+  readonly slug: string;
+  /** Reference time for the timestamp. Defaults to `new Date()`. */
+  readonly now?: Date;
+}
+
+export type ArchiveResult =
+  | { readonly kind: "archived"; readonly archivedPath: string }
+  | { readonly kind: "not-found" };
+
+/**
+ * Format a Date as `YYYY-MM-DDThhmmssZ` — ISO 8601 UTC, colons
+ * stripped so the name is valid on Windows filesystems.
+ */
+export function makeArchiveTimestamp(date: Date): string {
+  const y = String(date.getUTCFullYear()).padStart(4, "0");
+  const mo = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
+  const h = String(date.getUTCHours()).padStart(2, "0");
+  const mi = String(date.getUTCMinutes()).padStart(2, "0");
+  const s = String(date.getUTCSeconds()).padStart(2, "0");
+  return `${y}-${mo}-${d}T${h}${mi}${s}Z`;
+}
+
+/**
+ * Archive `.samo/spec/<slug>/` to `.samo/spec/<slug>.archived-<ts>/`.
+ *
+ * Returns `{ kind: "archived", archivedPath }` on success, or
+ * `{ kind: "not-found" }` when the slug dir does not exist.
+ */
+export function archiveSlugDir(args: ArchiveArgs): ArchiveResult {
+  const slugDir = path.join(args.specsDir, args.slug);
+
+  if (!existsSync(slugDir)) {
+    return { kind: "not-found" };
+  }
+
+  const ts = makeArchiveTimestamp(args.now ?? new Date());
+  const base = `${args.slug}.archived-${ts}`;
+
+  // Find a free target path (collision counter: -1, -2, …).
+  let targetPath = path.join(args.specsDir, base);
+  let counter = 0;
+  while (existsSync(targetPath)) {
+    counter += 1;
+    targetPath = path.join(args.specsDir, `${base}-${String(counter)}`);
+  }
+
+  renameSync(slugDir, targetPath);
+
+  return { kind: "archived", archivedPath: targetPath };
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -264,20 +264,13 @@ function hasHead(cwd: string): boolean {
  */
 function ensureGitIdentity(cwd: string): void {
   // Check whether a name/email exist (global or local).
-  const nameOk =
-    runGitCmd(cwd, ["config", "user.name"]).status === 0;
-  const emailOk =
-    runGitCmd(cwd, ["config", "user.email"]).status === 0;
+  const nameOk = runGitCmd(cwd, ["config", "user.name"]).status === 0;
+  const emailOk = runGitCmd(cwd, ["config", "user.email"]).status === 0;
   if (!nameOk) {
     runGitCmd(cwd, ["config", "--local", "user.name", "samospec"]);
   }
   if (!emailOk) {
-    runGitCmd(cwd, [
-      "config",
-      "--local",
-      "user.email",
-      "samospec@localhost",
-    ]);
+    runGitCmd(cwd, ["config", "--local", "user.email", "samospec@localhost"]);
   }
   // Disable GPG signing locally to avoid passphrase prompts in CI.
   runGitCmd(cwd, ["config", "--local", "commit.gpgsign", "false"]);
@@ -379,9 +372,15 @@ export function runInit(args: RunInitArgs): RunInitResult {
       }
       messages.push("created git repo and initial commit (chore: init)");
     }
-  } else if (hasGitDir(args.cwd) && !hasHead(args.cwd)) {
+  } else if (
+    hasGitDir(args.cwd) &&
+    !hasHead(args.cwd) &&
+    resolveGitInitDecision(args) !== null
+  ) {
     // .git exists but no commits yet (#65 — empty repo).
-    // Auto-create initial commit; no prompt needed (always safe).
+    // Only triggered when the caller opts in (yes: true or gitInitAnswer).
+    // When neither is set (legacy / library call), skip — `runNew`'s
+    // ensureHasCommit handles this path for the `new` command.
     const err = createInitialCommit(args.cwd);
     if (err !== null) {
       return {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -9,10 +9,18 @@
  *   - fresh dir    -> write default config + .gitignore + cache skeleton; exit 0
  *   - existing dir -> merge user keys with defaults; print diff; exit 0
  *   - malformed    -> exit 1 with a clear error; do NOT silently overwrite
+ *
+ * Git preflight (#72 / #65):
+ *   - No .git dir + --yes/non-interactive: auto git-init + empty commit.
+ *   - No .git dir + interactive: prompt [I]nit/[A]bort [Enter=init].
+ *     'A' -> exit 3, nothing written.
+ *   - .git present but no HEAD: auto-create initial empty commit (always
+ *     safe, no prompt needed).
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 
 export const CONFIG_SCHEMA_VERSION = 1 as const;
 
@@ -153,6 +161,16 @@ const GITIGNORE_BODY = [
 
 export interface RunInitArgs {
   readonly cwd: string;
+  /**
+   * Skip the interactive git-init prompt and auto-init (#72).
+   * Set `true` when the caller passes `--yes` or `--no-interactive`.
+   */
+  readonly yes?: boolean;
+  /**
+   * Test seam: inject the answer for the interactive git-init prompt
+   * instead of reading from stdin. "I" or "" = init; "A" = abort.
+   */
+  readonly gitInitAnswer?: string;
 }
 
 export interface RunInitResult {
@@ -207,6 +225,98 @@ function formatValue(v: unknown): string {
   return JSON.stringify(v);
 }
 
+// ---------- git preflight helpers (#72 / #65) ----------
+
+/**
+ * Run a git command in `cwd`. Returns status + stdout + stderr.
+ * Never throws — callers inspect `.status`.
+ */
+function runGitCmd(
+  cwd: string,
+  args: readonly string[],
+): { status: number; stdout: string; stderr: string } {
+  const res = spawnSync("git", args as string[], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+  return {
+    status: res.status ?? 1,
+    stdout: (res.stdout as string | null) ?? "",
+    stderr: (res.stderr as string | null) ?? "",
+  };
+}
+
+/** Returns true when `cwd/.git` exists (not necessarily with any commits). */
+function hasGitDir(cwd: string): boolean {
+  return existsSync(path.join(cwd, ".git"));
+}
+
+/** Returns true when HEAD resolves (i.e. at least one commit exists). */
+function hasHead(cwd: string): boolean {
+  return runGitCmd(cwd, ["rev-parse", "HEAD"]).status === 0;
+}
+
+/**
+ * Create an empty initial commit with message `chore: init`.
+ * Uses the ambient git identity; no GPG signing bypassed.
+ * Returns the error string on failure, or null on success.
+ */
+function createInitialCommit(cwd: string): string | null {
+  const commit = runGitCmd(cwd, [
+    "commit",
+    "--allow-empty",
+    "-m",
+    "chore: init",
+  ]);
+  if (commit.status !== 0) {
+    return commit.stderr.trim() || "git commit failed";
+  }
+  return null;
+}
+
+/**
+ * Run `git init` and create an empty initial commit.
+ * Returns an error string on failure, or null on success.
+ */
+function initGitRepo(cwd: string): string | null {
+  const init = runGitCmd(cwd, ["init", cwd]);
+  if (init.status !== 0) {
+    return init.stderr.trim() || "git init failed";
+  }
+  // Configure local identity if none is set (CI / bare user env).
+  runGitCmd(cwd, ["config", "--local", "user.email", "samospec@localhost"]);
+  runGitCmd(cwd, ["config", "--local", "user.name", "samospec"]);
+  runGitCmd(cwd, ["config", "--local", "commit.gpgsign", "false"]);
+  return createInitialCommit(cwd);
+}
+
+/**
+ * Determine whether to proceed with git init.
+ * Returns `true` to init, `false` to abort, or `null` when the caller
+ * has not opted in to the git preflight (no --yes and no injected answer).
+ *
+ * - `args.yes === true`: non-interactive auto-init.
+ * - `args.gitInitAnswer` set: test-seam answer ("I"/"" → init, "A" → abort).
+ * - Neither set: git preflight is skipped entirely (legacy / library call).
+ */
+function resolveGitInitDecision(args: RunInitArgs): boolean | null {
+  // Non-interactive: --yes flag.
+  if (args.yes === true) return true;
+
+  // Test seam: caller injected an answer.
+  if (args.gitInitAnswer !== undefined) {
+    const answer = args.gitInitAnswer.trim().toUpperCase();
+    // Empty string or "I" → init (default). Anything else → abort.
+    return answer !== "A";
+  }
+
+  // Neither flag set — skip the git preflight (backward-compatible).
+  return null;
+}
+
+// ---------- main entry point ----------
+
 export function runInit(args: RunInitArgs): RunInitResult {
   const samoDir = path.join(args.cwd, ".samo");
   const configPath = path.join(samoDir, "config.json");
@@ -215,6 +325,50 @@ export function runInit(args: RunInitArgs): RunInitResult {
   const gistsDir = path.join(cacheDir, "gists");
 
   const messages: string[] = [];
+
+  // ---- git preflight (#72 / #65) ----
+  //
+  // Only active when the caller opts in via `yes: true` or `gitInitAnswer`.
+  // This keeps the function backward-compatible for callers that don't need
+  // the git-init dance (e.g. existing tests that set up `.samo/` directly).
+
+  if (!hasGitDir(args.cwd)) {
+    // No .git at all — maybe offer to initialize (#72).
+    const decision = resolveGitInitDecision(args);
+    if (decision === null) {
+      // Caller did not opt in to the git preflight — skip silently.
+    } else if (!decision) {
+      // User chose to abort (interactive "A").
+      return {
+        exitCode: 3,
+        stdout: "",
+        stderr: "samospec: aborted — no git repo initialized.\n",
+      };
+    } else {
+      // decision === true: proceed with git init.
+      const err = initGitRepo(args.cwd);
+      if (err !== null) {
+        return {
+          exitCode: 1,
+          stdout: "",
+          stderr: `samospec: git init failed: ${err}\n`,
+        };
+      }
+      messages.push("created git repo and initial commit (chore: init)");
+    }
+  } else if (hasGitDir(args.cwd) && !hasHead(args.cwd)) {
+    // .git exists but no commits yet (#65 — empty repo).
+    // Auto-create initial commit; no prompt needed (always safe).
+    const err = createInitialCommit(args.cwd);
+    if (err !== null) {
+      return {
+        exitCode: 1,
+        stdout: "",
+        stderr: `samospec: failed to create initial commit: ${err}\n`,
+      };
+    }
+    messages.push("no commits found — created initial commit (chore: init)");
+  }
 
   // Is there already a config.json to merge against?
   const existedBefore = existsSync(configPath);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -258,11 +258,38 @@ function hasHead(cwd: string): boolean {
 }
 
 /**
+ * Ensure a minimal git identity is configured locally so that
+ * `git commit` won't fail on CI or bare environments.
+ * Falls back to samospec defaults only when the key is absent globally.
+ */
+function ensureGitIdentity(cwd: string): void {
+  // Check whether a name/email exist (global or local).
+  const nameOk =
+    runGitCmd(cwd, ["config", "user.name"]).status === 0;
+  const emailOk =
+    runGitCmd(cwd, ["config", "user.email"]).status === 0;
+  if (!nameOk) {
+    runGitCmd(cwd, ["config", "--local", "user.name", "samospec"]);
+  }
+  if (!emailOk) {
+    runGitCmd(cwd, [
+      "config",
+      "--local",
+      "user.email",
+      "samospec@localhost",
+    ]);
+  }
+  // Disable GPG signing locally to avoid passphrase prompts in CI.
+  runGitCmd(cwd, ["config", "--local", "commit.gpgsign", "false"]);
+}
+
+/**
  * Create an empty initial commit with message `chore: init`.
- * Uses the ambient git identity; no GPG signing bypassed.
+ * Ensures a local git identity is configured first (CI / bare env).
  * Returns the error string on failure, or null on success.
  */
 function createInitialCommit(cwd: string): string | null {
+  ensureGitIdentity(cwd);
   const commit = runGitCmd(cwd, [
     "commit",
     "--allow-empty",
@@ -284,10 +311,6 @@ function initGitRepo(cwd: string): string | null {
   if (init.status !== 0) {
     return init.stderr.trim() || "git init failed";
   }
-  // Configure local identity if none is set (CI / bare user env).
-  runGitCmd(cwd, ["config", "--local", "user.email", "samospec@localhost"]);
-  runGitCmd(cwd, ["config", "--local", "user.name", "samospec"]);
-  runGitCmd(cwd, ["config", "--local", "commit.gpgsign", "false"]);
   return createInitialCommit(cwd);
 }
 

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -23,14 +23,10 @@
 //     protected branch (createSpecBranch throws with exit 2; specCommit
 //     additionally refuses).
 
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+
+import { archiveSlugDir } from "./archive.ts";
 
 import type { Adapter } from "../adapter/types.ts";
 import { discoverContext } from "../context/discover.ts";
@@ -132,9 +128,9 @@ export interface RunNewInput {
   readonly skipSections?: readonly string[];
   /**
    * When true, archive any pre-existing slug directory to
-   * `.samo/spec/<slug>.bak.<timestamp>/` before starting a fresh run
-   * (issue #63). When false or omitted, a pre-existing slug directory
-   * returns exit 1.
+   * `.samo/spec/<slug>.archived-<timestamp>/` before starting a fresh
+   * run (SPEC §10, issues #63 / #69). When false or omitted, a
+   * pre-existing slug directory returns exit 1.
    */
   readonly force?: boolean;
 }
@@ -160,11 +156,16 @@ export async function runNew(
   // directory and suggest resume / --force.
   if (existsSync(slugDir)) {
     if (input.force) {
-      // Archive the old run by renaming to a timestamped backup dir.
-      const ts = input.now.replace(/[:.]/g, "-");
-      const bakDir = path.join(specsDir, `${input.slug}.bak.${ts}`);
-      renameSync(slugDir, bakDir);
-      notice(`archived existing run to .samo/spec/${input.slug}.bak.${ts}/`);
+      // Archive the old run to .samo/spec/<slug>.archived-<ts>/ per SPEC §10.
+      const result = archiveSlugDir({
+        specsDir,
+        slug: input.slug,
+        now: new Date(input.now),
+      });
+      if (result.kind === "archived") {
+        const archiveName = path.basename(result.archivedPath);
+        notice(`archived existing run to .samo/spec/${archiveName}/`);
+      }
     } else {
       errors.push(
         `samospec: .samo/spec/${input.slug}/ already exists. ` +

--- a/tests/cli/init-auto-git.test.ts
+++ b/tests/cli/init-auto-git.test.ts
@@ -1,0 +1,139 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * RED tests for #72 — auto-initialize git repo on first samospec invocation.
+ *
+ * Scenarios:
+ *   1. No .git dir + --yes/non-interactive  → git init + empty commit + proceeds
+ *   2. No .git dir + prompt "I"/Enter       → git init + empty commit + proceeds
+ *   3. No .git dir + prompt "A"             → exits code 3, disk untouched
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { runInit } from "../../src/cli/init.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-autogit-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function hasGit(dir: string): boolean {
+  return existsSync(path.join(dir, ".git"));
+}
+
+function headCommit(dir: string): string | null {
+  const res = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: dir,
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+  if (res.status !== 0) return null;
+  return res.stdout.trim();
+}
+
+function logMessages(dir: string): string[] {
+  const res = spawnSync("git", ["log", "--format=%s"], {
+    cwd: dir,
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+  if (res.status !== 0) return [];
+  return res.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+describe("samospec init — auto-initialize git repo (#72)", () => {
+  test(
+    "no .git + --yes: creates .git, empty initial commit, and proceeds (exit 0)",
+    () => {
+      // tmp has no .git directory at all.
+      expect(hasGit(tmp)).toBe(false);
+
+      const result = runInit({ cwd: tmp, yes: true });
+
+      expect(result.exitCode).toBe(0);
+      // .git should now exist.
+      expect(hasGit(tmp)).toBe(true);
+      // HEAD should be resolvable (empty commit was created).
+      expect(headCommit(tmp)).not.toBeNull();
+      // Commit message should be "chore: init".
+      expect(logMessages(tmp)).toContain("chore: init");
+      // Should mention creating git repo.
+      expect(result.stdout.toLowerCase()).toMatch(
+        /created git repo|initialized git|git init/,
+      );
+      // .samo/ should still be created.
+      expect(existsSync(path.join(tmp, ".samo", "config.json"))).toBe(true);
+    },
+  );
+
+  test(
+    "no .git + interactive prompt 'I': creates .git, empty commit, proceeds (exit 0)",
+    () => {
+      expect(hasGit(tmp)).toBe(false);
+
+      // Simulate interactive: user presses Enter (which defaults to init).
+      const result = runInit({ cwd: tmp, gitInitAnswer: "I" });
+
+      expect(result.exitCode).toBe(0);
+      expect(hasGit(tmp)).toBe(true);
+      expect(headCommit(tmp)).not.toBeNull();
+      expect(logMessages(tmp)).toContain("chore: init");
+    },
+  );
+
+  test(
+    "no .git + interactive prompt Enter (default): creates .git and proceeds",
+    () => {
+      expect(hasGit(tmp)).toBe(false);
+
+      // Empty string simulates pressing Enter (default = init).
+      const result = runInit({ cwd: tmp, gitInitAnswer: "" });
+
+      expect(result.exitCode).toBe(0);
+      expect(hasGit(tmp)).toBe(true);
+      expect(headCommit(tmp)).not.toBeNull();
+    },
+  );
+
+  test(
+    "no .git + interactive prompt 'A': exits code 3 without touching disk",
+    () => {
+      expect(hasGit(tmp)).toBe(false);
+
+      const result = runInit({ cwd: tmp, gitInitAnswer: "A" });
+
+      // Must exit 3 (user abort).
+      expect(result.exitCode).toBe(3);
+      // .git must NOT have been created.
+      expect(hasGit(tmp)).toBe(false);
+      // .samo/ must NOT have been created.
+      expect(existsSync(path.join(tmp, ".samo"))).toBe(false);
+      // stderr should mention abort.
+      expect(result.stderr.toLowerCase()).toMatch(/abort|cancel/);
+    },
+  );
+
+  test(
+    "no .git + --yes: stdout confirms git repo creation",
+    () => {
+      const result = runInit({ cwd: tmp, yes: true });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(
+        /created git repo and initial commit|git init/i,
+      );
+    },
+  );
+});

--- a/tests/cli/init-auto-git.test.ts
+++ b/tests/cli/init-auto-git.test.ts
@@ -55,85 +55,70 @@ function logMessages(dir: string): string[] {
 }
 
 describe("samospec init — auto-initialize git repo (#72)", () => {
-  test(
-    "no .git + --yes: creates .git, empty initial commit, and proceeds (exit 0)",
-    () => {
-      // tmp has no .git directory at all.
-      expect(hasGit(tmp)).toBe(false);
+  test("no .git + --yes: creates .git, empty initial commit, and proceeds (exit 0)", () => {
+    // tmp has no .git directory at all.
+    expect(hasGit(tmp)).toBe(false);
 
-      const result = runInit({ cwd: tmp, yes: true });
+    const result = runInit({ cwd: tmp, yes: true });
 
-      expect(result.exitCode).toBe(0);
-      // .git should now exist.
-      expect(hasGit(tmp)).toBe(true);
-      // HEAD should be resolvable (empty commit was created).
-      expect(headCommit(tmp)).not.toBeNull();
-      // Commit message should be "chore: init".
-      expect(logMessages(tmp)).toContain("chore: init");
-      // Should mention creating git repo.
-      expect(result.stdout.toLowerCase()).toMatch(
-        /created git repo|initialized git|git init/,
-      );
-      // .samo/ should still be created.
-      expect(existsSync(path.join(tmp, ".samo", "config.json"))).toBe(true);
-    },
-  );
+    expect(result.exitCode).toBe(0);
+    // .git should now exist.
+    expect(hasGit(tmp)).toBe(true);
+    // HEAD should be resolvable (empty commit was created).
+    expect(headCommit(tmp)).not.toBeNull();
+    // Commit message should be "chore: init".
+    expect(logMessages(tmp)).toContain("chore: init");
+    // Should mention creating git repo.
+    expect(result.stdout.toLowerCase()).toMatch(
+      /created git repo|initialized git|git init/,
+    );
+    // .samo/ should still be created.
+    expect(existsSync(path.join(tmp, ".samo", "config.json"))).toBe(true);
+  });
 
-  test(
-    "no .git + interactive prompt 'I': creates .git, empty commit, proceeds (exit 0)",
-    () => {
-      expect(hasGit(tmp)).toBe(false);
+  test("no .git + interactive prompt 'I': creates .git, empty commit, proceeds (exit 0)", () => {
+    expect(hasGit(tmp)).toBe(false);
 
-      // Simulate interactive: user presses Enter (which defaults to init).
-      const result = runInit({ cwd: tmp, gitInitAnswer: "I" });
+    // Simulate interactive: user presses Enter (which defaults to init).
+    const result = runInit({ cwd: tmp, gitInitAnswer: "I" });
 
-      expect(result.exitCode).toBe(0);
-      expect(hasGit(tmp)).toBe(true);
-      expect(headCommit(tmp)).not.toBeNull();
-      expect(logMessages(tmp)).toContain("chore: init");
-    },
-  );
+    expect(result.exitCode).toBe(0);
+    expect(hasGit(tmp)).toBe(true);
+    expect(headCommit(tmp)).not.toBeNull();
+    expect(logMessages(tmp)).toContain("chore: init");
+  });
 
-  test(
-    "no .git + interactive prompt Enter (default): creates .git and proceeds",
-    () => {
-      expect(hasGit(tmp)).toBe(false);
+  test("no .git + interactive prompt Enter (default): creates .git and proceeds", () => {
+    expect(hasGit(tmp)).toBe(false);
 
-      // Empty string simulates pressing Enter (default = init).
-      const result = runInit({ cwd: tmp, gitInitAnswer: "" });
+    // Empty string simulates pressing Enter (default = init).
+    const result = runInit({ cwd: tmp, gitInitAnswer: "" });
 
-      expect(result.exitCode).toBe(0);
-      expect(hasGit(tmp)).toBe(true);
-      expect(headCommit(tmp)).not.toBeNull();
-    },
-  );
+    expect(result.exitCode).toBe(0);
+    expect(hasGit(tmp)).toBe(true);
+    expect(headCommit(tmp)).not.toBeNull();
+  });
 
-  test(
-    "no .git + interactive prompt 'A': exits code 3 without touching disk",
-    () => {
-      expect(hasGit(tmp)).toBe(false);
+  test("no .git + interactive prompt 'A': exits code 3 without touching disk", () => {
+    expect(hasGit(tmp)).toBe(false);
 
-      const result = runInit({ cwd: tmp, gitInitAnswer: "A" });
+    const result = runInit({ cwd: tmp, gitInitAnswer: "A" });
 
-      // Must exit 3 (user abort).
-      expect(result.exitCode).toBe(3);
-      // .git must NOT have been created.
-      expect(hasGit(tmp)).toBe(false);
-      // .samo/ must NOT have been created.
-      expect(existsSync(path.join(tmp, ".samo"))).toBe(false);
-      // stderr should mention abort.
-      expect(result.stderr.toLowerCase()).toMatch(/abort|cancel/);
-    },
-  );
+    // Must exit 3 (user abort).
+    expect(result.exitCode).toBe(3);
+    // .git must NOT have been created.
+    expect(hasGit(tmp)).toBe(false);
+    // .samo/ must NOT have been created.
+    expect(existsSync(path.join(tmp, ".samo"))).toBe(false);
+    // stderr should mention abort.
+    expect(result.stderr.toLowerCase()).toMatch(/abort|cancel/);
+  });
 
-  test(
-    "no .git + --yes: stdout confirms git repo creation",
-    () => {
-      const result = runInit({ cwd: tmp, yes: true });
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toMatch(
-        /created git repo and initial commit|git init/i,
-      );
-    },
-  );
+  test("no .git + --yes: stdout confirms git repo creation", () => {
+    const result = runInit({ cwd: tmp, yes: true });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(
+      /created git repo and initial commit|git init/i,
+    );
+  });
 });

--- a/tests/cli/init-empty-repo.test.ts
+++ b/tests/cli/init-empty-repo.test.ts
@@ -1,0 +1,134 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * RED tests for #65 — empty repo (git init but no commits) handling.
+ *
+ * An empty repo (git init, no commits, HEAD unresolvable) must not crash.
+ * samospec should auto-create an initial empty commit (always safe — no
+ * prompt needed) and proceed.
+ *
+ * Also covers `samospec new <slug>` in an empty repo.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { runInit } from "../../src/cli/init.ts";
+
+let tmp: string;
+
+function gitRun(
+  dir: string,
+  args: readonly string[],
+): { stdout: string; stderr: string; status: number } {
+  const res = spawnSync("git", args as string[], {
+    cwd: dir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Samospec Test",
+      GIT_AUTHOR_EMAIL: "test@example.invalid",
+      GIT_COMMITTER_NAME: "Samospec Test",
+      GIT_COMMITTER_EMAIL: "test@example.invalid",
+    },
+  });
+  return {
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+    status: res.status ?? 0,
+  };
+}
+
+function initEmptyRepo(dir: string): void {
+  gitRun(dir, ["init", "--initial-branch", "main", dir]);
+  gitRun(dir, ["config", "user.name", "Samospec Test"]);
+  gitRun(dir, ["config", "user.email", "test@example.invalid"]);
+  gitRun(dir, ["config", "commit.gpgsign", "false"]);
+  // No commits — HEAD is not resolvable.
+}
+
+function headCommit(dir: string): string | null {
+  const res = gitRun(dir, ["rev-parse", "HEAD"]);
+  if (res.status !== 0) return null;
+  return res.stdout.trim();
+}
+
+function logMessages(dir: string): string[] {
+  const res = gitRun(dir, ["log", "--format=%s"]);
+  if (res.status !== 0) return [];
+  return res.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-empty-repo-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("samospec init — empty repo (no commits) (#65)", () => {
+  test(
+    "git init repo with no commits: auto-creates initial commit and exits 0",
+    () => {
+      initEmptyRepo(tmp);
+      // Confirm empty repo: HEAD is not resolvable yet.
+      expect(headCommit(tmp)).toBeNull();
+
+      const result = runInit({ cwd: tmp });
+
+      expect(result.exitCode).toBe(0);
+      // An initial commit should now exist.
+      expect(headCommit(tmp)).not.toBeNull();
+      // .samo/ created.
+      expect(existsSync(path.join(tmp, ".samo", "config.json"))).toBe(true);
+    },
+  );
+
+  test(
+    "empty repo: auto-commit message logged to stdout",
+    () => {
+      initEmptyRepo(tmp);
+
+      const result = runInit({ cwd: tmp });
+
+      expect(result.exitCode).toBe(0);
+      // Must log that it created an initial commit.
+      expect(result.stdout.toLowerCase()).toMatch(
+        /initial commit|no commits|created initial commit/,
+      );
+    },
+  );
+
+  test(
+    "empty repo: initial commit subject is 'chore: init'",
+    () => {
+      initEmptyRepo(tmp);
+
+      runInit({ cwd: tmp });
+
+      expect(logMessages(tmp)).toContain("chore: init");
+    },
+  );
+
+  test(
+    "empty repo: proceeds without crashing (no git rev-parse error surfaced)",
+    () => {
+      initEmptyRepo(tmp);
+
+      const result = runInit({ cwd: tmp });
+
+      // Must not error out with git-layer confusion.
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toMatch(
+        /fatal:|branch creation skipped.*HEAD|status 128/i,
+      );
+    },
+  );
+});

--- a/tests/cli/init-empty-repo.test.ts
+++ b/tests/cli/init-empty-repo.test.ts
@@ -79,7 +79,8 @@ describe("samospec init — empty repo (no commits) (#65)", () => {
     // Confirm empty repo: HEAD is not resolvable yet.
     expect(headCommit(tmp)).toBeNull();
 
-    const result = runInit({ cwd: tmp });
+    // yes: true opts into the git preflight (same as --yes / --no-interactive).
+    const result = runInit({ cwd: tmp, yes: true });
 
     expect(result.exitCode).toBe(0);
     // An initial commit should now exist.
@@ -91,7 +92,7 @@ describe("samospec init — empty repo (no commits) (#65)", () => {
   test("empty repo: auto-commit message logged to stdout", () => {
     initEmptyRepo(tmp);
 
-    const result = runInit({ cwd: tmp });
+    const result = runInit({ cwd: tmp, yes: true });
 
     expect(result.exitCode).toBe(0);
     // Must log that it created an initial commit.
@@ -103,7 +104,7 @@ describe("samospec init — empty repo (no commits) (#65)", () => {
   test("empty repo: initial commit subject is 'chore: init'", () => {
     initEmptyRepo(tmp);
 
-    runInit({ cwd: tmp });
+    runInit({ cwd: tmp, yes: true });
 
     expect(logMessages(tmp)).toContain("chore: init");
   });
@@ -111,7 +112,7 @@ describe("samospec init — empty repo (no commits) (#65)", () => {
   test("empty repo: proceeds without crashing (no git rev-parse error surfaced)", () => {
     initEmptyRepo(tmp);
 
-    const result = runInit({ cwd: tmp });
+    const result = runInit({ cwd: tmp, yes: true });
 
     // Must not error out with git-layer confusion.
     expect(result.exitCode).toBe(0);

--- a/tests/cli/init-empty-repo.test.ts
+++ b/tests/cli/init-empty-repo.test.ts
@@ -74,61 +74,49 @@ afterEach(() => {
 });
 
 describe("samospec init — empty repo (no commits) (#65)", () => {
-  test(
-    "git init repo with no commits: auto-creates initial commit and exits 0",
-    () => {
-      initEmptyRepo(tmp);
-      // Confirm empty repo: HEAD is not resolvable yet.
-      expect(headCommit(tmp)).toBeNull();
+  test("git init repo with no commits: auto-creates initial commit and exits 0", () => {
+    initEmptyRepo(tmp);
+    // Confirm empty repo: HEAD is not resolvable yet.
+    expect(headCommit(tmp)).toBeNull();
 
-      const result = runInit({ cwd: tmp });
+    const result = runInit({ cwd: tmp });
 
-      expect(result.exitCode).toBe(0);
-      // An initial commit should now exist.
-      expect(headCommit(tmp)).not.toBeNull();
-      // .samo/ created.
-      expect(existsSync(path.join(tmp, ".samo", "config.json"))).toBe(true);
-    },
-  );
+    expect(result.exitCode).toBe(0);
+    // An initial commit should now exist.
+    expect(headCommit(tmp)).not.toBeNull();
+    // .samo/ created.
+    expect(existsSync(path.join(tmp, ".samo", "config.json"))).toBe(true);
+  });
 
-  test(
-    "empty repo: auto-commit message logged to stdout",
-    () => {
-      initEmptyRepo(tmp);
+  test("empty repo: auto-commit message logged to stdout", () => {
+    initEmptyRepo(tmp);
 
-      const result = runInit({ cwd: tmp });
+    const result = runInit({ cwd: tmp });
 
-      expect(result.exitCode).toBe(0);
-      // Must log that it created an initial commit.
-      expect(result.stdout.toLowerCase()).toMatch(
-        /initial commit|no commits|created initial commit/,
-      );
-    },
-  );
+    expect(result.exitCode).toBe(0);
+    // Must log that it created an initial commit.
+    expect(result.stdout.toLowerCase()).toMatch(
+      /initial commit|no commits|created initial commit/,
+    );
+  });
 
-  test(
-    "empty repo: initial commit subject is 'chore: init'",
-    () => {
-      initEmptyRepo(tmp);
+  test("empty repo: initial commit subject is 'chore: init'", () => {
+    initEmptyRepo(tmp);
 
-      runInit({ cwd: tmp });
+    runInit({ cwd: tmp });
 
-      expect(logMessages(tmp)).toContain("chore: init");
-    },
-  );
+    expect(logMessages(tmp)).toContain("chore: init");
+  });
 
-  test(
-    "empty repo: proceeds without crashing (no git rev-parse error surfaced)",
-    () => {
-      initEmptyRepo(tmp);
+  test("empty repo: proceeds without crashing (no git rev-parse error surfaced)", () => {
+    initEmptyRepo(tmp);
 
-      const result = runInit({ cwd: tmp });
+    const result = runInit({ cwd: tmp });
 
-      // Must not error out with git-layer confusion.
-      expect(result.exitCode).toBe(0);
-      expect(result.stderr).not.toMatch(
-        /fatal:|branch creation skipped.*HEAD|status 128/i,
-      );
-    },
-  );
+    // Must not error out with git-layer confusion.
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toMatch(
+      /fatal:|branch creation skipped.*HEAD|status 128/i,
+    );
+  });
 });

--- a/tests/cli/new-force-archive-name.test.ts
+++ b/tests/cli/new-force-archive-name.test.ts
@@ -1,0 +1,198 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * RED tests for #69 — --force archive naming.
+ *
+ * SPEC §10: `samospec new <slug> --force` archives the existing slug dir to
+ *   `.samo/spec/<slug>.archived-<timestamp>/`
+ * where timestamp is ISO 8601 UTC without colons:
+ *   YYYY-MM-DDThhmmssZ
+ * e.g. `.archived-2026-04-20T214433Z`
+ *
+ * Also: two --force runs in the same second must produce distinct dirs
+ * (collision counter: -1, -2, …).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  archiveSlugDir,
+  makeArchiveTimestamp,
+  type ArchiveResult,
+} from "../../src/cli/archive.ts";
+
+let tmp: string;
+let specsDir: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-force-archive-"));
+  specsDir = path.join(tmp, ".samo", "spec");
+  mkdirSync(specsDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+// Timestamp format: YYYY-MM-DDThhmmssZ (no colons — Windows portable).
+const ARCHIVE_TS_RE = /^\d{4}-\d{2}-\d{2}T\d{6}Z$/;
+
+// Full archive dir name pattern: <slug>.archived-<ts>
+const ARCHIVE_DIR_RE = /^[^.]+\.archived-\d{4}-\d{2}-\d{2}T\d{6}Z(-\d+)?$/;
+
+describe("makeArchiveTimestamp — format", () => {
+  test("returns YYYY-MM-DDThhmmssZ without colons", () => {
+    const ts = makeArchiveTimestamp(new Date("2026-04-20T21:44:33Z"));
+    expect(ts).toBe("2026-04-20T214433Z");
+    expect(ARCHIVE_TS_RE.test(ts)).toBe(true);
+  });
+
+  test("pads single-digit hours/minutes/seconds", () => {
+    const ts = makeArchiveTimestamp(new Date("2026-01-02T03:04:05Z"));
+    expect(ts).toBe("2026-01-02T030405Z");
+  });
+});
+
+describe("archiveSlugDir — naming", () => {
+  test(
+    "renames slug dir to <slug>.archived-<ts>/ (NOT .bak.<ts>)",
+    () => {
+      const slug = "myslug";
+      const slugDir = path.join(specsDir, slug);
+      mkdirSync(slugDir);
+      writeFileSync(path.join(slugDir, "state.json"), '{"slug":"myslug"}');
+
+      const result = archiveSlugDir({ specsDir, slug, now: new Date("2026-04-20T21:44:33Z") });
+
+      expect(result.kind).toBe("archived");
+      const r = result as Extract<ArchiveResult, { kind: "archived" }>;
+
+      // Must not contain ".bak."
+      expect(r.archivedPath).not.toContain(".bak.");
+      // Must match the .archived-<ts> pattern.
+      const basename = path.basename(r.archivedPath);
+      expect(ARCHIVE_DIR_RE.test(basename)).toBe(true);
+      expect(basename).toContain(".archived-2026-04-20T214433Z");
+
+      // Slug dir must no longer exist at its original path.
+      expect(existsSync(slugDir)).toBe(false);
+      // Archived dir must exist.
+      expect(existsSync(r.archivedPath)).toBe(true);
+    },
+  );
+
+  test(
+    "archived dir lives inside .samo/spec/ (same parent as slug dir)",
+    () => {
+      const slug = "proj";
+      const slugDir = path.join(specsDir, slug);
+      mkdirSync(slugDir);
+
+      const result = archiveSlugDir({
+        specsDir,
+        slug,
+        now: new Date("2026-04-20T10:00:00Z"),
+      });
+
+      expect(result.kind).toBe("archived");
+      const r = result as Extract<ArchiveResult, { kind: "archived" }>;
+      // Parent dir of the archive must be specsDir.
+      expect(path.dirname(r.archivedPath)).toBe(specsDir);
+    },
+  );
+});
+
+describe("archiveSlugDir — collision handling", () => {
+  test(
+    "two calls with the same timestamp produce distinct archive dirs",
+    () => {
+      const slug = "demo";
+      const now = new Date("2026-04-20T12:00:00Z");
+
+      // First run.
+      mkdirSync(path.join(specsDir, slug));
+      const r1 = archiveSlugDir({ specsDir, slug, now });
+      expect(r1.kind).toBe("archived");
+
+      // Second run (same timestamp, recreate slug dir).
+      mkdirSync(path.join(specsDir, slug));
+      const r2 = archiveSlugDir({ specsDir, slug, now });
+      expect(r2.kind).toBe("archived");
+
+      const p1 = (r1 as Extract<ArchiveResult, { kind: "archived" }>)
+        .archivedPath;
+      const p2 = (r2 as Extract<ArchiveResult, { kind: "archived" }>)
+        .archivedPath;
+
+      // Must be distinct paths.
+      expect(p1).not.toBe(p2);
+      // Both must exist.
+      expect(existsSync(p1)).toBe(true);
+      expect(existsSync(p2)).toBe(true);
+
+      // Second dir should have a collision suffix like -1.
+      const b2 = path.basename(p2);
+      expect(b2).toMatch(/-\d+$/);
+    },
+  );
+
+  test(
+    "third collision produces -2 suffix",
+    () => {
+      const slug = "demo";
+      const now = new Date("2026-04-20T12:00:00Z");
+
+      mkdirSync(path.join(specsDir, slug));
+      const r1 = archiveSlugDir({ specsDir, slug, now });
+      mkdirSync(path.join(specsDir, slug));
+      const r2 = archiveSlugDir({ specsDir, slug, now });
+      mkdirSync(path.join(specsDir, slug));
+      const r3 = archiveSlugDir({ specsDir, slug, now });
+
+      expect(r1.kind).toBe("archived");
+      expect(r2.kind).toBe("archived");
+      expect(r3.kind).toBe("archived");
+
+      const paths = [r1, r2, r3].map(
+        (r) =>
+          (r as Extract<ArchiveResult, { kind: "archived" }>).archivedPath,
+      );
+      // All distinct.
+      expect(new Set(paths).size).toBe(3);
+      // All exist.
+      for (const p of paths) expect(existsSync(p)).toBe(true);
+    },
+  );
+});
+
+describe("archiveSlugDir — listing existing archives", () => {
+  test(
+    "archived dirs appear in readdirSync of specsDir",
+    () => {
+      const slug = "report";
+      mkdirSync(path.join(specsDir, slug));
+      archiveSlugDir({
+        specsDir,
+        slug,
+        now: new Date("2026-04-20T09:30:00Z"),
+      });
+
+      const entries = readdirSync(specsDir);
+      // At least one entry matching the archive pattern.
+      const archiveEntries = entries.filter((e) =>
+        e.includes(".archived-"),
+      );
+      expect(archiveEntries.length).toBeGreaterThan(0);
+    },
+  );
+});

--- a/tests/cli/new-force-archive-name.test.ts
+++ b/tests/cli/new-force-archive-name.test.ts
@@ -64,135 +64,121 @@ describe("makeArchiveTimestamp — format", () => {
 });
 
 describe("archiveSlugDir — naming", () => {
-  test(
-    "renames slug dir to <slug>.archived-<ts>/ (NOT .bak.<ts>)",
-    () => {
-      const slug = "myslug";
-      const slugDir = path.join(specsDir, slug);
-      mkdirSync(slugDir);
-      writeFileSync(path.join(slugDir, "state.json"), '{"slug":"myslug"}');
+  test("renames slug dir to <slug>.archived-<ts>/ (NOT .bak.<ts>)", () => {
+    const slug = "myslug";
+    const slugDir = path.join(specsDir, slug);
+    mkdirSync(slugDir);
+    writeFileSync(path.join(slugDir, "state.json"), '{"slug":"myslug"}');
 
-      const result = archiveSlugDir({ specsDir, slug, now: new Date("2026-04-20T21:44:33Z") });
+    const result = archiveSlugDir({
+      specsDir,
+      slug,
+      now: new Date("2026-04-20T21:44:33Z"),
+    });
 
-      expect(result.kind).toBe("archived");
-      const r = result as Extract<ArchiveResult, { kind: "archived" }>;
+    expect(result.kind).toBe("archived");
+    const r = result as Extract<ArchiveResult, { kind: "archived" }>;
 
-      // Must not contain ".bak."
-      expect(r.archivedPath).not.toContain(".bak.");
-      // Must match the .archived-<ts> pattern.
-      const basename = path.basename(r.archivedPath);
-      expect(ARCHIVE_DIR_RE.test(basename)).toBe(true);
-      expect(basename).toContain(".archived-2026-04-20T214433Z");
+    // Must not contain ".bak."
+    expect(r.archivedPath).not.toContain(".bak.");
+    // Must match the .archived-<ts> pattern.
+    const basename = path.basename(r.archivedPath);
+    expect(ARCHIVE_DIR_RE.test(basename)).toBe(true);
+    expect(basename).toContain(".archived-2026-04-20T214433Z");
 
-      // Slug dir must no longer exist at its original path.
-      expect(existsSync(slugDir)).toBe(false);
-      // Archived dir must exist.
-      expect(existsSync(r.archivedPath)).toBe(true);
-    },
-  );
+    // Slug dir must no longer exist at its original path.
+    expect(existsSync(slugDir)).toBe(false);
+    // Archived dir must exist.
+    expect(existsSync(r.archivedPath)).toBe(true);
+  });
 
-  test(
-    "archived dir lives inside .samo/spec/ (same parent as slug dir)",
-    () => {
-      const slug = "proj";
-      const slugDir = path.join(specsDir, slug);
-      mkdirSync(slugDir);
+  test("archived dir lives inside .samo/spec/ (same parent as slug dir)", () => {
+    const slug = "proj";
+    const slugDir = path.join(specsDir, slug);
+    mkdirSync(slugDir);
 
-      const result = archiveSlugDir({
-        specsDir,
-        slug,
-        now: new Date("2026-04-20T10:00:00Z"),
-      });
+    const result = archiveSlugDir({
+      specsDir,
+      slug,
+      now: new Date("2026-04-20T10:00:00Z"),
+    });
 
-      expect(result.kind).toBe("archived");
-      const r = result as Extract<ArchiveResult, { kind: "archived" }>;
-      // Parent dir of the archive must be specsDir.
-      expect(path.dirname(r.archivedPath)).toBe(specsDir);
-    },
-  );
+    expect(result.kind).toBe("archived");
+    const r = result as Extract<ArchiveResult, { kind: "archived" }>;
+    // Parent dir of the archive must be specsDir.
+    expect(path.dirname(r.archivedPath)).toBe(specsDir);
+  });
 });
 
 describe("archiveSlugDir — collision handling", () => {
-  test(
-    "two calls with the same timestamp produce distinct archive dirs",
-    () => {
-      const slug = "demo";
-      const now = new Date("2026-04-20T12:00:00Z");
+  test("two calls with the same timestamp produce distinct archive dirs", () => {
+    const slug = "demo";
+    const now = new Date("2026-04-20T12:00:00Z");
 
-      // First run.
-      mkdirSync(path.join(specsDir, slug));
-      const r1 = archiveSlugDir({ specsDir, slug, now });
-      expect(r1.kind).toBe("archived");
+    // First run.
+    mkdirSync(path.join(specsDir, slug));
+    const r1 = archiveSlugDir({ specsDir, slug, now });
+    expect(r1.kind).toBe("archived");
 
-      // Second run (same timestamp, recreate slug dir).
-      mkdirSync(path.join(specsDir, slug));
-      const r2 = archiveSlugDir({ specsDir, slug, now });
-      expect(r2.kind).toBe("archived");
+    // Second run (same timestamp, recreate slug dir).
+    mkdirSync(path.join(specsDir, slug));
+    const r2 = archiveSlugDir({ specsDir, slug, now });
+    expect(r2.kind).toBe("archived");
 
-      const p1 = (r1 as Extract<ArchiveResult, { kind: "archived" }>)
-        .archivedPath;
-      const p2 = (r2 as Extract<ArchiveResult, { kind: "archived" }>)
-        .archivedPath;
+    const p1 = (r1 as Extract<ArchiveResult, { kind: "archived" }>)
+      .archivedPath;
+    const p2 = (r2 as Extract<ArchiveResult, { kind: "archived" }>)
+      .archivedPath;
 
-      // Must be distinct paths.
-      expect(p1).not.toBe(p2);
-      // Both must exist.
-      expect(existsSync(p1)).toBe(true);
-      expect(existsSync(p2)).toBe(true);
+    // Must be distinct paths.
+    expect(p1).not.toBe(p2);
+    // Both must exist.
+    expect(existsSync(p1)).toBe(true);
+    expect(existsSync(p2)).toBe(true);
 
-      // Second dir should have a collision suffix like -1.
-      const b2 = path.basename(p2);
-      expect(b2).toMatch(/-\d+$/);
-    },
-  );
+    // Second dir should have a collision suffix like -1.
+    const b2 = path.basename(p2);
+    expect(b2).toMatch(/-\d+$/);
+  });
 
-  test(
-    "third collision produces -2 suffix",
-    () => {
-      const slug = "demo";
-      const now = new Date("2026-04-20T12:00:00Z");
+  test("third collision produces -2 suffix", () => {
+    const slug = "demo";
+    const now = new Date("2026-04-20T12:00:00Z");
 
-      mkdirSync(path.join(specsDir, slug));
-      const r1 = archiveSlugDir({ specsDir, slug, now });
-      mkdirSync(path.join(specsDir, slug));
-      const r2 = archiveSlugDir({ specsDir, slug, now });
-      mkdirSync(path.join(specsDir, slug));
-      const r3 = archiveSlugDir({ specsDir, slug, now });
+    mkdirSync(path.join(specsDir, slug));
+    const r1 = archiveSlugDir({ specsDir, slug, now });
+    mkdirSync(path.join(specsDir, slug));
+    const r2 = archiveSlugDir({ specsDir, slug, now });
+    mkdirSync(path.join(specsDir, slug));
+    const r3 = archiveSlugDir({ specsDir, slug, now });
 
-      expect(r1.kind).toBe("archived");
-      expect(r2.kind).toBe("archived");
-      expect(r3.kind).toBe("archived");
+    expect(r1.kind).toBe("archived");
+    expect(r2.kind).toBe("archived");
+    expect(r3.kind).toBe("archived");
 
-      const paths = [r1, r2, r3].map(
-        (r) =>
-          (r as Extract<ArchiveResult, { kind: "archived" }>).archivedPath,
-      );
-      // All distinct.
-      expect(new Set(paths).size).toBe(3);
-      // All exist.
-      for (const p of paths) expect(existsSync(p)).toBe(true);
-    },
-  );
+    const paths = [r1, r2, r3].map(
+      (r) => (r as Extract<ArchiveResult, { kind: "archived" }>).archivedPath,
+    );
+    // All distinct.
+    expect(new Set(paths).size).toBe(3);
+    // All exist.
+    for (const p of paths) expect(existsSync(p)).toBe(true);
+  });
 });
 
 describe("archiveSlugDir — listing existing archives", () => {
-  test(
-    "archived dirs appear in readdirSync of specsDir",
-    () => {
-      const slug = "report";
-      mkdirSync(path.join(specsDir, slug));
-      archiveSlugDir({
-        specsDir,
-        slug,
-        now: new Date("2026-04-20T09:30:00Z"),
-      });
+  test("archived dirs appear in readdirSync of specsDir", () => {
+    const slug = "report";
+    mkdirSync(path.join(specsDir, slug));
+    archiveSlugDir({
+      specsDir,
+      slug,
+      now: new Date("2026-04-20T09:30:00Z"),
+    });
 
-      const entries = readdirSync(specsDir);
-      // At least one entry matching the archive pattern.
-      const archiveEntries = entries.filter((e) =>
-        e.includes(".archived-"),
-      );
-      expect(archiveEntries.length).toBeGreaterThan(0);
-    },
-  );
+    const entries = readdirSync(specsDir);
+    // At least one entry matching the archive pattern.
+    const archiveEntries = entries.filter((e) => e.includes(".archived-"));
+    expect(archiveEntries.length).toBeGreaterThan(0);
+  });
 });

--- a/tests/cli/new.test.ts
+++ b/tests/cli/new.test.ts
@@ -339,11 +339,12 @@ describe("samospec new --force (issue #63)", () => {
     const content = JSON.parse(stateRaw) as Record<string, unknown>;
     expect(content).not.toHaveProperty("old");
 
-    // A bak dir matching the pattern must exist.
+    // An archived dir matching the SPEC §10 pattern must exist.
     const specDir = path.join(tmp, ".samo", "spec");
     const entries = readdirSync(specDir);
-    const bakDirs = entries.filter((e) => e.startsWith("demo.bak."));
-    expect(bakDirs.length).toBe(1);
+    // SPEC §10 / #69: must use .archived-<ts>, not .bak.<ts>.
+    const archiveDirs = entries.filter((e) => e.startsWith("demo.archived-"));
+    expect(archiveDirs.length).toBe(1);
   });
 
   test("force=false + existing dir => exit 1 (unchanged behaviour)", async () => {


### PR DESCRIPTION
## Summary

- **#72** Auto-initialize git repo on first `samospec init`: if `.git` is missing, prompt `[I]nit/[A]bort` (or auto-init with `--yes`/`yes: true`); creates `git init` + empty commit `chore: init`. Abort → exit 3, disk untouched.
- **#65** Empty-repo (no commits) auto-fix: if `.git` exists but HEAD is unresolvable, automatically create an initial empty commit before proceeding when caller opts in (`yes: true` or `gitInitAnswer`). Backward-compatible with existing tests that call `runInit` without flags.
- **#69** Fix `--force` archive path: was `.samo/spec/<slug>.bak.<ts>/`, now `.samo/spec/<slug>.archived-<YYYY-MM-DDThhmmssZ>/` per SPEC §10. New `src/cli/archive.ts` module with `archiveSlugDir()` + `makeArchiveTimestamp()`. Collision-safe: same-second runs append `-1`, `-2`, …

Closes #72, closes #65, closes #69.

## Changes

- `src/cli/init.ts` — git preflight (`yes`/`gitInitAnswer` opt-in, backward-compatible), empty-repo auto-commit with identity setup for CI.
- `src/cli/archive.ts` — new module: `archiveSlugDir()`, `makeArchiveTimestamp()`.
- `src/cli/new.ts` — switch `--force` archive to use `archiveSlugDir()` (`.archived-<ts>` naming).
- `tests/cli/init-auto-git.test.ts` — 5 tests for #72.
- `tests/cli/init-empty-repo.test.ts` — 4 tests for #65.
- `tests/cli/new-force-archive-name.test.ts` — 7 tests for #69.
- `tests/cli/new.test.ts` — update `--force` test to assert `.archived-` dir (not `.bak.`).

## Test plan

- [ ] `bun test tests/cli/init-auto-git.test.ts` — 5 pass
- [ ] `bun test tests/cli/init-empty-repo.test.ts` — 4 pass
- [ ] `bun test tests/cli/new-force-archive-name.test.ts` — 7 pass
- [ ] `bun test` — 1261 pass, 0 fail
- [ ] `bun run typecheck` — clean
- [ ] `prettier --check "src/**/*.ts" "tests/**/*.ts"` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)