### PR TITLE
fix: wire auto-git-init CLI entry + codex subscription_auth detection (#79 #80)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,9 +95,8 @@ export async function runCli(argv: readonly string[]): Promise<CliResult> {
   }
 
   if (command === "init") {
-    // Sprint 1 init takes no flags; ignore unused args.
-    void rest;
-    return runInit({ cwd: process.cwd() });
+    const yes = rest.includes("--yes") || rest.includes("--no-interactive");
+    return runInit({ cwd: process.cwd(), ...(yes ? { yes: true } : {}) });
   }
 
   if (command === "doctor") {

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -28,6 +28,7 @@ import path from "node:path";
 
 import { archiveSlugDir } from "./archive.ts";
 
+import { CodexAdapter } from "../adapter/codex.ts";
 import type { Adapter } from "../adapter/types.ts";
 import { discoverContext } from "../context/discover.ts";
 import { contextJsonPath } from "../context/provenance.ts";
@@ -139,6 +140,13 @@ export interface RunNewInput {
    * per-seat dumps and full prompt echoes are gated behind verbose=true.
    */
   readonly verbose?: boolean;
+  /**
+   * Test seam: inject a pre-built reviewer_a adapter so that
+   * resolveSubscriptionAuth can be controlled in tests without spawning
+   * a real codex binary. Production code omits this and uses
+   * `new CodexAdapter()`.
+   */
+  readonly reviewerAAdapter?: Adapter;
 }
 
 // ---------- CLI entry ----------
@@ -214,10 +222,17 @@ export async function runNew(
 
   try {
     // Preflight cost estimate (SPEC §5 Phase 1 + §11).
+    const reviewerAAdapter: Adapter =
+      input.reviewerAAdapter ?? new CodexAdapter();
+    const [leadSubAuth, reviewerASubAuth] = await Promise.all([
+      resolveSubscriptionAuth(adapter),
+      resolveSubscriptionAuth(reviewerAAdapter),
+    ]);
     const preflightRes = runPreflight({
       cwd: input.cwd,
       adapter,
-      subscriptionAuth: await resolveSubscriptionAuth(adapter),
+      subscriptionAuth: leadSubAuth,
+      reviewerASubscriptionAuth: reviewerASubAuth,
     });
     if (preflightRes.ok) {
       notice(preflightRes.text);
@@ -650,6 +665,7 @@ function runPreflight(args: {
   cwd: string;
   adapter: Adapter;
   subscriptionAuth: boolean;
+  reviewerASubscriptionAuth?: boolean;
 }): PreflightRunOk | PreflightRunSkipped {
   const configPath = path.join(args.cwd, ".samo", "config.json");
   if (!existsSync(configPath)) {
@@ -689,7 +705,7 @@ function runPreflight(args: {
       id: "reviewer_a",
       vendor: config.adapters.reviewer_a.adapter,
       role: "reviewer_a",
-      subscription_auth: false,
+      subscription_auth: args.reviewerASubscriptionAuth ?? false,
     },
     {
       id: "reviewer_b",

--- a/tests/cli/init-auto-git-e2e.test.ts
+++ b/tests/cli/init-auto-git-e2e.test.ts
@@ -1,0 +1,124 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED e2e CLI tests for #79 — `runInitCommand` must pass `--yes`
+// through to `runInit` so that the auto-git-init path fires when the
+// user runs `samospec init --yes` in a directory with no `.git`.
+//
+// These tests exercise the full `runCli` → `runInitCommand` → `runInit`
+// path, NOT the `runInit` unit in isolation. The unit tests
+// (tests/cli/init-auto-git.test.ts) already passed on main — the bug
+// is that the CLI entry never forwarded the flag.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+// Run the CLI entry directly (not via subprocess) so we can change cwd.
+// We drive it via the real src/main.ts as a subprocess so the working
+// directory is respected, matching how a real user invokes the tool.
+const CLI_PATH = path.resolve(
+  import.meta.dir,
+  "..",
+  "..",
+  "src",
+  "main.ts",
+);
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-autogit-e2e-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function runCli(
+  args: readonly string[],
+  cwd: string,
+): { stdout: string; stderr: string; status: number } {
+  const bun = Bun.argv[0];
+  const result = spawnSync(bun, ["run", CLI_PATH, ...(args as string[])], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NO_COLOR: "1",
+    },
+    timeout: 15_000,
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status ?? 1,
+  };
+}
+
+function hasGitDir(dir: string): boolean {
+  return existsSync(path.join(dir, ".git"));
+}
+
+function headCommit(dir: string): string | null {
+  const res = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: dir,
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+  if (res.status !== 0) return null;
+  return res.stdout.trim();
+}
+
+function commitCount(dir: string): number {
+  const res = spawnSync("git", ["rev-list", "--count", "HEAD"], {
+    cwd: dir,
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+  if (res.status !== 0) return 0;
+  return parseInt(res.stdout.trim(), 10);
+}
+
+// RED: Must fail on current main because `runInitCommand` passes
+// `{ cwd }` to `runInit` without forwarding `--yes`.
+describe("#79 — e2e CLI: `samospec init --yes` in a dir with no .git", () => {
+  test("creates .git/ directory", () => {
+    expect(hasGitDir(tmp)).toBe(false);
+
+    const result = runCli(["init", "--yes"], tmp);
+
+    // Exit 0 — init must succeed.
+    expect(result.status).toBe(0);
+    // .git must exist (the CLI wired --yes → auto-init).
+    expect(hasGitDir(tmp)).toBe(true);
+  });
+
+  test("creates exactly 1 initial commit", () => {
+    expect(hasGitDir(tmp)).toBe(false);
+
+    runCli(["init", "--yes"], tmp);
+
+    // HEAD must be resolvable (commit was created).
+    const head = headCommit(tmp);
+    expect(head).not.toBeNull();
+    // Exactly 1 commit (the initial empty commit from git-init helper).
+    expect(commitCount(tmp)).toBe(1);
+  });
+
+  test("also creates .samo/ alongside .git/", () => {
+    runCli(["init", "--yes"], tmp);
+
+    expect(existsSync(path.join(tmp, ".samo"))).toBe(true);
+    expect(existsSync(path.join(tmp, ".samo", "config.json"))).toBe(true);
+  });
+
+  test("stdout mentions git repo creation", () => {
+    const result = runCli(["init", "--yes"], tmp);
+    // The runInit helper emits "created git repo and initial commit".
+    expect(result.stdout.toLowerCase()).toMatch(
+      /created git repo|git init|git repo/,
+    );
+  });
+});

--- a/tests/cli/init-auto-git-e2e.test.ts
+++ b/tests/cli/init-auto-git-e2e.test.ts
@@ -18,13 +18,7 @@ import { spawnSync } from "node:child_process";
 // Run the CLI entry directly (not via subprocess) so we can change cwd.
 // We drive it via the real src/main.ts as a subprocess so the working
 // directory is respected, matching how a real user invokes the tool.
-const CLI_PATH = path.resolve(
-  import.meta.dir,
-  "..",
-  "..",
-  "src",
-  "main.ts",
-);
+const CLI_PATH = path.resolve(import.meta.dir, "..", "..", "src", "main.ts");
 
 let tmp: string;
 

--- a/tests/cli/preflight-codex-oauth-e2e.test.ts
+++ b/tests/cli/preflight-codex-oauth-e2e.test.ts
@@ -26,29 +26,14 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
-const CLI_PATH = path.resolve(
-  import.meta.dir,
-  "..",
-  "..",
-  "src",
-  "main.ts",
-);
-
-const FAKE_CLI_TS = path.resolve(
-  import.meta.dir,
-  "..",
-  "fixtures",
-  "fake-cli.ts",
-);
+const CLI_PATH = path.resolve(import.meta.dir, "..", "..", "src", "main.ts");
 
 let tmp: string;
 let fakeBinDir: string;
-let samoDir: string;
 
 beforeEach(() => {
   tmp = mkdtempSync(path.join(tmpdir(), "samospec-preflight-e2e-"));
   fakeBinDir = mkdtempSync(path.join(tmpdir(), "samospec-fakebin-e2e-"));
-  samoDir = path.join(tmp, ".samo");
 
   // Create a real git repo on a non-protected branch so new can proceed.
   spawnSync("git", ["init", "--initial-branch", "work", tmp], {

--- a/tests/cli/preflight-codex-oauth-e2e.test.ts
+++ b/tests/cli/preflight-codex-oauth-e2e.test.ts
@@ -1,0 +1,219 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED e2e CLI tests for #80 — when `OPENAI_API_KEY` is absent in the
+// spawned process environment (ChatGPT OAuth mode), the `samospec new`
+// preflight must show `unknown — OAuth` for reviewer_a, NOT a dollar
+// estimate such as `$1.88`.
+//
+// The bug: `runPreflight()` in src/cli/new.ts hardcodes
+// `subscription_auth: false` for reviewer_a regardless of what
+// `CodexAdapter.auth_status()` returns. Unit tests (preflight-codex-
+// oauth.test.ts) pass because they inject subscription_auth directly;
+// the CLI never actually calls auth_status() for reviewer_a.
+//
+// Fix: query the reviewer_a adapter's auth_status() and forward the
+// result into runPreflight so computePreflight sees the correct flag.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const CLI_PATH = path.resolve(
+  import.meta.dir,
+  "..",
+  "..",
+  "src",
+  "main.ts",
+);
+
+const FAKE_CLI_TS = path.resolve(
+  import.meta.dir,
+  "..",
+  "fixtures",
+  "fake-cli.ts",
+);
+
+let tmp: string;
+let fakeBinDir: string;
+let samoDir: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-preflight-e2e-"));
+  fakeBinDir = mkdtempSync(path.join(tmpdir(), "samospec-fakebin-e2e-"));
+  samoDir = path.join(tmp, ".samo");
+
+  // Create a real git repo on a non-protected branch so new can proceed.
+  spawnSync("git", ["init", "--initial-branch", "work", tmp], {
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+  spawnSync("git", ["commit", "--allow-empty", "-m", "chore: init"], {
+    cwd: tmp,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "test",
+      GIT_AUTHOR_EMAIL: "test@example.invalid",
+      GIT_COMMITTER_NAME: "test",
+      GIT_COMMITTER_EMAIL: "test@example.invalid",
+    },
+  });
+
+  // Set up fake claude binary. It must handle:
+  //   1. `claude --version` → version string (for detect)
+  //   2. `claude -p <flags> ...` → valid persona JSON (for ask)
+  //   3. subsequent calls → valid structured JSON
+  // We use a simple bun script wrapper around fake-cli.ts.
+  const fakeClaude = path.join(fakeBinDir, "claude");
+  writeFileSync(
+    fakeClaude,
+    // Return a valid persona JSON for all non-version calls so that
+    // `samospec new` can complete past the preflight + persona stages.
+    `#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  echo "1.0.0"
+  exit 0
+fi
+# For any work call: emit valid persona JSON (ask call).
+echo '{"persona":"Veteran \\"spec\\" expert","rationale":"test","usage":null,"effort_used":"max"}'
+exit 0
+`,
+  );
+  chmodSync(fakeClaude, 0o755);
+
+  // Create fake codex binary. It only needs to handle `--version`
+  // (for auth_status / detect). It is NOT called during `samospec new`
+  // (only during `iterate`), but it must be on PATH so the adapter
+  // sees it as installed and returns authenticated: true.
+  const fakeCodex = path.join(fakeBinDir, "codex");
+  writeFileSync(
+    fakeCodex,
+    `#!/usr/bin/env bash
+echo "0.1.0"
+exit 0
+`,
+  );
+  chmodSync(fakeCodex, 0o755);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  rmSync(fakeBinDir, { recursive: true, force: true });
+});
+
+function runSamospecNew(slug: string): {
+  stdout: string;
+  stderr: string;
+  status: number;
+} {
+  const bun = Bun.argv[0];
+  // Build minimal env: inject fake bins first in PATH, remove API keys.
+  const baseEnv = { ...process.env };
+  delete baseEnv["OPENAI_API_KEY"];
+  // We keep ANTHROPIC_API_KEY absent too, but claude may be subscription.
+  // The key check is: OPENAI_API_KEY is absent → reviewer_a OAuth.
+  const env: Record<string, string> = {
+    ...baseEnv,
+    PATH: `${fakeBinDir}:${baseEnv["PATH"] ?? "/usr/bin:/bin"}`,
+    NO_COLOR: "1",
+    HOME: tmp,
+  } as Record<string, string>;
+  // Ensure OPENAI_API_KEY is truly absent (delete any residual).
+  delete env["OPENAI_API_KEY"];
+
+  // Run with a timeout; the preflight is printed before any AI call,
+  // so even if the process later fails it will have already emitted it.
+  const result = spawnSync(
+    bun,
+    ["run", CLI_PATH, "new", slug, "--idea", "test"],
+    {
+      cwd: tmp,
+      encoding: "utf8",
+      env,
+      // Pipe "\n" answers for any interactive prompts; timeout after 20s.
+      input: "\n\n\n\n\n",
+      timeout: 20_000,
+    },
+  );
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status ?? 1,
+  };
+}
+
+// Helper: find the reviewer_a line in the per-adapter block.
+function findReviewerALine(stdout: string): string | null {
+  const lines = stdout.split("\n");
+  for (const line of lines) {
+    if (line.includes("reviewer_a")) return line;
+  }
+  return null;
+}
+
+// RED: must fail on current main because runPreflight hardcodes
+// subscription_auth: false for reviewer_a.
+describe("#80 — e2e CLI: samospec new preflight reviewer_a under ChatGPT OAuth", () => {
+  test("reviewer_a preflight line contains 'unknown — OAuth'", () => {
+    // samospec init first (need config.json for preflight).
+    const bun = Bun.argv[0];
+    const baseEnv = { ...process.env };
+    delete baseEnv["OPENAI_API_KEY"];
+    const initEnv = {
+      ...baseEnv,
+      PATH: `${fakeBinDir}:${baseEnv["PATH"] ?? "/usr/bin:/bin"}`,
+      NO_COLOR: "1",
+      HOME: tmp,
+    } as Record<string, string>;
+    spawnSync(bun, ["run", CLI_PATH, "init", "--yes"], {
+      cwd: tmp,
+      encoding: "utf8",
+      env: initEnv,
+      timeout: 15_000,
+    });
+    expect(existsSync(path.join(tmp, ".samo", "config.json"))).toBe(true);
+
+    const result = runSamospecNew("demo");
+
+    // Extract the reviewer_a line from stdout.
+    const reviewerLine = findReviewerALine(result.stdout);
+    expect(reviewerLine).not.toBeNull();
+
+    // KEY assertion: must say "OAuth" (not a dollar amount).
+    expect(reviewerLine).toContain("OAuth");
+  });
+
+  test("reviewer_a preflight line does NOT contain a dollar amount", () => {
+    const bun = Bun.argv[0];
+    const baseEnv = { ...process.env };
+    delete baseEnv["OPENAI_API_KEY"];
+    const initEnv = {
+      ...baseEnv,
+      PATH: `${fakeBinDir}:${baseEnv["PATH"] ?? "/usr/bin:/bin"}`,
+      NO_COLOR: "1",
+      HOME: tmp,
+    } as Record<string, string>;
+    spawnSync(bun, ["run", CLI_PATH, "init", "--yes"], {
+      cwd: tmp,
+      encoding: "utf8",
+      env: initEnv,
+      timeout: 15_000,
+    });
+
+    const result = runSamospecNew("demo");
+
+    const reviewerLine = findReviewerALine(result.stdout);
+    expect(reviewerLine).not.toBeNull();
+
+    // Must NOT contain a dollar price like "$1.88".
+    expect(reviewerLine).not.toMatch(/\$\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
## Summary

- **#79**: `runInitCommand` in `src/cli.ts` was calling `runInit({ cwd })` with `void rest`, so the `--yes` flag was silently dropped. `samospec init --yes` never triggered auto-git-init even though `runInit` supported it. Fix: parse `--yes` / `--no-interactive` and forward `yes: true`.
- **#80**: `runPreflight()` in `src/cli/new.ts` had `subscription_auth: false` hardcoded for reviewer_a (Codex), so when `OPENAI_API_KEY` is absent (ChatGPT OAuth), the preflight showed `$1.88` instead of `unknown — OAuth`. Fix: resolve `CodexAdapter.auth_status()` in parallel with the lead adapter and forward `reviewerASubscriptionAuth` into `runPreflight`.

Both are "unit test passes, CLI path never invokes helper" bugs.

## Manual repro transcripts

### #79 — `samospec init --yes` now creates a git repo

```
$ cd /tmp && mkdir demo && cd demo
$ bun run /path/to/src/main.ts init --yes
samospec: initialized .samo/ in /tmp/demo
created git repo and initial commit (chore: init)
created .samo/.gitignore
created .samo/config.json
$ ls -la
drwxr-xr-x  .git
drwxr-xr-x  .samo
$ git log --oneline
fc6f87a chore: init
```

### #80 — reviewer_a shows OAuth label when `OPENAI_API_KEY` is absent

```
$ cd /tmp/demo2 && git init -q && git commit --allow-empty -qm "chore: init"
$ env -u OPENAI_API_KEY bun run /path/to/src/main.ts init --yes
$ printf '\n\n\n\n\n' | env -u OPENAI_API_KEY timeout 15 bun run /path/to/src/main.ts new demo --idea "test" 2>&1 | grep reviewer
  reviewer_a: ~75K tokens, unknown — OAuth (no per-token cost visibility)
  reviewer_b: ~75K tokens, $3.00
  1 adapter(s) under OAuth; wall-clock + iteration caps substitute for token/cost budget
```

## Test plan

- [x] `bun run typecheck` — clean (0 errors)
- [x] `bun test` — 1278 pass, 0 fail
- [x] `bun run format:check` — clean
- [x] RED tests committed first (`test: RED for #79 #80 e2e CLI assertions`)
- [x] GREEN fix committed (`fix: wire auto-git-init CLI entry + codex subscription_auth detection (#79 #80)`)
- [x] Manual verification of both fixes above

Closes #79
Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)