### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.3.0] - 2026-04-21
+
+### Added
+
+- (describe additions)
+
+### Fixed
+
+- (describe fixes)
+
+### Changed
+
+- (describe changes)
+
 All notable changes to SamoSpec are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samospec",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Git-native CLI that turns a rough idea into a reviewed, versioned specification document.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release prep. Paired with v0.3.0 tag + release notes.