### PR TITLE
fix: enforce per-call timeout + session wall-clock in runNew (#81)

### DIFF
--- a/src/adapter/spawn.ts
+++ b/src/adapter/spawn.ts
@@ -137,9 +137,11 @@ export async function spawnCli(input: SpawnCliInput): Promise<SpawnCliResult> {
     // ignore: child may have already exited.
   }
 
+  const ac = new AbortController();
   let timedOut = false;
   const timer = setTimeout(() => {
     timedOut = true;
+    ac.abort();
     try {
       proc.kill("SIGKILL");
     } catch {
@@ -147,10 +149,56 @@ export async function spawnCli(input: SpawnCliInput): Promise<SpawnCliResult> {
     }
   }, input.timeoutMs);
 
+  // Bun's `new Response(stream).text()` blocks even after SIGKILL because
+  // the pipe FD doesn't close immediately. We use a manual reader with
+  // Promise.race against an abort signal so the stream read unblocks on
+  // timeout without waiting for EOF (#81).
+  async function readStream(
+    stream: ReadableStream<Uint8Array>,
+  ): Promise<string> {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    let onAbort: (() => void) | undefined;
+    const abortPromise = new Promise<never>((_resolve, reject) => {
+      if (ac.signal.aborted) {
+        reject(new DOMException("aborted", "AbortError"));
+        return;
+      }
+      onAbort = () => reject(new DOMException("aborted", "AbortError"));
+      ac.signal.addEventListener("abort", onAbort, { once: true });
+    });
+    try {
+      for (;;) {
+        const { done, value } = await Promise.race([
+          reader.read(),
+          abortPromise,
+        ]);
+        if (done) break;
+        if (value !== undefined) chunks.push(value);
+      }
+    } catch {
+      void reader.cancel().catch(() => {
+        /* ignore */
+      });
+    } finally {
+      if (onAbort !== undefined)
+        ac.signal.removeEventListener("abort", onAbort);
+      reader.releaseLock();
+    }
+    const totalLength = chunks.reduce((n, c) => n + c.length, 0);
+    const merged = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return new TextDecoder().decode(merged);
+  }
+
   const [stdoutText, stderrText, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
+    readStream(proc.stdout),
+    readStream(proc.stderr),
+    proc.exited.catch(() => -1),
   ]);
   clearTimeout(timer);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,7 @@ const USAGE =
   "  init                        Create or refresh .samo/ in the current repo.\n" +
   "  doctor                      Diagnose CLI availability, auth, git, lock, and config.\n" +
   "  new <slug> [--idea ...] [--force] [--skip <sections>]\n" +
+  "            [--max-session-wall-clock-ms <ms>]\n" +
   "                              Start a new spec (persona + 5-question interview).\n" +
   "                              --force archives any existing run before starting\n" +
   "                              fresh. --skip omits named baseline sections from\n" +
@@ -54,6 +55,11 @@ const USAGE =
   "                              case-insensitive). Valid sections: " +
   BASELINE_SECTION_NAMES.join(", ") +
   ".\n" +
+  "                              --max-session-wall-clock-ms caps the total session\n" +
+  "                              wall-clock time (positive integer ms); defaults to\n" +
+  "                              budget.max_session_wall_clock_minutes in config.json\n" +
+  "                              or 600000 (10 min). On cap, exits 4 with reason\n" +
+  "                              `session-wall-clock`.\n" +
   "  resume [<slug>]             Resume an in-progress spec from state.json.\n" +
   "  iterate [<slug>] [--rounds N] [--no-push] [--remote <name>]\n" +
   "                              Run review rounds until a stopping condition fires.\n" +
@@ -144,6 +150,7 @@ interface NewArgs {
   readonly explain: boolean;
   readonly skipSections?: readonly string[];
   readonly force: boolean;
+  readonly maxSessionWallClockMs?: number;
 }
 
 interface ResumeArgs {
@@ -199,6 +206,7 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
   let explain = false;
   let force = false;
   let skipSections: readonly string[] | undefined;
+  let maxSessionWallClockMs: number | undefined;
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
     if (token === undefined) continue;
@@ -234,6 +242,21 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
       skipSections = parsed;
       continue;
     }
+    if (token === "--max-session-wall-clock-ms") {
+      const raw = argv[i + 1] ?? "";
+      i += 1;
+      const parsed = parseMaxSessionWallClockMs(raw);
+      if (typeof parsed === "string") return parsed;
+      maxSessionWallClockMs = parsed;
+      continue;
+    }
+    if (token.startsWith("--max-session-wall-clock-ms=")) {
+      const raw = token.slice("--max-session-wall-clock-ms=".length);
+      const parsed = parseMaxSessionWallClockMs(raw);
+      if (typeof parsed === "string") return parsed;
+      maxSessionWallClockMs = parsed;
+      continue;
+    }
     if (token.startsWith("--")) {
       // Unknown flags ignored (permissive for future flags).
       continue;
@@ -252,7 +275,35 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
     explain,
     force,
     ...(skipSections !== undefined ? { skipSections } : {}),
+    ...(maxSessionWallClockMs !== undefined ? { maxSessionWallClockMs } : {}),
   };
+}
+
+/**
+ * Parse and validate --max-session-wall-clock-ms. Accepts a positive
+ * integer string (digits only; no decimals, no scientific notation).
+ * Returns the integer ms on success, or an error string to be echoed
+ * above the USAGE line.
+ */
+function parseMaxSessionWallClockMs(raw: string): number | string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return "samospec new: --max-session-wall-clock-ms requires a value";
+  }
+  if (!/^\d+$/.test(trimmed)) {
+    return (
+      "samospec new: --max-session-wall-clock-ms must be a positive integer " +
+      `(got '${raw}')`
+    );
+  }
+  const n = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    return (
+      "samospec new: --max-session-wall-clock-ms must be a positive integer " +
+      `(got '${raw}')`
+    );
+  }
+  return n;
 }
 
 function parseResumeArgs(argv: readonly string[]): ResumeArgs | string {
@@ -359,6 +410,9 @@ async function runNewCommand(rest: readonly string[]) {
       now: new Date().toISOString(),
       ...(parsed.skipSections !== undefined
         ? { skipSections: [...parsed.skipSections] }
+        : {}),
+      ...(parsed.maxSessionWallClockMs !== undefined
+        ? { maxSessionWallClockMs: parsed.maxSessionWallClockMs }
         : {}),
     },
     adapter,

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -81,6 +81,11 @@ import {
 
 const DEFAULT_MAX_WALL_CLOCK_MIN = 240;
 
+// Session wall-clock cap: 10 minutes by default (#81).
+// Configurable via budget.max_session_wall_clock_minutes in config.json,
+// or overridden per-call via RunNewInput.maxSessionWallClockMs.
+const DEFAULT_SESSION_WALL_CLOCK_MS = 10 * 60 * 1_000;
+
 const V01_VERSION = "0.1.0" as const;
 
 export interface RunNewResult {
@@ -139,6 +144,99 @@ export interface RunNewInput {
    * per-seat dumps and full prompt echoes are gated behind verbose=true.
    */
   readonly verbose?: boolean;
+  /**
+   * Session wall-clock cap in milliseconds (#81). When the total elapsed
+   * time since runNew() entry exceeds this value, the current phase is
+   * preempted and runNew() returns exit 4 with a "session-wall-clock"
+   * message. Falls back to budget.max_session_wall_clock_minutes from
+   * config.json, then to DEFAULT_SESSION_WALL_CLOCK_MS (10 min).
+   */
+  readonly maxSessionWallClockMs?: number;
+}
+
+// ---------- session wall-clock guard (#81) ----------
+
+/** Thrown by withDeadline() when the session wall-clock cap is exceeded. */
+class SessionWallClockError extends Error {
+  readonly phase: string;
+  readonly elapsedMs: number;
+  readonly limitMs: number;
+  constructor(phase: string, elapsedMs: number, limitMs: number) {
+    super(
+      `session-wall-clock: ${phase} exceeded ${String(limitMs)}ms limit ` +
+        `(elapsed ${String(elapsedMs)}ms)`,
+    );
+    this.name = "SessionWallClockError";
+    this.phase = phase;
+    this.elapsedMs = elapsedMs;
+    this.limitMs = limitMs;
+  }
+}
+
+/**
+ * Race `promise` against a deadline derived from `startMs + limitMs`.
+ * If the deadline fires first, throws `SessionWallClockError`.
+ */
+async function withDeadline<T>(
+  promise: Promise<T>,
+  phase: string,
+  startMs: number,
+  limitMs: number,
+): Promise<T> {
+  const remaining = limitMs - (Date.now() - startMs);
+  if (remaining <= 0) {
+    throw new SessionWallClockError(phase, Date.now() - startMs, limitMs);
+  }
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new SessionWallClockError(phase, Date.now() - startMs, limitMs));
+    }, remaining);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e: unknown) => {
+        clearTimeout(timer);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      },
+    );
+  });
+}
+
+/**
+ * Resolve the session wall-clock limit (ms) from:
+ * 1. input.maxSessionWallClockMs (explicit override)
+ * 2. budget.max_session_wall_clock_minutes in config.json
+ * 3. DEFAULT_SESSION_WALL_CLOCK_MS (10 min)
+ */
+function resolveSessionWallClockMs(input: RunNewInput): number {
+  if (typeof input.maxSessionWallClockMs === "number") {
+    return input.maxSessionWallClockMs;
+  }
+  try {
+    const configPath = path.join(input.cwd, ".samo", "config.json");
+    if (existsSync(configPath)) {
+      const raw = readFileSync(configPath, "utf8");
+      const cfg = JSON.parse(raw) as Record<string, unknown>;
+      const budget = cfg["budget"];
+      if (
+        typeof budget === "object" &&
+        budget !== null &&
+        !Array.isArray(budget)
+      ) {
+        const minutes = (budget as Record<string, unknown>)[
+          "max_session_wall_clock_minutes"
+        ];
+        if (typeof minutes === "number" && minutes > 0) {
+          return Math.round(minutes * 60 * 1_000);
+        }
+      }
+    }
+  } catch {
+    // config unreadable — fall through to default.
+  }
+  return DEFAULT_SESSION_WALL_CLOCK_MS;
 }
 
 // ---------- CLI entry ----------
@@ -152,6 +250,10 @@ export async function runNew(
   const notice = (line: string): void => {
     lines.push(line);
   };
+
+  // Session wall-clock guard (#81): track start time and cap.
+  const sessionStartMs = Date.now();
+  const sessionLimitMs = resolveSessionWallClockMs(input);
 
   const samoDir = path.join(input.cwd, ".samo");
   const specsDir = path.join(samoDir, "spec");
@@ -323,17 +425,37 @@ export async function runNew(
     const subAuth = await resolveSubscriptionAuth(adapter);
     let persona: PersonaProposal;
     try {
-      persona = await proposePersonaInteractive(
-        {
-          idea: input.idea,
-          explain: input.explain,
-          subscriptionAuth: subAuth,
-          onNotice: notice,
-          resolver: input.resolvers.persona,
-        },
-        adapter,
+      persona = await withDeadline(
+        proposePersonaInteractive(
+          {
+            idea: input.idea,
+            explain: input.explain,
+            subscriptionAuth: subAuth,
+            onNotice: notice,
+            resolver: input.resolvers.persona,
+          },
+          adapter,
+        ),
+        "persona",
+        sessionStartMs,
+        sessionLimitMs,
       );
     } catch (err) {
+      if (err instanceof SessionWallClockError) {
+        state = { ...state, round_state: "lead_terminal" };
+        state.updated_at = input.now;
+        writeState(statePath, state);
+        errors.push(
+          `samospec: session-wall-clock exceeded at persona phase ` +
+            `(${String(err.elapsedMs)}ms elapsed, limit ${String(err.limitMs)}ms). ` +
+            `Restart with --force or increase budget.max_session_wall_clock_minutes.`,
+        );
+        return {
+          exitCode: 4,
+          stdout: lines.join("\n"),
+          stderr: `${errors.join("\n")}\n`,
+        };
+      }
       if (err instanceof PersonaTerminalError) {
         state = { ...state, round_state: "lead_terminal" };
         state.updated_at = input.now;
@@ -407,20 +529,40 @@ export async function runNew(
     const interviewPath = path.join(slugDir, "interview.json");
     let interview: InterviewResult;
     try {
-      interview = await runInterview(
-        {
-          slug: input.slug,
-          persona: persona.persona,
-          explain: input.explain,
-          subscriptionAuth: subAuth,
-          onQuestion: input.resolvers.question,
-          onNotice: notice,
-          outputPath: interviewPath,
-          now: input.now,
-        },
-        adapter,
+      interview = await withDeadline(
+        runInterview(
+          {
+            slug: input.slug,
+            persona: persona.persona,
+            explain: input.explain,
+            subscriptionAuth: subAuth,
+            onQuestion: input.resolvers.question,
+            onNotice: notice,
+            outputPath: interviewPath,
+            now: input.now,
+          },
+          adapter,
+        ),
+        "interview",
+        sessionStartMs,
+        sessionLimitMs,
       );
     } catch (err) {
+      if (err instanceof SessionWallClockError) {
+        state = { ...state, round_state: "lead_terminal" };
+        state.updated_at = input.now;
+        writeState(statePath, state);
+        errors.push(
+          `samospec: session-wall-clock exceeded at interview phase ` +
+            `(${String(err.elapsedMs)}ms elapsed, limit ${String(err.limitMs)}ms). ` +
+            `Restart with --force or increase budget.max_session_wall_clock_minutes.`,
+        );
+        return {
+          exitCode: 4,
+          stdout: lines.join("\n"),
+          stderr: `${errors.join("\n")}\n`,
+        };
+      }
       if (err instanceof InterviewTerminalError) {
         state = { ...state, round_state: "lead_terminal" };
         state.updated_at = input.now;
@@ -458,21 +600,41 @@ export async function runNew(
 
     let draft;
     try {
-      draft = await authorDraft(
-        {
-          slug: input.slug,
-          idea: input.idea,
-          persona: persona.persona,
-          interview,
-          contextChunks: chunks,
-          explain: input.explain,
-          ...(input.skipSections !== undefined
-            ? { skipSections: input.skipSections }
-            : {}),
-        },
-        adapter,
+      draft = await withDeadline(
+        authorDraft(
+          {
+            slug: input.slug,
+            idea: input.idea,
+            persona: persona.persona,
+            interview,
+            contextChunks: chunks,
+            explain: input.explain,
+            ...(input.skipSections !== undefined
+              ? { skipSections: input.skipSections }
+              : {}),
+          },
+          adapter,
+        ),
+        "draft",
+        sessionStartMs,
+        sessionLimitMs,
       );
     } catch (err) {
+      if (err instanceof SessionWallClockError) {
+        state = { ...state, round_state: "lead_terminal" };
+        state.updated_at = input.now;
+        writeState(statePath, state);
+        errors.push(
+          `samospec: session-wall-clock exceeded at draft phase ` +
+            `(${String(err.elapsedMs)}ms elapsed, limit ${String(err.limitMs)}ms). ` +
+            `Restart with --force or increase budget.max_session_wall_clock_minutes.`,
+        );
+        return {
+          exitCode: 4,
+          stdout: lines.join("\n"),
+          stderr: `${errors.join("\n")}\n`,
+        };
+      }
       if (err instanceof DraftTerminalError) {
         state = { ...state, round_state: "lead_terminal" };
         state.updated_at = input.now;

--- a/tests/adapter/claude-spawn-timeout.test.ts
+++ b/tests/adapter/claude-spawn-timeout.test.ts
@@ -1,0 +1,128 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED test for #81: per-call spawn timeout must kill the child process
+// and the Promise must resolve within ~timeoutMs (not hang waiting for
+// stream EOF after SIGKILL).
+//
+// Fake CLI = `sleep 3600` equivalent via bun -e.
+// Adapter ask({ timeout: 2000 }) must return a timeout-classified error
+// within ~3s AND the child PID must be dead.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+
+import { ClaudeAdapter, ClaudeAdapterError } from "../../src/adapter/claude.ts";
+import { spawnCli, type SpawnCliInput, type SpawnCliResult } from "../../src/adapter/spawn.ts";
+
+const BUN_DIR = dirname(process.execPath);
+
+const TMP: string[] = [];
+
+function makeFakeBinaryDir(name: string, script: string): { dir: string; binary: string } {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-timeout-bin-"));
+  TMP.push(dir);
+  const binary = join(dir, name);
+  writeFileSync(binary, `#!/bin/sh\n${script}\n`);
+  chmodSync(binary, 0o755);
+  return { dir, binary };
+}
+
+afterAll(() => {
+  for (const d of TMP) {
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+describe("spawnCli timeout: child PID must be dead after timeout fires (#81)", () => {
+  test("spawnCli returns { ok:false, reason:'timeout' } and the child is dead within 3x timeoutMs", async () => {
+    // Use a shell script that sleeps forever and reports its PID to stdout first.
+    const dir = mkdtempSync(join(tmpdir(), "samospec-pid-track-"));
+    TMP.push(dir);
+    const pidFile = join(dir, "child.pid");
+    const { dir: binDir, binary } = makeFakeBinaryDir(
+      "fake-sleep",
+      `echo $$ > ${pidFile}\nsleep 3600`,
+    );
+
+    const startMs = Date.now();
+    const result = await spawnCli({
+      cmd: [binary],
+      stdin: "",
+      env: {},
+      timeoutMs: 1500,
+      host: { PATH: `${binDir}:/bin:/usr/bin`, HOME: "/tmp" },
+    });
+    const elapsedMs = Date.now() - startMs;
+
+    // Must resolve as a timeout failure.
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("timeout");
+
+    // Must resolve within 3x timeout (generous for CI overhead).
+    expect(elapsedMs).toBeLessThan(1500 * 3);
+
+    // Child PID must be dead — if `process.kill(pid, 0)` throws ESRCH, it's dead.
+    // Give the OS a small moment to reap the process.
+    await new Promise((r) => setTimeout(r, 200));
+    const { readFileSync, existsSync } = await import("node:fs");
+    if (existsSync(pidFile)) {
+      const pidStr = readFileSync(pidFile, "utf8").trim();
+      const pid = parseInt(pidStr, 10);
+      if (!isNaN(pid)) {
+        let processAlive = false;
+        try {
+          process.kill(pid, 0);
+          processAlive = true;
+        } catch {
+          // ESRCH = not found = dead. Expected.
+          processAlive = false;
+        }
+        expect(processAlive).toBe(false);
+      }
+    }
+  });
+});
+
+describe("ClaudeAdapter.ask timeout: classified error within 3s for hanging CLI (#81)", () => {
+  test("adapter.ask({ timeout: 2000 }) returns ClaudeAdapterError with reason='timeout' when CLI hangs", async () => {
+    // Build a hanging fake 'claude' binary that sleeps forever.
+    const { dir, binary } = makeFakeBinaryDir("claude", "sleep 3600");
+
+    const adapter = new ClaudeAdapter({
+      binary,
+      host: {
+        PATH: `${dir}:/bin:/usr/bin`,
+        HOME: "/tmp",
+        ANTHROPIC_API_KEY: "sk-fake",
+      },
+    });
+
+    const startMs = Date.now();
+    let caughtErr: unknown = null;
+    try {
+      await adapter.ask({
+        prompt: "hello",
+        context: "",
+        opts: { effort: "max", timeout: 2000 },
+      });
+    } catch (err) {
+      caughtErr = err;
+    }
+    const elapsedMs = Date.now() - startMs;
+
+    // Must throw a ClaudeAdapterError with reason 'timeout'.
+    expect(caughtErr).toBeInstanceOf(ClaudeAdapterError);
+    if (caughtErr instanceof ClaudeAdapterError) {
+      expect(caughtErr.payload.reason).toBe("timeout");
+    }
+
+    // The worst-case capped retry for a 2000ms base is 2000+3000+2000=7000ms.
+    // Must resolve within 3.5x * timeout * 3 retries + generous padding = ~25s.
+    // But with the fix applied (stream abort), it should be well under 10s.
+    // For a RED test we want to verify it resolves at all (not hang for 22 min).
+    expect(elapsedMs).toBeLessThan(25_000);
+  }, 30_000);
+});

--- a/tests/adapter/claude-spawn-timeout.test.ts
+++ b/tests/adapter/claude-spawn-timeout.test.ts
@@ -11,16 +11,17 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, dirname } from "node:path";
+import { join } from "node:path";
 
 import { ClaudeAdapter, ClaudeAdapterError } from "../../src/adapter/claude.ts";
-import { spawnCli, type SpawnCliInput, type SpawnCliResult } from "../../src/adapter/spawn.ts";
-
-const BUN_DIR = dirname(process.execPath);
+import { spawnCli } from "../../src/adapter/spawn.ts";
 
 const TMP: string[] = [];
 
-function makeFakeBinaryDir(name: string, script: string): { dir: string; binary: string } {
+function makeFakeBinaryDir(
+  name: string,
+  script: string,
+): { dir: string; binary: string } {
   const dir = mkdtempSync(join(tmpdir(), "samospec-timeout-bin-"));
   TMP.push(dir);
   const binary = join(dir, name);
@@ -31,7 +32,11 @@ function makeFakeBinaryDir(name: string, script: string): { dir: string; binary:
 
 afterAll(() => {
   for (const d of TMP) {
-    try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
   }
 });
 

--- a/tests/adapter/claude-spawn-timeout.test.ts
+++ b/tests/adapter/claude-spawn-timeout.test.ts
@@ -82,8 +82,7 @@ describe("spawnCli timeout: child PID must be dead after timeout fires (#81)", (
           process.kill(pid, 0);
           processAlive = true;
         } catch {
-          // ESRCH = not found = dead. Expected.
-          processAlive = false;
+          // ESRCH = not found = dead. Expected; leaves processAlive=false.
         }
         expect(processAlive).toBe(false);
       }

--- a/tests/cli/new-hang-recovery.test.ts
+++ b/tests/cli/new-hang-recovery.test.ts
@@ -34,20 +34,28 @@ function makeHangingAdapter(): Adapter {
   const auth: AuthStatus = { authenticated: true, subscription_auth: false };
   return {
     vendor: "fake-hang",
-    detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+    detect: (): Promise<DetectResult> =>
+      Promise.resolve({ installed: true, version: "0", path: "/fake" }),
     auth_status: (): Promise<AuthStatus> => Promise.resolve(auth),
     supports_structured_output: () => true,
     supports_effort: (_level: EffortLevel) => true,
-    models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
+    models: (): Promise<readonly ModelInfo[]> =>
+      Promise.resolve([{ id: "fake", family: "fake" }]),
     ask: (_input: AskInput): Promise<AskOutput> => {
       // Hangs forever — the session wall-clock guard must preempt this.
-      return new Promise(() => { /* never resolves */ });
+      return new Promise(() => {
+        /* never resolves */
+      });
     },
     critique: (_input: CritiqueInput): Promise<CritiqueOutput> => {
-      return new Promise(() => { /* never resolves */ });
+      return new Promise(() => {
+        /* never resolves */
+      });
     },
     revise: (_input: ReviseInput): Promise<ReviseOutput> => {
-      return new Promise(() => { /* never resolves */ });
+      return new Promise(() => {
+        /* never resolves */
+      });
     },
   };
 }
@@ -69,38 +77,34 @@ afterEach(() => {
 });
 
 describe("samospec new hang recovery (#81)", () => {
-  test(
-    "runNew with hanging adapter exits within 10s with exit 4 + session-wall-clock reason",
-    async () => {
-      const adapter = makeHangingAdapter();
-      const startMs = Date.now();
+  test("runNew with hanging adapter exits within 10s with exit 4 + session-wall-clock reason", async () => {
+    const adapter = makeHangingAdapter();
+    const startMs = Date.now();
 
-      // maxWallClockMinutes: use a config-file based cap.
-      // The test sets max_session_wall_clock_minutes=0.08 (≈5s) via RunNewInput.
-      const result = await runNew(
-        {
-          cwd: tmp,
-          slug: "demo",
-          idea: "test idea",
-          explain: false,
-          resolvers: acceptResolvers(),
-          now: "2026-04-19T10:00:00Z",
-          // 5-second session wall-clock cap via new field.
-          maxSessionWallClockMs: 5_000,
-        },
-        adapter,
-      );
-      const elapsedMs = Date.now() - startMs;
+    // maxWallClockMinutes: use a config-file based cap.
+    // The test sets max_session_wall_clock_minutes=0.08 (≈5s) via RunNewInput.
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "test idea",
+        explain: false,
+        resolvers: acceptResolvers(),
+        now: "2026-04-19T10:00:00Z",
+        // 5-second session wall-clock cap via new field.
+        maxSessionWallClockMs: 5_000,
+      },
+      adapter,
+    );
+    const elapsedMs = Date.now() - startMs;
 
-      // Must terminate within 10s.
-      expect(elapsedMs).toBeLessThan(10_000);
+    // Must terminate within 10s.
+    expect(elapsedMs).toBeLessThan(10_000);
 
-      // Must exit with exit code 4 (lead_terminal).
-      expect(result.exitCode).toBe(4);
+    // Must exit with exit code 4 (lead_terminal).
+    expect(result.exitCode).toBe(4);
 
-      // stderr must contain "session-wall-clock" reason (not a generic "adapter error").
-      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
-    },
-    12_000, // Bun test timeout: 12s
-  );
+    // stderr must contain "session-wall-clock" reason (not a generic "adapter error").
+    expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+  }, 12_000); // Bun test timeout: 12s
 });

--- a/tests/cli/new-hang-recovery.test.ts
+++ b/tests/cli/new-hang-recovery.test.ts
@@ -1,0 +1,106 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED test for #81: `samospec new <slug>` with a mock adapter that hangs
+// on the first `ask` call must exit within configurable timeout (5s in
+// this test) with `lead_terminal` reason and a specific `timeout` message.
+//
+// The adapter hangs forever on ask(). With the session wall-clock guard
+// in place, runNew must kill the hanging phase and return exit 4 with
+// a message containing "timeout" and "session-wall-clock".
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  AuthStatus,
+  CritiqueInput,
+  CritiqueOutput,
+  DetectResult,
+  EffortLevel,
+  ModelInfo,
+  ReviseInput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+import { runInit } from "../../src/cli/init.ts";
+
+// Adapter that hangs on ask() indefinitely.
+function makeHangingAdapter(): Adapter {
+  const auth: AuthStatus = { authenticated: true, subscription_auth: false };
+  return {
+    vendor: "fake-hang",
+    detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+    auth_status: (): Promise<AuthStatus> => Promise.resolve(auth),
+    supports_structured_output: () => true,
+    supports_effort: (_level: EffortLevel) => true,
+    models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
+    ask: (_input: AskInput): Promise<AskOutput> => {
+      // Hangs forever — the session wall-clock guard must preempt this.
+      return new Promise(() => { /* never resolves */ });
+    },
+    critique: (_input: CritiqueInput): Promise<CritiqueOutput> => {
+      return new Promise(() => { /* never resolves */ });
+    },
+    revise: (_input: ReviseInput): Promise<ReviseOutput> => {
+      return new Promise(() => { /* never resolves */ });
+    },
+  };
+}
+
+function acceptResolvers(): ChoiceResolvers {
+  return {
+    persona: () => Promise.resolve({ kind: "accept" }),
+    question: (_q) => Promise.resolve({ choice: "decide for me" }),
+  };
+}
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-hang-"));
+  runInit({ cwd: tmp });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("samospec new hang recovery (#81)", () => {
+  test(
+    "runNew with hanging adapter exits within 10s with exit 4 + session-wall-clock reason",
+    async () => {
+      const adapter = makeHangingAdapter();
+      const startMs = Date.now();
+
+      // maxWallClockMinutes: use a config-file based cap.
+      // The test sets max_session_wall_clock_minutes=0.08 (≈5s) via RunNewInput.
+      const result = await runNew(
+        {
+          cwd: tmp,
+          slug: "demo",
+          idea: "test idea",
+          explain: false,
+          resolvers: acceptResolvers(),
+          now: "2026-04-19T10:00:00Z",
+          // 5-second session wall-clock cap via new field.
+          maxSessionWallClockMs: 5_000,
+        },
+        adapter,
+      );
+      const elapsedMs = Date.now() - startMs;
+
+      // Must terminate within 10s.
+      expect(elapsedMs).toBeLessThan(10_000);
+
+      // Must exit with exit code 4 (lead_terminal).
+      expect(result.exitCode).toBe(4);
+
+      // stderr must contain "session-wall-clock" reason (not a generic "adapter error").
+      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+    },
+    12_000, // Bun test timeout: 12s
+  );
+});

--- a/tests/cli/new-max-session-wall-clock-ms-flag.test.ts
+++ b/tests/cli/new-max-session-wall-clock-ms-flag.test.ts
@@ -1,0 +1,175 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// CLI-level e2e for `--max-session-wall-clock-ms` (#81, PR #83 review).
+//
+// The runtime plumbing in src/cli/new.ts already honors
+// `RunNewInput.maxSessionWallClockMs`, but the CLI parser in src/cli.ts
+// must also accept `--max-session-wall-clock-ms <ms>` (or `=ms`) and
+// thread the value into `runNew`. Without the parser change users
+// running `samospec new demo --max-session-wall-clock-ms 5000` would
+// fall back to the 10-minute default — the exact "unit tests pass, CLI
+// never invokes" pattern that bit #79/#80.
+//
+// Strategy: spawn a real `bun run src/main.ts new <slug>` in a tmpdir
+// with a stub `claude` binary on PATH that hangs forever. With a 5s
+// cap, the command MUST terminate within ~7s and stderr MUST contain
+// `session-wall-clock`. The pre-fix CLI ignores the flag; the hang
+// would fall back to the 10-min default → test times out.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const CLI_PATH = path.resolve(import.meta.dir, "..", "..", "src", "main.ts");
+
+let tmp: string;
+let fakeHome: string;
+let fakeBin: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-wallclock-cli-"));
+  fakeHome = mkdtempSync(path.join(tmpdir(), "samospec-wallclock-home-"));
+  fakeBin = mkdtempSync(path.join(tmpdir(), "samospec-wallclock-bin-"));
+
+  // Write a hanging fake `claude` binary: sleeps forever on any invocation.
+  const claudeStub = path.join(fakeBin, "claude");
+  writeFileSync(claudeStub, "#!/bin/sh\nsleep 3600\n");
+  chmodSync(claudeStub, 0o755);
+
+  // Also stub `codex` so reviewer_a preflight doesn't error out before
+  // the lead phase starts.
+  const codexStub = path.join(fakeBin, "codex");
+  writeFileSync(
+    codexStub,
+    "#!/bin/sh\n" +
+      'if [ "$1" = "--version" ]; then echo "0.0.0-fake"; exit 0; fi\n' +
+      "sleep 3600\n",
+  );
+  chmodSync(codexStub, 0o755);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  rmSync(fakeHome, { recursive: true, force: true });
+  rmSync(fakeBin, { recursive: true, force: true });
+});
+
+function runSamospec(
+  args: readonly string[],
+  opts: { cwd: string; timeoutMs?: number } = { cwd: tmp },
+): { stdout: string; stderr: string; status: number; elapsedMs: number } {
+  const env: Record<string, string> = {
+    PATH: `${fakeBin}:/bin:/usr/bin:/usr/local/bin`,
+    HOME: fakeHome,
+    NO_COLOR: "1",
+    ANTHROPIC_API_KEY: "sk-fake-test-key",
+  };
+  const bun = Bun.argv[0];
+  const startMs = Date.now();
+  const result = spawnSync(bun, ["run", CLI_PATH, ...(args as string[])], {
+    cwd: opts.cwd,
+    encoding: "utf8",
+    env,
+    timeout: opts.timeoutMs ?? 15_000,
+  });
+  const elapsedMs = Date.now() - startMs;
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status ?? 1,
+    elapsedMs,
+  };
+}
+
+describe("samospec new --max-session-wall-clock-ms (CLI flag, #81)", () => {
+  test("USAGE string documents --max-session-wall-clock-ms", () => {
+    const res = runSamospec([], { cwd: tmp, timeoutMs: 8_000 });
+    expect(res.stderr.toLowerCase()).toContain("--max-session-wall-clock-ms");
+  });
+
+  test("--max-session-wall-clock-ms 5000 caps a hanging session to ~5s", () => {
+    // Init the repo (git + .samo/).
+    spawnSync("git", ["init", "--initial-branch", "feature/wc-e2e", tmp], {
+      cwd: tmpdir(),
+      encoding: "utf8",
+    });
+    const initRes = runSamospec(["init"], { cwd: tmp, timeoutMs: 8_000 });
+    expect(initRes.status).toBe(0);
+
+    // Now run `samospec new demo --max-session-wall-clock-ms 5000`
+    // with the hanging `claude` stub on PATH. Must exit within ~7s.
+    const startMs = Date.now();
+    const res = runSamospec(
+      [
+        "new",
+        "demo",
+        "--idea",
+        "cli flag test",
+        "--max-session-wall-clock-ms",
+        "5000",
+      ],
+      { cwd: tmp, timeoutMs: 12_000 },
+    );
+    const elapsedMs = Date.now() - startMs;
+
+    // Must terminate within 10s (gives ~5s cap + overhead).
+    expect(elapsedMs).toBeLessThan(10_000);
+
+    // Must exit with non-zero (4 from runNew, or 1 from parser) and
+    // stderr must mention session-wall-clock.
+    expect(res.status).not.toBe(0);
+    expect(res.stderr.toLowerCase()).toContain("session-wall-clock");
+  }, 20_000);
+
+  test("--max-session-wall-clock-ms=5000 (equals form) also caps a hanging session", () => {
+    spawnSync("git", ["init", "--initial-branch", "feature/wc-eq", tmp], {
+      cwd: tmpdir(),
+      encoding: "utf8",
+    });
+    const initRes = runSamospec(["init"], { cwd: tmp, timeoutMs: 8_000 });
+    expect(initRes.status).toBe(0);
+
+    const startMs = Date.now();
+    const res = runSamospec(
+      [
+        "new",
+        "demo-eq",
+        "--idea",
+        "eq form test",
+        "--max-session-wall-clock-ms=5000",
+      ],
+      { cwd: tmp, timeoutMs: 12_000 },
+    );
+    const elapsedMs = Date.now() - startMs;
+
+    expect(elapsedMs).toBeLessThan(10_000);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr.toLowerCase()).toContain("session-wall-clock");
+  }, 20_000);
+
+  test("--max-session-wall-clock-ms with non-integer value rejects with exit 1", () => {
+    spawnSync("git", ["init", "--initial-branch", "feature/wc-bad", tmp], {
+      cwd: tmpdir(),
+      encoding: "utf8",
+    });
+    const initRes = runSamospec(["init"], { cwd: tmp, timeoutMs: 8_000 });
+    expect(initRes.status).toBe(0);
+
+    const res = runSamospec(
+      [
+        "new",
+        "demo-bad",
+        "--idea",
+        "bad value",
+        "--max-session-wall-clock-ms",
+        "not-a-number",
+      ],
+      { cwd: tmp, timeoutMs: 8_000 },
+    );
+    expect(res.status).toBe(1);
+    // Error must name the flag so the user can diagnose.
+    expect(res.stderr.toLowerCase()).toContain("max-session-wall-clock-ms");
+  });
+});

--- a/tests/cli/session-wallclock.test.ts
+++ b/tests/cli/session-wallclock.test.ts
@@ -37,14 +37,25 @@ function makeHangingAdapter(): Adapter {
   const auth: AuthStatus = { authenticated: true, subscription_auth: false };
   return {
     vendor: "fake-hang",
-    detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+    detect: (): Promise<DetectResult> =>
+      Promise.resolve({ installed: true, version: "0", path: "/fake" }),
     auth_status: (): Promise<AuthStatus> => Promise.resolve(auth),
     supports_structured_output: () => true,
     supports_effort: (_level: EffortLevel) => true,
-    models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
-    ask: (_input: AskInput): Promise<AskOutput> => new Promise(() => { /* hangs */ }),
-    critique: (_input: CritiqueInput): Promise<CritiqueOutput> => new Promise(() => { /* hangs */ }),
-    revise: (_input: ReviseInput): Promise<ReviseOutput> => new Promise(() => { /* hangs */ }),
+    models: (): Promise<readonly ModelInfo[]> =>
+      Promise.resolve([{ id: "fake", family: "fake" }]),
+    ask: (_input: AskInput): Promise<AskOutput> =>
+      new Promise(() => {
+        /* hangs */
+      }),
+    critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
+      new Promise(() => {
+        /* hangs */
+      }),
+    revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+      new Promise(() => {
+        /* hangs */
+      }),
   };
 }
 
@@ -65,116 +76,120 @@ afterEach(() => {
 });
 
 describe("session wall-clock cap (#81)", () => {
-  test(
-    "exceeding wall-clock cap terminates with exit 4 + session-wall-clock reason",
-    async () => {
-      const adapter = makeHangingAdapter();
-      const startMs = Date.now();
+  test("exceeding wall-clock cap terminates with exit 4 + session-wall-clock reason", async () => {
+    const adapter = makeHangingAdapter();
+    const startMs = Date.now();
 
-      const result = await runNew(
-        {
-          cwd: tmp,
-          slug: "wc-test",
-          idea: "wall clock test",
-          explain: false,
-          resolvers: acceptResolvers(),
-          now: "2026-04-19T10:00:00Z",
-          // 3-second session wall-clock cap.
-          maxSessionWallClockMs: 3_000,
-        },
-        adapter,
-      );
-      const elapsedMs = Date.now() - startMs;
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "wc-test",
+        idea: "wall clock test",
+        explain: false,
+        resolvers: acceptResolvers(),
+        now: "2026-04-19T10:00:00Z",
+        // 3-second session wall-clock cap.
+        maxSessionWallClockMs: 3_000,
+      },
+      adapter,
+    );
+    const elapsedMs = Date.now() - startMs;
 
-      expect(elapsedMs).toBeLessThan(8_000);
-      expect(result.exitCode).toBe(4);
-      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
-    },
-    10_000,
-  );
+    expect(elapsedMs).toBeLessThan(8_000);
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+  }, 10_000);
 
-  test(
-    "wall-clock cap is read from config.json budget.max_session_wall_clock_minutes",
-    async () => {
-      // Patch the config to set max_session_wall_clock_minutes = 0.05 (3s).
-      const configPath = path.join(tmp, ".samo", "config.json");
-      const raw = readFileSync(configPath, "utf8");
-      const cfg = JSON.parse(raw) as Record<string, unknown>;
-      const budget = (cfg["budget"] ?? {}) as Record<string, unknown>;
-      budget["max_session_wall_clock_minutes"] = 0.05; // ~3s
-      cfg["budget"] = budget;
-      writeFileSync(configPath, JSON.stringify(cfg, null, 2));
+  test("wall-clock cap is read from config.json budget.max_session_wall_clock_minutes", async () => {
+    // Patch the config to set max_session_wall_clock_minutes = 0.05 (3s).
+    const configPath = path.join(tmp, ".samo", "config.json");
+    const raw = readFileSync(configPath, "utf8");
+    const cfg = JSON.parse(raw) as Record<string, unknown>;
+    const budget = (cfg["budget"] ?? {}) as Record<string, unknown>;
+    budget["max_session_wall_clock_minutes"] = 0.05; // ~3s
+    cfg["budget"] = budget;
+    writeFileSync(configPath, JSON.stringify(cfg, null, 2));
 
-      const adapter = makeHangingAdapter();
-      const startMs = Date.now();
+    const adapter = makeHangingAdapter();
+    const startMs = Date.now();
 
-      // Do NOT pass maxSessionWallClockMs — must read from config.
-      const result = await runNew(
-        {
-          cwd: tmp,
-          slug: "cfg-wc",
-          idea: "config wall clock test",
-          explain: false,
-          resolvers: acceptResolvers(),
-          now: "2026-04-19T10:00:00Z",
-        },
-        adapter,
-      );
-      const elapsedMs = Date.now() - startMs;
+    // Do NOT pass maxSessionWallClockMs — must read from config.
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "cfg-wc",
+        idea: "config wall clock test",
+        explain: false,
+        resolvers: acceptResolvers(),
+        now: "2026-04-19T10:00:00Z",
+      },
+      adapter,
+    );
+    const elapsedMs = Date.now() - startMs;
 
-      expect(elapsedMs).toBeLessThan(10_000);
-      expect(result.exitCode).toBe(4);
-      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
-    },
-    12_000,
-  );
+    expect(elapsedMs).toBeLessThan(10_000);
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+  }, 12_000);
 
-  test(
-    "session that completes within wall-clock cap exits 0",
-    async () => {
-      // Fast-responding adapter that completes immediately.
-      const personaJson = JSON.stringify({
-        persona: 'Veteran "CLI engineer" expert',
-        rationale: "fast",
-      });
-      const questionsJson = JSON.stringify({
-        questions: [{ id: "q1", text: "scope?", options: ["narrow", "wide"] }],
-      });
-      let callCount = 0;
-      const fastAdapter: Adapter = {
-        vendor: "fake-fast",
-        detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
-        auth_status: (): Promise<AuthStatus> => Promise.resolve({ authenticated: true, subscription_auth: false }),
-        supports_structured_output: () => true,
-        supports_effort: (_level: EffortLevel) => true,
-        models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
-        ask: (_input: AskInput): Promise<AskOutput> => {
-          const c = callCount++;
-          const answer = c === 0 ? personaJson : questionsJson;
-          return Promise.resolve({ answer, usage: null, effort_used: "max" });
-        },
-        critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
-          Promise.resolve({ findings: [], summary: "ok", suggested_next_version: "0.1.1", usage: null, effort_used: "max" }),
-        revise: (_input: ReviseInput): Promise<ReviseOutput> =>
-          Promise.resolve({ spec: "# SPEC\n\nok.", ready: true, rationale: "done", decisions: [], usage: null, effort_used: "max" }),
-      };
+  test("session that completes within wall-clock cap exits 0", async () => {
+    // Fast-responding adapter that completes immediately.
+    const personaJson = JSON.stringify({
+      persona: 'Veteran "CLI engineer" expert',
+      rationale: "fast",
+    });
+    const questionsJson = JSON.stringify({
+      questions: [{ id: "q1", text: "scope?", options: ["narrow", "wide"] }],
+    });
+    let callCount = 0;
+    const fastAdapter: Adapter = {
+      vendor: "fake-fast",
+      detect: (): Promise<DetectResult> =>
+        Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+      auth_status: (): Promise<AuthStatus> =>
+        Promise.resolve({ authenticated: true, subscription_auth: false }),
+      supports_structured_output: () => true,
+      supports_effort: (_level: EffortLevel) => true,
+      models: (): Promise<readonly ModelInfo[]> =>
+        Promise.resolve([{ id: "fake", family: "fake" }]),
+      ask: (_input: AskInput): Promise<AskOutput> => {
+        const c = callCount++;
+        const answer = c === 0 ? personaJson : questionsJson;
+        return Promise.resolve({ answer, usage: null, effort_used: "max" });
+      },
+      critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
+        Promise.resolve({
+          findings: [],
+          summary: "ok",
+          suggested_next_version: "0.1.1",
+          usage: null,
+          effort_used: "max",
+        }),
+      revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+        Promise.resolve({
+          spec: "# SPEC\n\nok.",
+          ready: true,
+          rationale: "done",
+          decisions: [],
+          usage: null,
+          effort_used: "max",
+        }),
+    };
 
-      const result = await runNew(
-        {
-          cwd: tmp,
-          slug: "fast-run",
-          idea: "fast test",
-          explain: false,
-          resolvers: acceptResolvers(),
-          now: "2026-04-19T10:00:00Z",
-          // 10-minute cap — should be more than enough.
-          maxSessionWallClockMs: 600_000,
-        },
-        fastAdapter,
-      );
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "fast-run",
+        idea: "fast test",
+        explain: false,
+        resolvers: acceptResolvers(),
+        now: "2026-04-19T10:00:00Z",
+        // 10-minute cap — should be more than enough.
+        maxSessionWallClockMs: 600_000,
+      },
+      fastAdapter,
+    );
 
-      expect(result.exitCode).toBe(0);
-    },
-    30_000,
-  );
+    expect(result.exitCode).toBe(0);
+  }, 30_000);
 });

--- a/tests/cli/session-wallclock.test.ts
+++ b/tests/cli/session-wallclock.test.ts
@@ -1,0 +1,180 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED test for #81: session wall-clock cap.
+//
+// SPEC §7 default: 10 minutes session wall-clock cap, configurable via
+// `.samo/config.json` `budget.max_session_wall_clock_minutes`.
+//
+// Tests:
+// 1. A session that exceeds the wall-clock cap terminates with reason
+//    `session-wall-clock` and exit code 4.
+// 2. The cap is read from config.json `budget.max_session_wall_clock_minutes`
+//    when present.
+// 3. A session that completes within the cap succeeds normally.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  AuthStatus,
+  CritiqueInput,
+  CritiqueOutput,
+  DetectResult,
+  EffortLevel,
+  ModelInfo,
+  ReviseInput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+import { runInit } from "../../src/cli/init.ts";
+
+function makeHangingAdapter(): Adapter {
+  const auth: AuthStatus = { authenticated: true, subscription_auth: false };
+  return {
+    vendor: "fake-hang",
+    detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+    auth_status: (): Promise<AuthStatus> => Promise.resolve(auth),
+    supports_structured_output: () => true,
+    supports_effort: (_level: EffortLevel) => true,
+    models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
+    ask: (_input: AskInput): Promise<AskOutput> => new Promise(() => { /* hangs */ }),
+    critique: (_input: CritiqueInput): Promise<CritiqueOutput> => new Promise(() => { /* hangs */ }),
+    revise: (_input: ReviseInput): Promise<ReviseOutput> => new Promise(() => { /* hangs */ }),
+  };
+}
+
+function acceptResolvers(): ChoiceResolvers {
+  return {
+    persona: () => Promise.resolve({ kind: "accept" }),
+    question: (_q) => Promise.resolve({ choice: "decide for me" }),
+  };
+}
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-wallclock-"));
+  runInit({ cwd: tmp });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("session wall-clock cap (#81)", () => {
+  test(
+    "exceeding wall-clock cap terminates with exit 4 + session-wall-clock reason",
+    async () => {
+      const adapter = makeHangingAdapter();
+      const startMs = Date.now();
+
+      const result = await runNew(
+        {
+          cwd: tmp,
+          slug: "wc-test",
+          idea: "wall clock test",
+          explain: false,
+          resolvers: acceptResolvers(),
+          now: "2026-04-19T10:00:00Z",
+          // 3-second session wall-clock cap.
+          maxSessionWallClockMs: 3_000,
+        },
+        adapter,
+      );
+      const elapsedMs = Date.now() - startMs;
+
+      expect(elapsedMs).toBeLessThan(8_000);
+      expect(result.exitCode).toBe(4);
+      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+    },
+    10_000,
+  );
+
+  test(
+    "wall-clock cap is read from config.json budget.max_session_wall_clock_minutes",
+    async () => {
+      // Patch the config to set max_session_wall_clock_minutes = 0.05 (3s).
+      const configPath = path.join(tmp, ".samo", "config.json");
+      const raw = readFileSync(configPath, "utf8");
+      const cfg = JSON.parse(raw) as Record<string, unknown>;
+      const budget = (cfg["budget"] ?? {}) as Record<string, unknown>;
+      budget["max_session_wall_clock_minutes"] = 0.05; // ~3s
+      cfg["budget"] = budget;
+      writeFileSync(configPath, JSON.stringify(cfg, null, 2));
+
+      const adapter = makeHangingAdapter();
+      const startMs = Date.now();
+
+      // Do NOT pass maxSessionWallClockMs — must read from config.
+      const result = await runNew(
+        {
+          cwd: tmp,
+          slug: "cfg-wc",
+          idea: "config wall clock test",
+          explain: false,
+          resolvers: acceptResolvers(),
+          now: "2026-04-19T10:00:00Z",
+        },
+        adapter,
+      );
+      const elapsedMs = Date.now() - startMs;
+
+      expect(elapsedMs).toBeLessThan(10_000);
+      expect(result.exitCode).toBe(4);
+      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+    },
+    12_000,
+  );
+
+  test(
+    "session that completes within wall-clock cap exits 0",
+    async () => {
+      // Fast-responding adapter that completes immediately.
+      const personaJson = JSON.stringify({
+        persona: 'Veteran "CLI engineer" expert',
+        rationale: "fast",
+      });
+      const questionsJson = JSON.stringify({
+        questions: [{ id: "q1", text: "scope?", options: ["narrow", "wide"] }],
+      });
+      let callCount = 0;
+      const fastAdapter: Adapter = {
+        vendor: "fake-fast",
+        detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+        auth_status: (): Promise<AuthStatus> => Promise.resolve({ authenticated: true, subscription_auth: false }),
+        supports_structured_output: () => true,
+        supports_effort: (_level: EffortLevel) => true,
+        models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
+        ask: (_input: AskInput): Promise<AskOutput> => {
+          const c = callCount++;
+          const answer = c === 0 ? personaJson : questionsJson;
+          return Promise.resolve({ answer, usage: null, effort_used: "max" });
+        },
+        critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
+          Promise.resolve({ findings: [], summary: "ok", suggested_next_version: "0.1.1", usage: null, effort_used: "max" }),
+        revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+          Promise.resolve({ spec: "# SPEC\n\nok.", ready: true, rationale: "done", decisions: [], usage: null, effort_used: "max" }),
+      };
+
+      const result = await runNew(
+        {
+          cwd: tmp,
+          slug: "fast-run",
+          idea: "fast test",
+          explain: false,
+          resolvers: acceptResolvers(),
+          now: "2026-04-19T10:00:00Z",
+          // 10-minute cap — should be more than enough.
+          maxSessionWallClockMs: 600_000,
+        },
+        fastAdapter,
+      );
+
+      expect(result.exitCode).toBe(0);
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
## Summary

- **Root cause**: `Bun.spawn` with piped stdio — `new Response(stream).text()` blocks waiting for EOF even after `proc.kill("SIGKILL")`. The timeout timer fires and kills the child, but the stream read never unblocks, so `spawnCli` hangs indefinitely. This caused the 22-minute hang reported in #81.
- **Fix 1 (spawn.ts)**: Replace `new Response(stream).text()` with a manual `ReadableStream` reader + `AbortController`. On timeout we call `ac.abort()` before SIGKILL; the reader's `Promise.race` against the abort promise unblocks immediately, no longer waiting for pipe EOF.
- **Fix 2 (new.ts)**: Add a session wall-clock guard (`withDeadline<T>()`) that wraps the three long-running phases (`persona`, `interview`, `draft`). If total elapsed time exceeds the cap, `SessionWallClockError` is thrown, caught, and converted to exit 4 + `session-wall-clock` in stderr. Cap is configurable via `budget.max_session_wall_clock_minutes` in config.json (default 10 min) or `RunNewInput.maxSessionWallClockMs` (test/CI override).

## Manual repro transcript

```
$ bun repro.ts   # (hanging adapter + 5s wall-clock cap)

[repro] Starting runNew with 5s session wall-clock cap...
[repro] Without fix, this would hang indefinitely.
[repro] runNew returned in 5007ms (fix working!)
[repro] exit code: 4
[repro] stderr: samospec: session-wall-clock exceeded at persona phase
         (5002ms elapsed, limit 5000ms). Restart with --force or
         increase budget.max_session_wall_clock_minutes.
[repro] PASS: timeout enforced correctly
```

Before this fix, a hanging claude CLI binary caused `samospec new` to block for `3.5 × timeoutMs × phases` = up to ~21 minutes (or more with retries), matching the live demo in #81 that required `pkill -9`.

## Test plan

- [x] `bun test tests/adapter/claude-spawn-timeout.test.ts` — 2 tests: `spawnCli` resolves `{ok:false,reason:'timeout'}` within 3x timeout AND child PID is dead via ESRCH; `ClaudeAdapter.ask` throws `ClaudeAdapterError(reason='timeout')` within 25s for hanging binary.
- [x] `bun test tests/cli/new-hang-recovery.test.ts` — hanging adapter + 5s wall-clock cap → exit 4 + `session-wall-clock` within 10s.
- [x] `bun test tests/cli/session-wallclock.test.ts` — 3 tests: wall-clock cap fires; cap read from `config.json`; fast adapter exits 0.
- [x] `bun test` (full suite) — **1278/1278 pass**, 0 fail.
- [x] `bun run typecheck` — clean.
- [x] `eslint src/adapter/spawn.ts src/cli/new.ts` — clean.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)