### PR TITLE
feat: #85 idea-precedence + reviewer-B contradiction detection (v0.4.0)

### DIFF
--- a/.samo/blueprints/SPEC.md
+++ b/.samo/blueprints/SPEC.md
@@ -221,6 +221,22 @@ Return shape: `{ ..., usage?, effort_used }`. `usage: null` means the adapter ca
 
 Sections are named in the prompt literally. Unknown section names in `--skip` are an error (exit 1). Additional topic-specific sections beyond these nine are always permitted.
 
+**AUTHORITATIVE idea framing (v0.4.0 / #85).** When `--idea` is supplied, all prompt builders inject an idea-precedence block before the spec or question payload:
+
+```
+## Project idea (AUTHORITATIVE — this is what the tool does)
+{idea}
+
+## Project slug (filesystem-safe identifier only — DO NOT infer semantics from it)
+{slug}
+
+If the slug and the idea appear to conflict, the IDEA wins. If the idea contains
+"NOT X" / "this is NOT a Y" disclaimers, honor them strictly — do not silently
+re-introduce the rejected framing in any section.
+```
+
+The original idea is persisted in `state.json` under `input.idea` at first write (immediately after the initial state record) so `iterate` and `resume` can thread it into every subsequent prompt call without requiring the user to re-supply `--idea`. Reviewer B's critique prompt additionally carries an `IDEA-CONTRADICTION CHECK` directive: when the idea contains explicit disclaimers, Reviewer B flags any spec section that reintroduces the disclaimed class as a `contradiction` finding (severity: major), quoting both the disclaimer and the offending section text.
+
 **Optional `decisions` array on `revise()`.** The `revise()` response may include a structured `decisions` array so the loop can populate `decisions.md` with per-finding verdicts:
 
 ```json

--- a/src/adapter/claude-reviewer-b.ts
+++ b/src/adapter/claude-reviewer-b.ts
@@ -25,8 +25,18 @@
 // instance (see `./claude-resolver.ts`). When the lead advances the
 // resolver on a model-unavailable failure, Reviewer B's very next
 // spawn picks up the new pin automatically.
+//
+// v0.4.0 (#85): when CritiqueInput carries an `idea` string, Reviewer B
+// receives an explicit contradiction-detection directive: flag any spec
+// section that reintroduces a class the idea disclaimed. The idea is
+// prepended to the guidelines via `buildCritiquePromptForReviewerB` so
+// the model sees it before the spec text.
 
-import { ClaudeAdapter, type ClaudeAdapterOpts } from "./claude.ts";
+import {
+  ClaudeAdapter,
+  buildCritiquePrompt,
+  type ClaudeAdapterOpts,
+} from "./claude.ts";
 import { type CritiqueInput, type CritiqueOutput } from "./types.ts";
 
 // SPEC §7: literal persona prefix applied to Reviewer B critique()
@@ -48,6 +58,49 @@ export const REVIEWER_B_PERSONA_PREFIX =
   "(9) embedded changelog. " +
   "Raise a missing-requirement finding for each absent mandatory section.";
 
+// v0.4.0 (#85): when an idea string is present, Reviewer B carries this
+// contradiction-detection directive verbatim before the guidelines.
+// Exported so tests can assert on the literal wording.
+export const REVIEWER_B_CONTRADICTION_DIRECTIVE =
+  "IDEA-CONTRADICTION CHECK: The user's original idea is provided below " +
+  "under '## Original idea'. If the idea contains explicit disclaimers " +
+  "(e.g. 'NOT X', 'not a Y', 'this is NOT a Z'), carefully read every " +
+  "section of the spec and flag any section that reintroduces the disclaimed " +
+  "class as a `contradiction` finding (severity: major). Quote the exact " +
+  "disclaimer from the idea and the offending spec section text in the " +
+  "finding's `text` field.";
+
+/**
+ * Build the full critique prompt for Reviewer B, incorporating:
+ * 1. The persona prefix (taxonomy weighting + baseline section check).
+ * 2. If `input.idea` is present: the contradiction-detection directive
+ *    + the idea string under a labelled header.
+ * 3. The caller's guidelines (if any).
+ * 4. The standard critique prompt structure (schema + spec text).
+ *
+ * Exported so tests can inspect the assembled prompt without spawning.
+ */
+export function buildCritiquePromptForReviewerB(input: CritiqueInput): string {
+  // Build the composed guidelines = persona + optional idea-contradiction
+  // directive + caller guidelines.
+  const ideaSection =
+    input.idea !== undefined && input.idea.trim().length > 0
+      ? `${REVIEWER_B_CONTRADICTION_DIRECTIVE}\n\n## Original idea\n${input.idea}\n`
+      : "";
+
+  const composedGuidelines = [
+    REVIEWER_B_PERSONA_PREFIX,
+    ideaSection,
+    input.guidelines,
+  ]
+    .filter((s) => s.trim().length > 0)
+    .join("\n\n");
+
+  // Build using the same base prompt builder so schema + spec text are
+  // identical to what the plain ClaudeAdapter would produce.
+  return buildCritiquePrompt({ ...input, guidelines: composedGuidelines });
+}
+
 // ---------- ClaudeReviewerBAdapter ----------
 
 export class ClaudeReviewerBAdapter extends ClaudeAdapter {
@@ -60,14 +113,23 @@ export class ClaudeReviewerBAdapter extends ClaudeAdapter {
   }
 
   override critique(input: CritiqueInput): Promise<CritiqueOutput> {
-    // Prepend the persona prefix to the caller's guidelines so the
-    // system-level taxonomy weighting is the first thing the model
-    // reads. The inner ClaudeAdapter.critique() then builds the usual
-    // critique prompt around this composed guideline string.
-    const composedGuidelines =
-      input.guidelines === ""
-        ? REVIEWER_B_PERSONA_PREFIX
-        : `${REVIEWER_B_PERSONA_PREFIX}\n\n${input.guidelines}`;
+    // v0.4.0 (#85): use buildCritiquePromptForReviewerB which injects
+    // the persona prefix + optional idea-contradiction directive. We
+    // override the inherited critique() by reconstructing the input with
+    // pre-composed guidelines so super.critique() sees the full prompt.
+    //
+    // We call super.critique() with the composed guidelines so the
+    // inherited spawn + JSON-parse + retry plumbing runs unchanged.
+    const composedGuidelines = [
+      REVIEWER_B_PERSONA_PREFIX,
+      input.idea !== undefined && input.idea.trim().length > 0
+        ? `${REVIEWER_B_CONTRADICTION_DIRECTIVE}\n\n## Original idea\n${input.idea}`
+        : "",
+      input.guidelines,
+    ]
+      .filter((s) => s.trim().length > 0)
+      .join("\n\n");
+
     const withPersona: CritiqueInput = {
       ...input,
       guidelines: composedGuidelines,

--- a/src/adapter/claude.ts
+++ b/src/adapter/claude.ts
@@ -569,14 +569,55 @@ export function buildBaselineSectionsBlock(
   );
 }
 
+// ---------- idea-precedence framing (SPEC §7 v0.4.0 / Issue #85) ----------
+
+/**
+ * Build the idea-precedence block that tells the lead (and Reviewer B)
+ * that --idea is the AUTHORITATIVE source of semantics. The slug is a
+ * filesystem identifier only — the model must NOT infer project meaning
+ * from it.
+ *
+ * Returns an empty string when `idea` is absent (backward compatible).
+ *
+ * Exact wording is tested in tests/adapter/lead-prompt-idea-precedence.test.ts
+ * — change carefully.
+ */
+export function buildIdeaPrecedenceBlock(opts: {
+  idea?: string;
+  slug?: string;
+}): string {
+  if (opts.idea === undefined || opts.idea.trim().length === 0) {
+    return "";
+  }
+  const slugLine =
+    opts.slug !== undefined && opts.slug.trim().length > 0
+      ? `\n## Project slug (filesystem-safe identifier only — DO NOT infer semantics from it)\n${opts.slug}\n`
+      : "";
+  return (
+    `\n## Project idea (AUTHORITATIVE — this is what the tool does)\n${opts.idea}\n` +
+    slugLine +
+    "\nIf the slug and the idea appear to conflict, the IDEA wins. " +
+    'If the idea contains "NOT X" / "this is NOT a Y" disclaimers, ' +
+    "honor them strictly — do not silently re-introduce the rejected " +
+    "framing in any section.\n"
+  );
+}
+
 // ---------- prompt builders (exported for tests) ----------
 
 export function buildAskPrompt(input: AskInput): string {
   const ctx = input.context === "" ? "" : `\n\nContext:\n${input.context}\n`;
+  const ideaOpts: { idea?: string; slug?: string } = {};
+  if (typeof input.idea === "string" && input.idea.length > 0)
+    ideaOpts.idea = input.idea;
+  if (typeof input.slug === "string" && input.slug.length > 0)
+    ideaOpts.slug = input.slug;
+  const ideaBlock = buildIdeaPrecedenceBlock(ideaOpts);
   return (
     "You are the samospec lead. Respond ONLY with a JSON object matching " +
     'the schema { "answer": string, "usage": null, "effort_used": ' +
     `"${input.opts.effort}" }. Do not wrap in code fences.` +
+    ideaBlock +
     ctx +
     `\n\nQuestion:\n${input.prompt}\n`
   );
@@ -595,6 +636,12 @@ export function buildCritiquePrompt(input: CritiqueInput): string {
 
 export function buildRevisePrompt(input: ReviseInput): string {
   const baselineSections = buildBaselineSectionsBlock(input.skipSections ?? []);
+  const reviseIdeaOpts: { idea?: string; slug?: string } = {};
+  if (typeof input.idea === "string" && input.idea.length > 0)
+    reviseIdeaOpts.idea = input.idea;
+  if (typeof input.slug === "string" && input.slug.length > 0)
+    reviseIdeaOpts.slug = input.slug;
+  const ideaBlock = buildIdeaPrecedenceBlock(reviseIdeaOpts);
   return (
     "You are the samospec lead. Emit the FULL revised SPEC.md text — " +
     'not a patch. Return ONLY a JSON object: { "spec": <full text>, ' +
@@ -607,6 +654,7 @@ export function buildRevisePrompt(input: ReviseInput): string {
     "object in the decisions array with a one-sentence rationale. " +
     "Verdict options: accepted (applied to the spec), rejected " +
     "(did not apply, with reason), deferred (punted to a later version)." +
+    ideaBlock +
     baselineSections +
     `\n\nCurrent spec:\n${input.spec}\n\nReviews (JSON):\n` +
     `${JSON.stringify(input.reviews)}\n\nDecisions so far (JSON):\n` +

--- a/src/adapter/spawn.ts
+++ b/src/adapter/spawn.ts
@@ -137,9 +137,11 @@ export async function spawnCli(input: SpawnCliInput): Promise<SpawnCliResult> {
     // ignore: child may have already exited.
   }
 
+  const ac = new AbortController();
   let timedOut = false;
   const timer = setTimeout(() => {
     timedOut = true;
+    ac.abort();
     try {
       proc.kill("SIGKILL");
     } catch {
@@ -147,10 +149,56 @@ export async function spawnCli(input: SpawnCliInput): Promise<SpawnCliResult> {
     }
   }, input.timeoutMs);
 
+  // Bun's `new Response(stream).text()` blocks even after SIGKILL because
+  // the pipe FD doesn't close immediately. We use a manual reader with
+  // Promise.race against an abort signal so the stream read unblocks on
+  // timeout without waiting for EOF (#81).
+  async function readStream(
+    stream: ReadableStream<Uint8Array>,
+  ): Promise<string> {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    let onAbort: (() => void) | undefined;
+    const abortPromise = new Promise<never>((_resolve, reject) => {
+      if (ac.signal.aborted) {
+        reject(new DOMException("aborted", "AbortError"));
+        return;
+      }
+      onAbort = () => reject(new DOMException("aborted", "AbortError"));
+      ac.signal.addEventListener("abort", onAbort, { once: true });
+    });
+    try {
+      for (;;) {
+        const { done, value } = await Promise.race([
+          reader.read(),
+          abortPromise,
+        ]);
+        if (done) break;
+        if (value !== undefined) chunks.push(value);
+      }
+    } catch {
+      void reader.cancel().catch(() => {
+        /* ignore */
+      });
+    } finally {
+      if (onAbort !== undefined)
+        ac.signal.removeEventListener("abort", onAbort);
+      reader.releaseLock();
+    }
+    const totalLength = chunks.reduce((n, c) => n + c.length, 0);
+    const merged = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return new TextDecoder().decode(merged);
+  }
+
   const [stdoutText, stderrText, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
+    readStream(proc.stdout),
+    readStream(proc.stderr),
+    proc.exited.catch(() => -1),
   ]);
   clearTimeout(timer);
 

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -78,6 +78,18 @@ export const AskInputSchema = z.object({
   prompt: z.string().min(1),
   context: z.string(),
   opts: WorkOptsSchema,
+  /**
+   * #85: original --idea string (AUTHORITATIVE). When present, prompt
+   * builders inject the idea-precedence framing block so the lead never
+   * infers semantics from the slug alone.
+   */
+  idea: z.string().optional(),
+  /**
+   * #85: filesystem-safe slug (non-authoritative identifier only).
+   * Included alongside `idea` so the prompt can clearly label it as
+   * a non-semantic identifier.
+   */
+  slug: z.string().optional(),
 });
 export type AskInput = z.infer<typeof AskInputSchema>;
 
@@ -117,6 +129,11 @@ export const CritiqueInputSchema = z.object({
   spec: z.string().min(1),
   guidelines: z.string(),
   opts: WorkOptsSchema,
+  /**
+   * #85: original --idea string passed to Reviewer B so it can flag
+   * contradiction findings when the spec reintroduces a disclaimed class.
+   */
+  idea: z.string().optional(),
 });
 export type CritiqueInput = z.infer<typeof CritiqueInputSchema>;
 
@@ -161,6 +178,15 @@ export const ReviseInputSchema = z.object({
    * Names are matched case-insensitively against BASELINE_SECTION_NAMES.
    */
   skipSections: z.array(z.string()).optional(),
+  /**
+   * #85: original --idea string (AUTHORITATIVE). When present, prompt
+   * builders inject the idea-precedence framing block.
+   */
+  idea: z.string().optional(),
+  /**
+   * #85: filesystem-safe slug (non-authoritative identifier only).
+   */
+  slug: z.string().optional(),
 });
 export type ReviseInput = z.infer<typeof ReviseInputSchema>;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,7 @@ const USAGE =
   "  init                        Create or refresh .samo/ in the current repo.\n" +
   "  doctor                      Diagnose CLI availability, auth, git, lock, and config.\n" +
   "  new <slug> [--idea ...] [--force] [--skip <sections>]\n" +
+  "            [--max-session-wall-clock-ms <ms>]\n" +
   "                              Start a new spec (persona + 5-question interview).\n" +
   "                              --force archives any existing run before starting\n" +
   "                              fresh. --skip omits named baseline sections from\n" +
@@ -54,6 +55,11 @@ const USAGE =
   "                              case-insensitive). Valid sections: " +
   BASELINE_SECTION_NAMES.join(", ") +
   ".\n" +
+  "                              --max-session-wall-clock-ms caps the total session\n" +
+  "                              wall-clock time (positive integer ms); defaults to\n" +
+  "                              budget.max_session_wall_clock_minutes in config.json\n" +
+  "                              or 600000 (10 min). On cap, exits 4 with reason\n" +
+  "                              `session-wall-clock`.\n" +
   "  resume [<slug>]             Resume an in-progress spec from state.json.\n" +
   "  iterate [<slug>] [--rounds N] [--no-push] [--remote <name>]\n" +
   "                              Run review rounds until a stopping condition fires.\n" +
@@ -144,6 +150,7 @@ interface NewArgs {
   readonly explain: boolean;
   readonly skipSections?: readonly string[];
   readonly force: boolean;
+  readonly maxSessionWallClockMs?: number;
 }
 
 interface ResumeArgs {
@@ -199,6 +206,7 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
   let explain = false;
   let force = false;
   let skipSections: readonly string[] | undefined;
+  let maxSessionWallClockMs: number | undefined;
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
     if (token === undefined) continue;
@@ -234,6 +242,21 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
       skipSections = parsed;
       continue;
     }
+    if (token === "--max-session-wall-clock-ms") {
+      const raw = argv[i + 1] ?? "";
+      i += 1;
+      const parsed = parseMaxSessionWallClockMs(raw);
+      if (typeof parsed === "string") return parsed;
+      maxSessionWallClockMs = parsed;
+      continue;
+    }
+    if (token.startsWith("--max-session-wall-clock-ms=")) {
+      const raw = token.slice("--max-session-wall-clock-ms=".length);
+      const parsed = parseMaxSessionWallClockMs(raw);
+      if (typeof parsed === "string") return parsed;
+      maxSessionWallClockMs = parsed;
+      continue;
+    }
     if (token.startsWith("--")) {
       // Unknown flags ignored (permissive for future flags).
       continue;
@@ -252,7 +275,35 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
     explain,
     force,
     ...(skipSections !== undefined ? { skipSections } : {}),
+    ...(maxSessionWallClockMs !== undefined ? { maxSessionWallClockMs } : {}),
   };
+}
+
+/**
+ * Parse and validate --max-session-wall-clock-ms. Accepts a positive
+ * integer string (digits only; no decimals, no scientific notation).
+ * Returns the integer ms on success, or an error string to be echoed
+ * above the USAGE line.
+ */
+function parseMaxSessionWallClockMs(raw: string): number | string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return "samospec new: --max-session-wall-clock-ms requires a value";
+  }
+  if (!/^\d+$/.test(trimmed)) {
+    return (
+      "samospec new: --max-session-wall-clock-ms must be a positive integer " +
+      `(got '${raw}')`
+    );
+  }
+  const n = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    return (
+      "samospec new: --max-session-wall-clock-ms must be a positive integer " +
+      `(got '${raw}')`
+    );
+  }
+  return n;
 }
 
 function parseResumeArgs(argv: readonly string[]): ResumeArgs | string {
@@ -359,6 +410,9 @@ async function runNewCommand(rest: readonly string[]) {
       now: new Date().toISOString(),
       ...(parsed.skipSections !== undefined
         ? { skipSections: [...parsed.skipSections] }
+        : {}),
+      ...(parsed.maxSessionWallClockMs !== undefined
+        ? { maxSessionWallClockMs: parsed.maxSessionWallClockMs }
         : {}),
     },
     adapter,

--- a/src/cli/draft.ts
+++ b/src/cli/draft.ts
@@ -164,6 +164,14 @@ export async function authorDraft(
       ...(input.skipSections !== undefined
         ? { skipSections: [...input.skipSections] }
         : {}),
+      // #85: thread idea + slug through to the prompt builder so the
+      // AUTHORITATIVE idea framing appears in the v0.1 draft revise call.
+      ...(input.idea !== undefined && input.idea.trim().length > 0
+        ? { idea: input.idea }
+        : {}),
+      ...(input.slug !== undefined && input.slug.trim().length > 0
+        ? { slug: input.slug }
+        : {}),
     });
   } catch (err) {
     throw classifyReviseError(err);

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -459,6 +459,11 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
         );
         mkdirSync(dirs.roundDir, { recursive: true });
 
+        // #85: thread the original idea from state.input.idea into the
+        // round so Reviewer B can detect idea-contradictions and the
+        // lead's revise() prompt carries the AUTHORITATIVE framing.
+        const ideaForRound = state.input?.idea;
+
         // Run the round.
         const roundOutcome = await runRound({
           now: input.now,
@@ -470,6 +475,9 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
           critiqueTimeoutMs: callTimeouts.criticA_ms,
           reviseTimeoutMs: callTimeouts.revise_ms,
           ...(manualEditDirective !== undefined ? { manualEditDirective } : {}),
+          ...(ideaForRound !== undefined
+            ? { idea: ideaForRound, slug: input.slug }
+            : {}),
         });
 
         // Persist state at round boundary (round_state tracking).

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -81,6 +81,11 @@ import {
 
 const DEFAULT_MAX_WALL_CLOCK_MIN = 240;
 
+// Session wall-clock cap: 10 minutes by default (#81).
+// Configurable via budget.max_session_wall_clock_minutes in config.json,
+// or overridden per-call via RunNewInput.maxSessionWallClockMs.
+const DEFAULT_SESSION_WALL_CLOCK_MS = 10 * 60 * 1_000;
+
 const V01_VERSION = "0.1.0" as const;
 
 export interface RunNewResult {
@@ -139,6 +144,99 @@ export interface RunNewInput {
    * per-seat dumps and full prompt echoes are gated behind verbose=true.
    */
   readonly verbose?: boolean;
+  /**
+   * Session wall-clock cap in milliseconds (#81). When the total elapsed
+   * time since runNew() entry exceeds this value, the current phase is
+   * preempted and runNew() returns exit 4 with a "session-wall-clock"
+   * message. Falls back to budget.max_session_wall_clock_minutes from
+   * config.json, then to DEFAULT_SESSION_WALL_CLOCK_MS (10 min).
+   */
+  readonly maxSessionWallClockMs?: number;
+}
+
+// ---------- session wall-clock guard (#81) ----------
+
+/** Thrown by withDeadline() when the session wall-clock cap is exceeded. */
+class SessionWallClockError extends Error {
+  readonly phase: string;
+  readonly elapsedMs: number;
+  readonly limitMs: number;
+  constructor(phase: string, elapsedMs: number, limitMs: number) {
+    super(
+      `session-wall-clock: ${phase} exceeded ${String(limitMs)}ms limit ` +
+        `(elapsed ${String(elapsedMs)}ms)`,
+    );
+    this.name = "SessionWallClockError";
+    this.phase = phase;
+    this.elapsedMs = elapsedMs;
+    this.limitMs = limitMs;
+  }
+}
+
+/**
+ * Race `promise` against a deadline derived from `startMs + limitMs`.
+ * If the deadline fires first, throws `SessionWallClockError`.
+ */
+async function withDeadline<T>(
+  promise: Promise<T>,
+  phase: string,
+  startMs: number,
+  limitMs: number,
+): Promise<T> {
+  const remaining = limitMs - (Date.now() - startMs);
+  if (remaining <= 0) {
+    throw new SessionWallClockError(phase, Date.now() - startMs, limitMs);
+  }
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new SessionWallClockError(phase, Date.now() - startMs, limitMs));
+    }, remaining);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e: unknown) => {
+        clearTimeout(timer);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      },
+    );
+  });
+}
+
+/**
+ * Resolve the session wall-clock limit (ms) from:
+ * 1. input.maxSessionWallClockMs (explicit override)
+ * 2. budget.max_session_wall_clock_minutes in config.json
+ * 3. DEFAULT_SESSION_WALL_CLOCK_MS (10 min)
+ */
+function resolveSessionWallClockMs(input: RunNewInput): number {
+  if (typeof input.maxSessionWallClockMs === "number") {
+    return input.maxSessionWallClockMs;
+  }
+  try {
+    const configPath = path.join(input.cwd, ".samo", "config.json");
+    if (existsSync(configPath)) {
+      const raw = readFileSync(configPath, "utf8");
+      const cfg = JSON.parse(raw) as Record<string, unknown>;
+      const budget = cfg["budget"];
+      if (
+        typeof budget === "object" &&
+        budget !== null &&
+        !Array.isArray(budget)
+      ) {
+        const minutes = (budget as Record<string, unknown>)[
+          "max_session_wall_clock_minutes"
+        ];
+        if (typeof minutes === "number" && minutes > 0) {
+          return Math.round(minutes * 60 * 1_000);
+        }
+      }
+    }
+  } catch {
+    // config unreadable — fall through to default.
+  }
+  return DEFAULT_SESSION_WALL_CLOCK_MS;
 }
 
 // ---------- CLI entry ----------
@@ -152,6 +250,10 @@ export async function runNew(
   const notice = (line: string): void => {
     lines.push(line);
   };
+
+  // Session wall-clock guard (#81): track start time and cap.
+  const sessionStartMs = Date.now();
+  const sessionLimitMs = resolveSessionWallClockMs(input);
 
   const samoDir = path.join(input.cwd, ".samo");
   const specsDir = path.join(samoDir, "spec");
@@ -323,17 +425,37 @@ export async function runNew(
     const subAuth = await resolveSubscriptionAuth(adapter);
     let persona: PersonaProposal;
     try {
-      persona = await proposePersonaInteractive(
-        {
-          idea: input.idea,
-          explain: input.explain,
-          subscriptionAuth: subAuth,
-          onNotice: notice,
-          resolver: input.resolvers.persona,
-        },
-        adapter,
+      persona = await withDeadline(
+        proposePersonaInteractive(
+          {
+            idea: input.idea,
+            explain: input.explain,
+            subscriptionAuth: subAuth,
+            onNotice: notice,
+            resolver: input.resolvers.persona,
+          },
+          adapter,
+        ),
+        "persona",
+        sessionStartMs,
+        sessionLimitMs,
       );
     } catch (err) {
+      if (err instanceof SessionWallClockError) {
+        state = { ...state, round_state: "lead_terminal" };
+        state.updated_at = input.now;
+        writeState(statePath, state);
+        errors.push(
+          `samospec: session-wall-clock exceeded at persona phase ` +
+            `(${String(err.elapsedMs)}ms elapsed, limit ${String(err.limitMs)}ms). ` +
+            `Restart with --force or increase budget.max_session_wall_clock_minutes.`,
+        );
+        return {
+          exitCode: 4,
+          stdout: lines.join("\n"),
+          stderr: `${errors.join("\n")}\n`,
+        };
+      }
       if (err instanceof PersonaTerminalError) {
         state = { ...state, round_state: "lead_terminal" };
         state.updated_at = input.now;
@@ -407,20 +529,40 @@ export async function runNew(
     const interviewPath = path.join(slugDir, "interview.json");
     let interview: InterviewResult;
     try {
-      interview = await runInterview(
-        {
-          slug: input.slug,
-          persona: persona.persona,
-          explain: input.explain,
-          subscriptionAuth: subAuth,
-          onQuestion: input.resolvers.question,
-          onNotice: notice,
-          outputPath: interviewPath,
-          now: input.now,
-        },
-        adapter,
+      interview = await withDeadline(
+        runInterview(
+          {
+            slug: input.slug,
+            persona: persona.persona,
+            explain: input.explain,
+            subscriptionAuth: subAuth,
+            onQuestion: input.resolvers.question,
+            onNotice: notice,
+            outputPath: interviewPath,
+            now: input.now,
+          },
+          adapter,
+        ),
+        "interview",
+        sessionStartMs,
+        sessionLimitMs,
       );
     } catch (err) {
+      if (err instanceof SessionWallClockError) {
+        state = { ...state, round_state: "lead_terminal" };
+        state.updated_at = input.now;
+        writeState(statePath, state);
+        errors.push(
+          `samospec: session-wall-clock exceeded at interview phase ` +
+            `(${String(err.elapsedMs)}ms elapsed, limit ${String(err.limitMs)}ms). ` +
+            `Restart with --force or increase budget.max_session_wall_clock_minutes.`,
+        );
+        return {
+          exitCode: 4,
+          stdout: lines.join("\n"),
+          stderr: `${errors.join("\n")}\n`,
+        };
+      }
       if (err instanceof InterviewTerminalError) {
         state = { ...state, round_state: "lead_terminal" };
         state.updated_at = input.now;
@@ -458,21 +600,41 @@ export async function runNew(
 
     let draft;
     try {
-      draft = await authorDraft(
-        {
-          slug: input.slug,
-          idea: input.idea,
-          persona: persona.persona,
-          interview,
-          contextChunks: chunks,
-          explain: input.explain,
-          ...(input.skipSections !== undefined
-            ? { skipSections: input.skipSections }
-            : {}),
-        },
-        adapter,
+      draft = await withDeadline(
+        authorDraft(
+          {
+            slug: input.slug,
+            idea: input.idea,
+            persona: persona.persona,
+            interview,
+            contextChunks: chunks,
+            explain: input.explain,
+            ...(input.skipSections !== undefined
+              ? { skipSections: input.skipSections }
+              : {}),
+          },
+          adapter,
+        ),
+        "draft",
+        sessionStartMs,
+        sessionLimitMs,
       );
     } catch (err) {
+      if (err instanceof SessionWallClockError) {
+        state = { ...state, round_state: "lead_terminal" };
+        state.updated_at = input.now;
+        writeState(statePath, state);
+        errors.push(
+          `samospec: session-wall-clock exceeded at draft phase ` +
+            `(${String(err.elapsedMs)}ms elapsed, limit ${String(err.limitMs)}ms). ` +
+            `Restart with --force or increase budget.max_session_wall_clock_minutes.`,
+        );
+        return {
+          exitCode: 4,
+          stdout: lines.join("\n"),
+          stderr: `${errors.join("\n")}\n`,
+        };
+      }
       if (err instanceof DraftTerminalError) {
         state = { ...state, round_state: "lead_terminal" };
         state.updated_at = input.now;

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -426,7 +426,12 @@ export async function runNew(
 
     // Initial state.json. Starts at phase 'detect' and advances as we
     // make progress so a crash leaves a truthful state record.
-    let state = newState({ slug: input.slug, now: input.now });
+    // #85: persist input.idea immediately so resume and iterate can
+    // thread it into prompt builders even if new is interrupted early.
+    let state = {
+      ...newState({ slug: input.slug, now: input.now }),
+      ...(input.idea.trim().length > 0 ? { input: { idea: input.idea } } : {}),
+    };
     const statePath = path.join(slugDir, "state.json");
     writeState(statePath, state);
 
@@ -716,6 +721,8 @@ export async function runNew(
     }
 
     // state.json: advance to committed, version v0.1, round 0.
+    // `state.input.idea` was already written at initialization time (#85)
+    // so resume + iterate have it even if new was interrupted.
     state = {
       ...state,
       round_state: "committed",

--- a/src/loop/round.ts
+++ b/src/loop/round.ts
@@ -133,6 +133,17 @@ export interface RunRoundInput {
   readonly reviewerUnavailableNote?: string;
   readonly degradedResolution?: DegradedResult;
   readonly signal?: AbortSignal;
+  /**
+   * #85 (v0.4.0): original --idea string. When present, threaded into
+   * Reviewer B's critique() call so it can flag idea-contradictions, and
+   * into the lead's revise() call so the AUTHORITATIVE framing appears.
+   */
+  readonly idea?: string;
+  /**
+   * #85 (v0.4.0): filesystem-safe slug (non-authoritative identifier).
+   * Passed alongside `idea` into the revise() prompt builder.
+   */
+  readonly slug?: string;
 }
 
 export type RoundStopReason =
@@ -378,6 +389,8 @@ export async function runRound(input: RunRoundInput): Promise<RunRoundOutcome> {
     guidelinesA: input.guidelinesA ?? "",
     guidelinesB: input.guidelinesB ?? "",
     ...(input.signal !== undefined ? { signal: input.signal } : {}),
+    // #85: thread idea to Reviewer B for contradiction detection.
+    ...(input.idea !== undefined ? { idea: input.idea } : {}),
   });
 
   // Persist seats + critique files atomically.
@@ -396,6 +409,8 @@ export async function runRound(input: RunRoundInput): Promise<RunRoundOutcome> {
       guidelinesA: input.guidelinesA ?? "",
       guidelinesB: input.guidelinesB ?? "",
       ...(input.signal !== undefined ? { signal: input.signal } : {}),
+      // #85: thread idea to Reviewer B for contradiction detection.
+      ...(input.idea !== undefined ? { idea: input.idea } : {}),
     });
     // Overwrite disk with the retry results.
     persistSeatResults(dirs, attempt2);
@@ -470,6 +485,10 @@ export async function runRound(input: RunRoundInput): Promise<RunRoundOutcome> {
       reviews: reviewsForLead,
       decisions_history: [...input.decisionsHistory],
       opts: { effort: "max", timeout: reviseTimeout },
+      // #85: thread idea + slug into the revise prompt for AUTHORITATIVE
+      // idea framing in every review-round lead call.
+      ...(input.idea !== undefined ? { idea: input.idea } : {}),
+      ...(input.slug !== undefined ? { slug: input.slug } : {}),
     });
 
     // Extract decisions from the response. Priority:
@@ -519,6 +538,8 @@ interface ReviewerParallelInput {
   readonly guidelinesA: string;
   readonly guidelinesB: string;
   readonly signal?: AbortSignal;
+  /** #85: idea string threaded into Reviewer B's critique() call. */
+  readonly idea?: string;
 }
 
 async function runReviewersParallel(
@@ -547,6 +568,9 @@ async function runReviewersParallel(
       spec: input.specText,
       guidelines: input.guidelinesB,
       opts: { effort: "max", timeout: input.critiqueTimeoutMs },
+      // #85: thread the original idea so Reviewer B can detect
+      // idea-contradictions against disclaimed classes.
+      ...(input.idea !== undefined ? { idea: input.idea } : {}),
     })
     .then<SeatOutcome>((critique) => ({
       seat: "reviewer_b",

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -150,6 +150,18 @@ export const stateSchema = z
     published_pr_url: z.string().min(1).optional(),
     created_at: isoTimestampSchema,
     updated_at: isoTimestampSchema,
+    /**
+     * #85 (v0.4.0): original user inputs recorded at `samospec new` time
+     * so subsequent commands (iterate, resume) can thread the idea string
+     * into prompt builders without requiring re-supply on the CLI.
+     */
+    input: z
+      .object({
+        /** Original --idea string (AUTHORITATIVE per SPEC §7 v0.4.0). */
+        idea: z.string().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/tests/adapter/claude-spawn-timeout.test.ts
+++ b/tests/adapter/claude-spawn-timeout.test.ts
@@ -1,0 +1,128 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED test for #81: per-call spawn timeout must kill the child process
+// and the Promise must resolve within ~timeoutMs (not hang waiting for
+// stream EOF after SIGKILL).
+//
+// Fake CLI = `sleep 3600` equivalent via bun -e.
+// Adapter ask({ timeout: 2000 }) must return a timeout-classified error
+// within ~3s AND the child PID must be dead.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+
+import { ClaudeAdapter, ClaudeAdapterError } from "../../src/adapter/claude.ts";
+import { spawnCli, type SpawnCliInput, type SpawnCliResult } from "../../src/adapter/spawn.ts";
+
+const BUN_DIR = dirname(process.execPath);
+
+const TMP: string[] = [];
+
+function makeFakeBinaryDir(name: string, script: string): { dir: string; binary: string } {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-timeout-bin-"));
+  TMP.push(dir);
+  const binary = join(dir, name);
+  writeFileSync(binary, `#!/bin/sh\n${script}\n`);
+  chmodSync(binary, 0o755);
+  return { dir, binary };
+}
+
+afterAll(() => {
+  for (const d of TMP) {
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+describe("spawnCli timeout: child PID must be dead after timeout fires (#81)", () => {
+  test("spawnCli returns { ok:false, reason:'timeout' } and the child is dead within 3x timeoutMs", async () => {
+    // Use a shell script that sleeps forever and reports its PID to stdout first.
+    const dir = mkdtempSync(join(tmpdir(), "samospec-pid-track-"));
+    TMP.push(dir);
+    const pidFile = join(dir, "child.pid");
+    const { dir: binDir, binary } = makeFakeBinaryDir(
+      "fake-sleep",
+      `echo $$ > ${pidFile}\nsleep 3600`,
+    );
+
+    const startMs = Date.now();
+    const result = await spawnCli({
+      cmd: [binary],
+      stdin: "",
+      env: {},
+      timeoutMs: 1500,
+      host: { PATH: `${binDir}:/bin:/usr/bin`, HOME: "/tmp" },
+    });
+    const elapsedMs = Date.now() - startMs;
+
+    // Must resolve as a timeout failure.
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("timeout");
+
+    // Must resolve within 3x timeout (generous for CI overhead).
+    expect(elapsedMs).toBeLessThan(1500 * 3);
+
+    // Child PID must be dead — if `process.kill(pid, 0)` throws ESRCH, it's dead.
+    // Give the OS a small moment to reap the process.
+    await new Promise((r) => setTimeout(r, 200));
+    const { readFileSync, existsSync } = await import("node:fs");
+    if (existsSync(pidFile)) {
+      const pidStr = readFileSync(pidFile, "utf8").trim();
+      const pid = parseInt(pidStr, 10);
+      if (!isNaN(pid)) {
+        let processAlive = false;
+        try {
+          process.kill(pid, 0);
+          processAlive = true;
+        } catch {
+          // ESRCH = not found = dead. Expected.
+          processAlive = false;
+        }
+        expect(processAlive).toBe(false);
+      }
+    }
+  });
+});
+
+describe("ClaudeAdapter.ask timeout: classified error within 3s for hanging CLI (#81)", () => {
+  test("adapter.ask({ timeout: 2000 }) returns ClaudeAdapterError with reason='timeout' when CLI hangs", async () => {
+    // Build a hanging fake 'claude' binary that sleeps forever.
+    const { dir, binary } = makeFakeBinaryDir("claude", "sleep 3600");
+
+    const adapter = new ClaudeAdapter({
+      binary,
+      host: {
+        PATH: `${dir}:/bin:/usr/bin`,
+        HOME: "/tmp",
+        ANTHROPIC_API_KEY: "sk-fake",
+      },
+    });
+
+    const startMs = Date.now();
+    let caughtErr: unknown = null;
+    try {
+      await adapter.ask({
+        prompt: "hello",
+        context: "",
+        opts: { effort: "max", timeout: 2000 },
+      });
+    } catch (err) {
+      caughtErr = err;
+    }
+    const elapsedMs = Date.now() - startMs;
+
+    // Must throw a ClaudeAdapterError with reason 'timeout'.
+    expect(caughtErr).toBeInstanceOf(ClaudeAdapterError);
+    if (caughtErr instanceof ClaudeAdapterError) {
+      expect(caughtErr.payload.reason).toBe("timeout");
+    }
+
+    // The worst-case capped retry for a 2000ms base is 2000+3000+2000=7000ms.
+    // Must resolve within 3.5x * timeout * 3 retries + generous padding = ~25s.
+    // But with the fix applied (stream abort), it should be well under 10s.
+    // For a RED test we want to verify it resolves at all (not hang for 22 min).
+    expect(elapsedMs).toBeLessThan(25_000);
+  }, 30_000);
+});

--- a/tests/adapter/claude-spawn-timeout.test.ts
+++ b/tests/adapter/claude-spawn-timeout.test.ts
@@ -11,16 +11,17 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, dirname } from "node:path";
+import { join } from "node:path";
 
 import { ClaudeAdapter, ClaudeAdapterError } from "../../src/adapter/claude.ts";
-import { spawnCli, type SpawnCliInput, type SpawnCliResult } from "../../src/adapter/spawn.ts";
-
-const BUN_DIR = dirname(process.execPath);
+import { spawnCli } from "../../src/adapter/spawn.ts";
 
 const TMP: string[] = [];
 
-function makeFakeBinaryDir(name: string, script: string): { dir: string; binary: string } {
+function makeFakeBinaryDir(
+  name: string,
+  script: string,
+): { dir: string; binary: string } {
   const dir = mkdtempSync(join(tmpdir(), "samospec-timeout-bin-"));
   TMP.push(dir);
   const binary = join(dir, name);
@@ -31,7 +32,11 @@ function makeFakeBinaryDir(name: string, script: string): { dir: string; binary:
 
 afterAll(() => {
   for (const d of TMP) {
-    try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
   }
 });
 

--- a/tests/adapter/claude-spawn-timeout.test.ts
+++ b/tests/adapter/claude-spawn-timeout.test.ts
@@ -82,8 +82,7 @@ describe("spawnCli timeout: child PID must be dead after timeout fires (#81)", (
           process.kill(pid, 0);
           processAlive = true;
         } catch {
-          // ESRCH = not found = dead. Expected.
-          processAlive = false;
+          // ESRCH = not found = dead. Expected; leaves processAlive=false.
         }
         expect(processAlive).toBe(false);
       }

--- a/tests/adapter/lead-prompt-idea-precedence.test.ts
+++ b/tests/adapter/lead-prompt-idea-precedence.test.ts
@@ -1,0 +1,139 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED tests for #85: --idea must be AUTHORITATIVE in all prompt builders.
+// The slug is a filesystem identifier only — the lead must not infer
+// project semantics from it when an idea string is present.
+//
+// Assertions use exact-substring matching so the implementation MUST
+// contain the required directive wording verbatim.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildAskPrompt,
+  buildRevisePrompt,
+} from "../../src/adapter/claude.ts";
+import type { AskInput, ReviseInput } from "../../src/adapter/types.ts";
+
+// ---------- shared fixtures ----------
+
+const IDEA = "NOT a CRUD todo app";
+const SLUG = "todo-stream";
+
+function makeReviseInputWithIdea(overrides?: {
+  idea?: string;
+  slug?: string;
+}): ReviseInput {
+  return {
+    spec: "# SPEC (v0.1 draft scaffold)\n\n## Project idea\n\ntodo\n",
+    reviews: [],
+    decisions_history: [],
+    opts: { effort: "max", timeout: 600_000 },
+    idea: overrides?.idea ?? IDEA,
+    slug: overrides?.slug ?? SLUG,
+  };
+}
+
+function makeAskInputWithIdea(overrides?: {
+  idea?: string;
+  slug?: string;
+}): AskInput {
+  return {
+    prompt: "Propose a persona for this idea.",
+    context: "",
+    opts: { effort: "max", timeout: 120_000 },
+    idea: overrides?.idea ?? IDEA,
+    slug: overrides?.slug ?? SLUG,
+  };
+}
+
+// ---------- buildRevisePrompt — idea-precedence framing ----------
+
+describe("buildRevisePrompt — idea-precedence framing (#85)", () => {
+  test('prompt contains the AUTHORITATIVE header "## Project idea (AUTHORITATIVE"', () => {
+    const prompt = buildRevisePrompt(makeReviseInputWithIdea());
+    expect(prompt).toContain("## Project idea (AUTHORITATIVE");
+  });
+
+  test("prompt contains the full --idea text verbatim", () => {
+    const prompt = buildRevisePrompt(makeReviseInputWithIdea());
+    expect(prompt).toContain(IDEA);
+  });
+
+  test('prompt contains "DO NOT infer semantics from it" slug directive', () => {
+    const prompt = buildRevisePrompt(makeReviseInputWithIdea());
+    expect(prompt).toContain("DO NOT infer semantics from it");
+  });
+
+  test('prompt contains "IDEA wins" conflict-resolution directive', () => {
+    const prompt = buildRevisePrompt(makeReviseInputWithIdea());
+    expect(prompt).toContain("IDEA wins");
+  });
+
+  test("slug appears under a non-authoritative header", () => {
+    const prompt = buildRevisePrompt(makeReviseInputWithIdea());
+    // The slug should appear in the prompt (under a non-authoritative header)
+    expect(prompt).toContain(SLUG);
+    // The slug section header must NOT contain "AUTHORITATIVE"
+    const slugHeaderIdx = prompt.indexOf("Project slug");
+    expect(slugHeaderIdx).toBeGreaterThanOrEqual(0);
+    const slugSection = prompt.slice(slugHeaderIdx, slugHeaderIdx + 200);
+    expect(slugSection).not.toContain("AUTHORITATIVE");
+  });
+
+  test("idea-precedence block appears when idea is provided", () => {
+    const prompt = buildRevisePrompt(makeReviseInputWithIdea());
+    // Must contain NOT disclaimers directive
+    expect(prompt).toContain("NOT X");
+  });
+
+  test("when no idea/slug provided, prompt still works (no crash)", () => {
+    const input: ReviseInput = {
+      spec: "# SPEC\n\nContent.",
+      reviews: [],
+      decisions_history: [],
+      opts: { effort: "max", timeout: 600_000 },
+    };
+    const prompt = buildRevisePrompt(input);
+    expect(typeof prompt).toBe("string");
+    expect(prompt.length).toBeGreaterThan(0);
+    // Without idea, AUTHORITATIVE block should not appear
+    expect(prompt).not.toContain("## Project idea (AUTHORITATIVE");
+  });
+});
+
+// ---------- buildAskPrompt — idea-precedence framing ----------
+
+describe("buildAskPrompt — idea-precedence framing (#85)", () => {
+  test('prompt contains the AUTHORITATIVE header when idea is provided', () => {
+    const prompt = buildAskPrompt(makeAskInputWithIdea());
+    expect(prompt).toContain("## Project idea (AUTHORITATIVE");
+  });
+
+  test("prompt contains the full --idea text verbatim", () => {
+    const prompt = buildAskPrompt(makeAskInputWithIdea());
+    expect(prompt).toContain(IDEA);
+  });
+
+  test('prompt contains "DO NOT infer semantics from it" slug directive', () => {
+    const prompt = buildAskPrompt(makeAskInputWithIdea());
+    expect(prompt).toContain("DO NOT infer semantics from it");
+  });
+
+  test('prompt contains "IDEA wins" conflict-resolution directive', () => {
+    const prompt = buildAskPrompt(makeAskInputWithIdea());
+    expect(prompt).toContain("IDEA wins");
+  });
+
+  test("ask prompt without idea still works (no crash, no AUTHORITATIVE block)", () => {
+    const input: AskInput = {
+      prompt: "Simple question.",
+      context: "",
+      opts: { effort: "max", timeout: 120_000 },
+    };
+    const prompt = buildAskPrompt(input);
+    expect(typeof prompt).toBe("string");
+    expect(prompt.length).toBeGreaterThan(0);
+    expect(prompt).not.toContain("## Project idea (AUTHORITATIVE");
+  });
+});

--- a/tests/adapter/lead-prompt-idea-precedence.test.ts
+++ b/tests/adapter/lead-prompt-idea-precedence.test.ts
@@ -9,10 +9,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import {
-  buildAskPrompt,
-  buildRevisePrompt,
-} from "../../src/adapter/claude.ts";
+import { buildAskPrompt, buildRevisePrompt } from "../../src/adapter/claude.ts";
 import type { AskInput, ReviseInput } from "../../src/adapter/types.ts";
 
 // ---------- shared fixtures ----------
@@ -105,7 +102,7 @@ describe("buildRevisePrompt — idea-precedence framing (#85)", () => {
 // ---------- buildAskPrompt — idea-precedence framing ----------
 
 describe("buildAskPrompt — idea-precedence framing (#85)", () => {
-  test('prompt contains the AUTHORITATIVE header when idea is provided', () => {
+  test("prompt contains the AUTHORITATIVE header when idea is provided", () => {
     const prompt = buildAskPrompt(makeAskInputWithIdea());
     expect(prompt).toContain("## Project idea (AUTHORITATIVE");
   });

--- a/tests/adapter/reviewer-b-idea-contradictions.test.ts
+++ b/tests/adapter/reviewer-b-idea-contradictions.test.ts
@@ -1,0 +1,269 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED tests for #85 Lever B: Reviewer B must receive the original idea
+// string and flag contradiction findings when the spec reintroduces a
+// class that the idea explicitly disclaimed.
+//
+// These tests drive ClaudeReviewerBAdapter through a fake-spawn harness
+// and inspect (a) what the prompt builder emits when given an idea-aware
+// CritiqueInput, and (b) that a synthetic Reviewer B response containing
+// a contradiction finding passes schema validation end-to-end.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ClaudeReviewerBAdapter,
+  REVIEWER_B_PERSONA_PREFIX,
+} from "../../src/adapter/claude-reviewer-b.ts";
+import { buildCritiquePromptForReviewerB } from "../../src/adapter/claude-reviewer-b.ts";
+import type { CritiqueInput } from "../../src/adapter/types.ts";
+import type { SpawnCliInput, SpawnCliResult } from "../../src/adapter/spawn.ts";
+
+// ---------- helpers ----------
+
+function makeInstalledHost(): Record<string, string | undefined> {
+  return {
+    PATH: "/usr/bin:/bin",
+    HOME: "/tmp",
+    ANTHROPIC_API_KEY: "sk-ant-test-fake-key",
+  };
+}
+
+const OPTS = { effort: "max" as const, timeout: 120_000 };
+
+function makeSpy(
+  scripted: SpawnCliResult,
+): { spawn: (i: SpawnCliInput) => Promise<SpawnCliResult>; calls: SpawnCliInput[] } {
+  const calls: SpawnCliInput[] = [];
+  const spawn = (i: SpawnCliInput): Promise<SpawnCliResult> => {
+    calls.push(i);
+    return Promise.resolve(scripted);
+  };
+  return { spawn, calls };
+}
+
+// ---------- buildCritiquePromptForReviewerB — exported builder ----------
+
+describe("buildCritiquePromptForReviewerB — idea-contradiction directive (#85)", () => {
+  test("exported function exists", () => {
+    expect(typeof buildCritiquePromptForReviewerB).toBe("function");
+  });
+
+  test("prompt includes the original idea string", () => {
+    const idea = "NOT a CRUD todo app";
+    const input: CritiqueInput = {
+      spec: "# Spec\n\n§5: todo-list CRUD operations for baseline tracking.",
+      guidelines: "be pedantic",
+      opts: OPTS,
+      idea,
+    };
+    const prompt = buildCritiquePromptForReviewerB(input);
+    expect(prompt).toContain(idea);
+  });
+
+  test('prompt instructs reviewer B to flag "contradiction" for disclaimed classes', () => {
+    const input: CritiqueInput = {
+      spec: "# Spec",
+      guidelines: "",
+      opts: OPTS,
+      idea: "NOT a todo-list app",
+    };
+    const prompt = buildCritiquePromptForReviewerB(input);
+    // Must instruct to flag contradiction findings
+    expect(prompt).toContain("contradiction");
+  });
+
+  test('prompt instructs to quote the disclaimer', () => {
+    const input: CritiqueInput = {
+      spec: "# Spec",
+      guidelines: "",
+      opts: OPTS,
+      idea: "NOT a todo-list app",
+    };
+    const prompt = buildCritiquePromptForReviewerB(input);
+    // Must tell reviewer B to quote the disclaimer text
+    const lower = prompt.toLowerCase();
+    const hasQuote =
+      lower.includes("quote") ||
+      lower.includes("disclaim") ||
+      lower.includes("disclaimer");
+    expect(hasQuote).toBe(true);
+  });
+
+  test("prompt still includes REVIEWER_B_PERSONA_PREFIX framing", () => {
+    const input: CritiqueInput = {
+      spec: "# Spec",
+      guidelines: "",
+      opts: OPTS,
+      idea: "CLI that greps comments. NOT a todo-list app.",
+    };
+    const prompt = buildCritiquePromptForReviewerB(input);
+    expect(prompt).toContain("ambiguity");
+    expect(prompt).toContain("weak-testing");
+  });
+
+  test("when no idea provided, prompt still works and is a valid string", () => {
+    const input: CritiqueInput = {
+      spec: "# Spec",
+      guidelines: "",
+      opts: OPTS,
+    };
+    const prompt = buildCritiquePromptForReviewerB(input);
+    expect(typeof prompt).toBe("string");
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------- ClaudeReviewerBAdapter — idea threaded through critique() ----------
+
+describe("ClaudeReviewerBAdapter — idea in critique() call (#85)", () => {
+  test("critique() prompt carries the idea string when CritiqueInput.idea is set", async () => {
+    const idea = "NOT a CRUD todo app";
+    const contradictionFinding = {
+      category: "contradiction" as const,
+      text: 'Spec §5 describes "todo-list CRUD" — this contradicts the idea disclaimer: "NOT a CRUD todo app".',
+      severity: "major" as const,
+    };
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: JSON.stringify({
+        findings: [contradictionFinding],
+        summary: "Reviewer B flagged an idea-contradiction in §5.",
+        suggested_next_version: "0.1.1",
+        usage: null,
+        effort_used: "max",
+      }),
+      stderr: "",
+    });
+
+    const adapter = new ClaudeReviewerBAdapter({
+      host: makeInstalledHost(),
+      spawn: spy.spawn,
+    });
+
+    const input: CritiqueInput = {
+      spec: "# todo-stream SPEC v0.1\n\n§5: todo-list CRUD operations baseline.",
+      guidelines: "",
+      opts: OPTS,
+      idea,
+    };
+
+    const result = await adapter.critique(input);
+
+    // Prompt must carry the idea string.
+    const workCall = spy.calls.find((c) => c.stdin.length > 0);
+    expect(workCall).toBeDefined();
+    if (workCall === undefined) return;
+    expect(workCall.stdin).toContain(idea);
+
+    // Result must contain a contradiction finding.
+    const contradictions = result.findings.filter(
+      (f) => f.category === "contradiction",
+    );
+    expect(contradictions.length).toBeGreaterThan(0);
+    const cf = contradictions[0];
+    expect(cf).toBeDefined();
+    if (cf === undefined) return;
+    expect(cf.severity).toBe("major");
+    // The finding text should quote the disclaimer
+    expect(cf.text).toContain("NOT a CRUD todo app");
+  });
+
+  test("critique() without idea still works (backward compatible)", async () => {
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: JSON.stringify({
+        findings: [],
+        summary: "looks good",
+        suggested_next_version: "0.1.1",
+        usage: null,
+        effort_used: "max",
+      }),
+      stderr: "",
+    });
+
+    const adapter = new ClaudeReviewerBAdapter({
+      host: makeInstalledHost(),
+      spawn: spy.spawn,
+    });
+
+    const result = await adapter.critique({
+      spec: "# SPEC\n\nContent.",
+      guidelines: "",
+      opts: OPTS,
+    });
+
+    expect(result.findings).toHaveLength(0);
+    expect(result.summary).toBe("looks good");
+  });
+});
+
+// ---------- fake integration: spec reintroduces disclaimed class ----------
+
+describe("Reviewer B — fake integration: contradiction detection (#85)", () => {
+  test("when spec mentions 'todo-list CRUD' and idea disclaimed it, reviewer B emits contradiction", async () => {
+    // Spec §5 reintroduces "todo-list CRUD" — exactly what the idea disclaimed.
+    const idea = "NOT a CRUD todo app";
+    const specWithContradiction =
+      "# todo-stream SPEC v0.1\n\n" +
+      "## §4 Architecture\nBun/TypeScript CLI.\n\n" +
+      "## §5 Implementation details\n" +
+      "todo-list CRUD baseline add and .todo-stream-ignore for tracking.\n";
+
+    // Fake Reviewer B emits a contradiction finding that quotes the disclaimer.
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: JSON.stringify({
+        findings: [
+          {
+            category: "contradiction",
+            text:
+              'Spec §5 reintroduces "todo-list CRUD" operations — this contradicts the ' +
+              'idea disclaimer "NOT a CRUD todo app". Remove CRUD baseline tracking.',
+            severity: "major",
+          },
+        ],
+        summary:
+          "Reviewer B found 1 idea-contradiction: spec §5 reintroduces disclaimed CRUD framing.",
+        suggested_next_version: "0.1.1",
+        usage: null,
+        effort_used: "max",
+      }),
+      stderr: "",
+    });
+
+    const adapter = new ClaudeReviewerBAdapter({
+      host: makeInstalledHost(),
+      spawn: spy.spawn,
+    });
+
+    const result = await adapter.critique({
+      spec: specWithContradiction,
+      guidelines: "",
+      opts: OPTS,
+      idea,
+    });
+
+    // Must have at least one contradiction finding.
+    const contradictions = result.findings.filter(
+      (f) => f.category === "contradiction",
+    );
+    expect(contradictions.length).toBeGreaterThanOrEqual(1);
+
+    // The contradiction finding must quote the disclaimer.
+    const cf = contradictions[0];
+    expect(cf).toBeDefined();
+    if (cf === undefined) return;
+    expect(cf.text).toContain("NOT a CRUD todo app");
+    expect(cf.severity).toBe("major");
+
+    // Prompt sent to the (fake) Reviewer B must include the idea string.
+    const workCall = spy.calls.find((c) => c.stdin.length > 0);
+    expect(workCall).toBeDefined();
+    if (workCall === undefined) return;
+    expect(workCall.stdin).toContain(idea);
+  });
+});

--- a/tests/adapter/reviewer-b-idea-contradictions.test.ts
+++ b/tests/adapter/reviewer-b-idea-contradictions.test.ts
@@ -13,9 +13,8 @@ import { describe, expect, test } from "bun:test";
 
 import {
   ClaudeReviewerBAdapter,
-  REVIEWER_B_PERSONA_PREFIX,
+  buildCritiquePromptForReviewerB,
 } from "../../src/adapter/claude-reviewer-b.ts";
-import { buildCritiquePromptForReviewerB } from "../../src/adapter/claude-reviewer-b.ts";
 import type { CritiqueInput } from "../../src/adapter/types.ts";
 import type { SpawnCliInput, SpawnCliResult } from "../../src/adapter/spawn.ts";
 
@@ -31,9 +30,10 @@ function makeInstalledHost(): Record<string, string | undefined> {
 
 const OPTS = { effort: "max" as const, timeout: 120_000 };
 
-function makeSpy(
-  scripted: SpawnCliResult,
-): { spawn: (i: SpawnCliInput) => Promise<SpawnCliResult>; calls: SpawnCliInput[] } {
+function makeSpy(scripted: SpawnCliResult): {
+  spawn: (i: SpawnCliInput) => Promise<SpawnCliResult>;
+  calls: SpawnCliInput[];
+} {
   const calls: SpawnCliInput[] = [];
   const spawn = (i: SpawnCliInput): Promise<SpawnCliResult> => {
     calls.push(i);
@@ -73,7 +73,7 @@ describe("buildCritiquePromptForReviewerB — idea-contradiction directive (#85)
     expect(prompt).toContain("contradiction");
   });
 
-  test('prompt instructs to quote the disclaimer', () => {
+  test("prompt instructs to quote the disclaimer", () => {
     const input: CritiqueInput = {
       spec: "# Spec",
       guidelines: "",

--- a/tests/cli/new-hang-recovery.test.ts
+++ b/tests/cli/new-hang-recovery.test.ts
@@ -34,20 +34,28 @@ function makeHangingAdapter(): Adapter {
   const auth: AuthStatus = { authenticated: true, subscription_auth: false };
   return {
     vendor: "fake-hang",
-    detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+    detect: (): Promise<DetectResult> =>
+      Promise.resolve({ installed: true, version: "0", path: "/fake" }),
     auth_status: (): Promise<AuthStatus> => Promise.resolve(auth),
     supports_structured_output: () => true,
     supports_effort: (_level: EffortLevel) => true,
-    models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
+    models: (): Promise<readonly ModelInfo[]> =>
+      Promise.resolve([{ id: "fake", family: "fake" }]),
     ask: (_input: AskInput): Promise<AskOutput> => {
       // Hangs forever — the session wall-clock guard must preempt this.
-      return new Promise(() => { /* never resolves */ });
+      return new Promise(() => {
+        /* never resolves */
+      });
     },
     critique: (_input: CritiqueInput): Promise<CritiqueOutput> => {
-      return new Promise(() => { /* never resolves */ });
+      return new Promise(() => {
+        /* never resolves */
+      });
     },
     revise: (_input: ReviseInput): Promise<ReviseOutput> => {
-      return new Promise(() => { /* never resolves */ });
+      return new Promise(() => {
+        /* never resolves */
+      });
     },
   };
 }
@@ -69,38 +77,34 @@ afterEach(() => {
 });
 
 describe("samospec new hang recovery (#81)", () => {
-  test(
-    "runNew with hanging adapter exits within 10s with exit 4 + session-wall-clock reason",
-    async () => {
-      const adapter = makeHangingAdapter();
-      const startMs = Date.now();
+  test("runNew with hanging adapter exits within 10s with exit 4 + session-wall-clock reason", async () => {
+    const adapter = makeHangingAdapter();
+    const startMs = Date.now();
 
-      // maxWallClockMinutes: use a config-file based cap.
-      // The test sets max_session_wall_clock_minutes=0.08 (≈5s) via RunNewInput.
-      const result = await runNew(
-        {
-          cwd: tmp,
-          slug: "demo",
-          idea: "test idea",
-          explain: false,
-          resolvers: acceptResolvers(),
-          now: "2026-04-19T10:00:00Z",
-          // 5-second session wall-clock cap via new field.
-          maxSessionWallClockMs: 5_000,
-        },
-        adapter,
-      );
-      const elapsedMs = Date.now() - startMs;
+    // maxWallClockMinutes: use a config-file based cap.
+    // The test sets max_session_wall_clock_minutes=0.08 (≈5s) via RunNewInput.
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "test idea",
+        explain: false,
+        resolvers: acceptResolvers(),
+        now: "2026-04-19T10:00:00Z",
+        // 5-second session wall-clock cap via new field.
+        maxSessionWallClockMs: 5_000,
+      },
+      adapter,
+    );
+    const elapsedMs = Date.now() - startMs;
 
-      // Must terminate within 10s.
-      expect(elapsedMs).toBeLessThan(10_000);
+    // Must terminate within 10s.
+    expect(elapsedMs).toBeLessThan(10_000);
 
-      // Must exit with exit code 4 (lead_terminal).
-      expect(result.exitCode).toBe(4);
+    // Must exit with exit code 4 (lead_terminal).
+    expect(result.exitCode).toBe(4);
 
-      // stderr must contain "session-wall-clock" reason (not a generic "adapter error").
-      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
-    },
-    12_000, // Bun test timeout: 12s
-  );
+    // stderr must contain "session-wall-clock" reason (not a generic "adapter error").
+    expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+  }, 12_000); // Bun test timeout: 12s
 });

--- a/tests/cli/new-hang-recovery.test.ts
+++ b/tests/cli/new-hang-recovery.test.ts
@@ -1,0 +1,106 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED test for #81: `samospec new <slug>` with a mock adapter that hangs
+// on the first `ask` call must exit within configurable timeout (5s in
+// this test) with `lead_terminal` reason and a specific `timeout` message.
+//
+// The adapter hangs forever on ask(). With the session wall-clock guard
+// in place, runNew must kill the hanging phase and return exit 4 with
+// a message containing "timeout" and "session-wall-clock".
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  AuthStatus,
+  CritiqueInput,
+  CritiqueOutput,
+  DetectResult,
+  EffortLevel,
+  ModelInfo,
+  ReviseInput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+import { runInit } from "../../src/cli/init.ts";
+
+// Adapter that hangs on ask() indefinitely.
+function makeHangingAdapter(): Adapter {
+  const auth: AuthStatus = { authenticated: true, subscription_auth: false };
+  return {
+    vendor: "fake-hang",
+    detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+    auth_status: (): Promise<AuthStatus> => Promise.resolve(auth),
+    supports_structured_output: () => true,
+    supports_effort: (_level: EffortLevel) => true,
+    models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
+    ask: (_input: AskInput): Promise<AskOutput> => {
+      // Hangs forever — the session wall-clock guard must preempt this.
+      return new Promise(() => { /* never resolves */ });
+    },
+    critique: (_input: CritiqueInput): Promise<CritiqueOutput> => {
+      return new Promise(() => { /* never resolves */ });
+    },
+    revise: (_input: ReviseInput): Promise<ReviseOutput> => {
+      return new Promise(() => { /* never resolves */ });
+    },
+  };
+}
+
+function acceptResolvers(): ChoiceResolvers {
+  return {
+    persona: () => Promise.resolve({ kind: "accept" }),
+    question: (_q) => Promise.resolve({ choice: "decide for me" }),
+  };
+}
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-hang-"));
+  runInit({ cwd: tmp });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("samospec new hang recovery (#81)", () => {
+  test(
+    "runNew with hanging adapter exits within 10s with exit 4 + session-wall-clock reason",
+    async () => {
+      const adapter = makeHangingAdapter();
+      const startMs = Date.now();
+
+      // maxWallClockMinutes: use a config-file based cap.
+      // The test sets max_session_wall_clock_minutes=0.08 (≈5s) via RunNewInput.
+      const result = await runNew(
+        {
+          cwd: tmp,
+          slug: "demo",
+          idea: "test idea",
+          explain: false,
+          resolvers: acceptResolvers(),
+          now: "2026-04-19T10:00:00Z",
+          // 5-second session wall-clock cap via new field.
+          maxSessionWallClockMs: 5_000,
+        },
+        adapter,
+      );
+      const elapsedMs = Date.now() - startMs;
+
+      // Must terminate within 10s.
+      expect(elapsedMs).toBeLessThan(10_000);
+
+      // Must exit with exit code 4 (lead_terminal).
+      expect(result.exitCode).toBe(4);
+
+      // stderr must contain "session-wall-clock" reason (not a generic "adapter error").
+      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+    },
+    12_000, // Bun test timeout: 12s
+  );
+});

--- a/tests/cli/new-max-session-wall-clock-ms-flag.test.ts
+++ b/tests/cli/new-max-session-wall-clock-ms-flag.test.ts
@@ -1,0 +1,175 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// CLI-level e2e for `--max-session-wall-clock-ms` (#81, PR #83 review).
+//
+// The runtime plumbing in src/cli/new.ts already honors
+// `RunNewInput.maxSessionWallClockMs`, but the CLI parser in src/cli.ts
+// must also accept `--max-session-wall-clock-ms <ms>` (or `=ms`) and
+// thread the value into `runNew`. Without the parser change users
+// running `samospec new demo --max-session-wall-clock-ms 5000` would
+// fall back to the 10-minute default — the exact "unit tests pass, CLI
+// never invokes" pattern that bit #79/#80.
+//
+// Strategy: spawn a real `bun run src/main.ts new <slug>` in a tmpdir
+// with a stub `claude` binary on PATH that hangs forever. With a 5s
+// cap, the command MUST terminate within ~7s and stderr MUST contain
+// `session-wall-clock`. The pre-fix CLI ignores the flag; the hang
+// would fall back to the 10-min default → test times out.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const CLI_PATH = path.resolve(import.meta.dir, "..", "..", "src", "main.ts");
+
+let tmp: string;
+let fakeHome: string;
+let fakeBin: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-wallclock-cli-"));
+  fakeHome = mkdtempSync(path.join(tmpdir(), "samospec-wallclock-home-"));
+  fakeBin = mkdtempSync(path.join(tmpdir(), "samospec-wallclock-bin-"));
+
+  // Write a hanging fake `claude` binary: sleeps forever on any invocation.
+  const claudeStub = path.join(fakeBin, "claude");
+  writeFileSync(claudeStub, "#!/bin/sh\nsleep 3600\n");
+  chmodSync(claudeStub, 0o755);
+
+  // Also stub `codex` so reviewer_a preflight doesn't error out before
+  // the lead phase starts.
+  const codexStub = path.join(fakeBin, "codex");
+  writeFileSync(
+    codexStub,
+    "#!/bin/sh\n" +
+      'if [ "$1" = "--version" ]; then echo "0.0.0-fake"; exit 0; fi\n' +
+      "sleep 3600\n",
+  );
+  chmodSync(codexStub, 0o755);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  rmSync(fakeHome, { recursive: true, force: true });
+  rmSync(fakeBin, { recursive: true, force: true });
+});
+
+function runSamospec(
+  args: readonly string[],
+  opts: { cwd: string; timeoutMs?: number } = { cwd: tmp },
+): { stdout: string; stderr: string; status: number; elapsedMs: number } {
+  const env: Record<string, string> = {
+    PATH: `${fakeBin}:/bin:/usr/bin:/usr/local/bin`,
+    HOME: fakeHome,
+    NO_COLOR: "1",
+    ANTHROPIC_API_KEY: "sk-fake-test-key",
+  };
+  const bun = Bun.argv[0];
+  const startMs = Date.now();
+  const result = spawnSync(bun, ["run", CLI_PATH, ...(args as string[])], {
+    cwd: opts.cwd,
+    encoding: "utf8",
+    env,
+    timeout: opts.timeoutMs ?? 15_000,
+  });
+  const elapsedMs = Date.now() - startMs;
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status ?? 1,
+    elapsedMs,
+  };
+}
+
+describe("samospec new --max-session-wall-clock-ms (CLI flag, #81)", () => {
+  test("USAGE string documents --max-session-wall-clock-ms", () => {
+    const res = runSamospec([], { cwd: tmp, timeoutMs: 8_000 });
+    expect(res.stderr.toLowerCase()).toContain("--max-session-wall-clock-ms");
+  });
+
+  test("--max-session-wall-clock-ms 5000 caps a hanging session to ~5s", () => {
+    // Init the repo (git + .samo/).
+    spawnSync("git", ["init", "--initial-branch", "feature/wc-e2e", tmp], {
+      cwd: tmpdir(),
+      encoding: "utf8",
+    });
+    const initRes = runSamospec(["init"], { cwd: tmp, timeoutMs: 8_000 });
+    expect(initRes.status).toBe(0);
+
+    // Now run `samospec new demo --max-session-wall-clock-ms 5000`
+    // with the hanging `claude` stub on PATH. Must exit within ~7s.
+    const startMs = Date.now();
+    const res = runSamospec(
+      [
+        "new",
+        "demo",
+        "--idea",
+        "cli flag test",
+        "--max-session-wall-clock-ms",
+        "5000",
+      ],
+      { cwd: tmp, timeoutMs: 12_000 },
+    );
+    const elapsedMs = Date.now() - startMs;
+
+    // Must terminate within 10s (gives ~5s cap + overhead).
+    expect(elapsedMs).toBeLessThan(10_000);
+
+    // Must exit with non-zero (4 from runNew, or 1 from parser) and
+    // stderr must mention session-wall-clock.
+    expect(res.status).not.toBe(0);
+    expect(res.stderr.toLowerCase()).toContain("session-wall-clock");
+  }, 20_000);
+
+  test("--max-session-wall-clock-ms=5000 (equals form) also caps a hanging session", () => {
+    spawnSync("git", ["init", "--initial-branch", "feature/wc-eq", tmp], {
+      cwd: tmpdir(),
+      encoding: "utf8",
+    });
+    const initRes = runSamospec(["init"], { cwd: tmp, timeoutMs: 8_000 });
+    expect(initRes.status).toBe(0);
+
+    const startMs = Date.now();
+    const res = runSamospec(
+      [
+        "new",
+        "demo-eq",
+        "--idea",
+        "eq form test",
+        "--max-session-wall-clock-ms=5000",
+      ],
+      { cwd: tmp, timeoutMs: 12_000 },
+    );
+    const elapsedMs = Date.now() - startMs;
+
+    expect(elapsedMs).toBeLessThan(10_000);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr.toLowerCase()).toContain("session-wall-clock");
+  }, 20_000);
+
+  test("--max-session-wall-clock-ms with non-integer value rejects with exit 1", () => {
+    spawnSync("git", ["init", "--initial-branch", "feature/wc-bad", tmp], {
+      cwd: tmpdir(),
+      encoding: "utf8",
+    });
+    const initRes = runSamospec(["init"], { cwd: tmp, timeoutMs: 8_000 });
+    expect(initRes.status).toBe(0);
+
+    const res = runSamospec(
+      [
+        "new",
+        "demo-bad",
+        "--idea",
+        "bad value",
+        "--max-session-wall-clock-ms",
+        "not-a-number",
+      ],
+      { cwd: tmp, timeoutMs: 8_000 },
+    );
+    expect(res.status).toBe(1);
+    // Error must name the flag so the user can diagnose.
+    expect(res.stderr.toLowerCase()).toContain("max-session-wall-clock-ms");
+  });
+});

--- a/tests/cli/session-wallclock.test.ts
+++ b/tests/cli/session-wallclock.test.ts
@@ -37,14 +37,25 @@ function makeHangingAdapter(): Adapter {
   const auth: AuthStatus = { authenticated: true, subscription_auth: false };
   return {
     vendor: "fake-hang",
-    detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+    detect: (): Promise<DetectResult> =>
+      Promise.resolve({ installed: true, version: "0", path: "/fake" }),
     auth_status: (): Promise<AuthStatus> => Promise.resolve(auth),
     supports_structured_output: () => true,
     supports_effort: (_level: EffortLevel) => true,
-    models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
-    ask: (_input: AskInput): Promise<AskOutput> => new Promise(() => { /* hangs */ }),
-    critique: (_input: CritiqueInput): Promise<CritiqueOutput> => new Promise(() => { /* hangs */ }),
-    revise: (_input: ReviseInput): Promise<ReviseOutput> => new Promise(() => { /* hangs */ }),
+    models: (): Promise<readonly ModelInfo[]> =>
+      Promise.resolve([{ id: "fake", family: "fake" }]),
+    ask: (_input: AskInput): Promise<AskOutput> =>
+      new Promise(() => {
+        /* hangs */
+      }),
+    critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
+      new Promise(() => {
+        /* hangs */
+      }),
+    revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+      new Promise(() => {
+        /* hangs */
+      }),
   };
 }
 
@@ -65,116 +76,120 @@ afterEach(() => {
 });
 
 describe("session wall-clock cap (#81)", () => {
-  test(
-    "exceeding wall-clock cap terminates with exit 4 + session-wall-clock reason",
-    async () => {
-      const adapter = makeHangingAdapter();
-      const startMs = Date.now();
+  test("exceeding wall-clock cap terminates with exit 4 + session-wall-clock reason", async () => {
+    const adapter = makeHangingAdapter();
+    const startMs = Date.now();
 
-      const result = await runNew(
-        {
-          cwd: tmp,
-          slug: "wc-test",
-          idea: "wall clock test",
-          explain: false,
-          resolvers: acceptResolvers(),
-          now: "2026-04-19T10:00:00Z",
-          // 3-second session wall-clock cap.
-          maxSessionWallClockMs: 3_000,
-        },
-        adapter,
-      );
-      const elapsedMs = Date.now() - startMs;
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "wc-test",
+        idea: "wall clock test",
+        explain: false,
+        resolvers: acceptResolvers(),
+        now: "2026-04-19T10:00:00Z",
+        // 3-second session wall-clock cap.
+        maxSessionWallClockMs: 3_000,
+      },
+      adapter,
+    );
+    const elapsedMs = Date.now() - startMs;
 
-      expect(elapsedMs).toBeLessThan(8_000);
-      expect(result.exitCode).toBe(4);
-      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
-    },
-    10_000,
-  );
+    expect(elapsedMs).toBeLessThan(8_000);
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+  }, 10_000);
 
-  test(
-    "wall-clock cap is read from config.json budget.max_session_wall_clock_minutes",
-    async () => {
-      // Patch the config to set max_session_wall_clock_minutes = 0.05 (3s).
-      const configPath = path.join(tmp, ".samo", "config.json");
-      const raw = readFileSync(configPath, "utf8");
-      const cfg = JSON.parse(raw) as Record<string, unknown>;
-      const budget = (cfg["budget"] ?? {}) as Record<string, unknown>;
-      budget["max_session_wall_clock_minutes"] = 0.05; // ~3s
-      cfg["budget"] = budget;
-      writeFileSync(configPath, JSON.stringify(cfg, null, 2));
+  test("wall-clock cap is read from config.json budget.max_session_wall_clock_minutes", async () => {
+    // Patch the config to set max_session_wall_clock_minutes = 0.05 (3s).
+    const configPath = path.join(tmp, ".samo", "config.json");
+    const raw = readFileSync(configPath, "utf8");
+    const cfg = JSON.parse(raw) as Record<string, unknown>;
+    const budget = (cfg["budget"] ?? {}) as Record<string, unknown>;
+    budget["max_session_wall_clock_minutes"] = 0.05; // ~3s
+    cfg["budget"] = budget;
+    writeFileSync(configPath, JSON.stringify(cfg, null, 2));
 
-      const adapter = makeHangingAdapter();
-      const startMs = Date.now();
+    const adapter = makeHangingAdapter();
+    const startMs = Date.now();
 
-      // Do NOT pass maxSessionWallClockMs — must read from config.
-      const result = await runNew(
-        {
-          cwd: tmp,
-          slug: "cfg-wc",
-          idea: "config wall clock test",
-          explain: false,
-          resolvers: acceptResolvers(),
-          now: "2026-04-19T10:00:00Z",
-        },
-        adapter,
-      );
-      const elapsedMs = Date.now() - startMs;
+    // Do NOT pass maxSessionWallClockMs — must read from config.
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "cfg-wc",
+        idea: "config wall clock test",
+        explain: false,
+        resolvers: acceptResolvers(),
+        now: "2026-04-19T10:00:00Z",
+      },
+      adapter,
+    );
+    const elapsedMs = Date.now() - startMs;
 
-      expect(elapsedMs).toBeLessThan(10_000);
-      expect(result.exitCode).toBe(4);
-      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
-    },
-    12_000,
-  );
+    expect(elapsedMs).toBeLessThan(10_000);
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+  }, 12_000);
 
-  test(
-    "session that completes within wall-clock cap exits 0",
-    async () => {
-      // Fast-responding adapter that completes immediately.
-      const personaJson = JSON.stringify({
-        persona: 'Veteran "CLI engineer" expert',
-        rationale: "fast",
-      });
-      const questionsJson = JSON.stringify({
-        questions: [{ id: "q1", text: "scope?", options: ["narrow", "wide"] }],
-      });
-      let callCount = 0;
-      const fastAdapter: Adapter = {
-        vendor: "fake-fast",
-        detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
-        auth_status: (): Promise<AuthStatus> => Promise.resolve({ authenticated: true, subscription_auth: false }),
-        supports_structured_output: () => true,
-        supports_effort: (_level: EffortLevel) => true,
-        models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
-        ask: (_input: AskInput): Promise<AskOutput> => {
-          const c = callCount++;
-          const answer = c === 0 ? personaJson : questionsJson;
-          return Promise.resolve({ answer, usage: null, effort_used: "max" });
-        },
-        critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
-          Promise.resolve({ findings: [], summary: "ok", suggested_next_version: "0.1.1", usage: null, effort_used: "max" }),
-        revise: (_input: ReviseInput): Promise<ReviseOutput> =>
-          Promise.resolve({ spec: "# SPEC\n\nok.", ready: true, rationale: "done", decisions: [], usage: null, effort_used: "max" }),
-      };
+  test("session that completes within wall-clock cap exits 0", async () => {
+    // Fast-responding adapter that completes immediately.
+    const personaJson = JSON.stringify({
+      persona: 'Veteran "CLI engineer" expert',
+      rationale: "fast",
+    });
+    const questionsJson = JSON.stringify({
+      questions: [{ id: "q1", text: "scope?", options: ["narrow", "wide"] }],
+    });
+    let callCount = 0;
+    const fastAdapter: Adapter = {
+      vendor: "fake-fast",
+      detect: (): Promise<DetectResult> =>
+        Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+      auth_status: (): Promise<AuthStatus> =>
+        Promise.resolve({ authenticated: true, subscription_auth: false }),
+      supports_structured_output: () => true,
+      supports_effort: (_level: EffortLevel) => true,
+      models: (): Promise<readonly ModelInfo[]> =>
+        Promise.resolve([{ id: "fake", family: "fake" }]),
+      ask: (_input: AskInput): Promise<AskOutput> => {
+        const c = callCount++;
+        const answer = c === 0 ? personaJson : questionsJson;
+        return Promise.resolve({ answer, usage: null, effort_used: "max" });
+      },
+      critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
+        Promise.resolve({
+          findings: [],
+          summary: "ok",
+          suggested_next_version: "0.1.1",
+          usage: null,
+          effort_used: "max",
+        }),
+      revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+        Promise.resolve({
+          spec: "# SPEC\n\nok.",
+          ready: true,
+          rationale: "done",
+          decisions: [],
+          usage: null,
+          effort_used: "max",
+        }),
+    };
 
-      const result = await runNew(
-        {
-          cwd: tmp,
-          slug: "fast-run",
-          idea: "fast test",
-          explain: false,
-          resolvers: acceptResolvers(),
-          now: "2026-04-19T10:00:00Z",
-          // 10-minute cap — should be more than enough.
-          maxSessionWallClockMs: 600_000,
-        },
-        fastAdapter,
-      );
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "fast-run",
+        idea: "fast test",
+        explain: false,
+        resolvers: acceptResolvers(),
+        now: "2026-04-19T10:00:00Z",
+        // 10-minute cap — should be more than enough.
+        maxSessionWallClockMs: 600_000,
+      },
+      fastAdapter,
+    );
 
-      expect(result.exitCode).toBe(0);
-    },
-    30_000,
-  );
+    expect(result.exitCode).toBe(0);
+  }, 30_000);
 });

--- a/tests/cli/session-wallclock.test.ts
+++ b/tests/cli/session-wallclock.test.ts
@@ -1,0 +1,180 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED test for #81: session wall-clock cap.
+//
+// SPEC §7 default: 10 minutes session wall-clock cap, configurable via
+// `.samo/config.json` `budget.max_session_wall_clock_minutes`.
+//
+// Tests:
+// 1. A session that exceeds the wall-clock cap terminates with reason
+//    `session-wall-clock` and exit code 4.
+// 2. The cap is read from config.json `budget.max_session_wall_clock_minutes`
+//    when present.
+// 3. A session that completes within the cap succeeds normally.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  AuthStatus,
+  CritiqueInput,
+  CritiqueOutput,
+  DetectResult,
+  EffortLevel,
+  ModelInfo,
+  ReviseInput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+import { runInit } from "../../src/cli/init.ts";
+
+function makeHangingAdapter(): Adapter {
+  const auth: AuthStatus = { authenticated: true, subscription_auth: false };
+  return {
+    vendor: "fake-hang",
+    detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+    auth_status: (): Promise<AuthStatus> => Promise.resolve(auth),
+    supports_structured_output: () => true,
+    supports_effort: (_level: EffortLevel) => true,
+    models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
+    ask: (_input: AskInput): Promise<AskOutput> => new Promise(() => { /* hangs */ }),
+    critique: (_input: CritiqueInput): Promise<CritiqueOutput> => new Promise(() => { /* hangs */ }),
+    revise: (_input: ReviseInput): Promise<ReviseOutput> => new Promise(() => { /* hangs */ }),
+  };
+}
+
+function acceptResolvers(): ChoiceResolvers {
+  return {
+    persona: () => Promise.resolve({ kind: "accept" }),
+    question: (_q) => Promise.resolve({ choice: "decide for me" }),
+  };
+}
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-wallclock-"));
+  runInit({ cwd: tmp });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("session wall-clock cap (#81)", () => {
+  test(
+    "exceeding wall-clock cap terminates with exit 4 + session-wall-clock reason",
+    async () => {
+      const adapter = makeHangingAdapter();
+      const startMs = Date.now();
+
+      const result = await runNew(
+        {
+          cwd: tmp,
+          slug: "wc-test",
+          idea: "wall clock test",
+          explain: false,
+          resolvers: acceptResolvers(),
+          now: "2026-04-19T10:00:00Z",
+          // 3-second session wall-clock cap.
+          maxSessionWallClockMs: 3_000,
+        },
+        adapter,
+      );
+      const elapsedMs = Date.now() - startMs;
+
+      expect(elapsedMs).toBeLessThan(8_000);
+      expect(result.exitCode).toBe(4);
+      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+    },
+    10_000,
+  );
+
+  test(
+    "wall-clock cap is read from config.json budget.max_session_wall_clock_minutes",
+    async () => {
+      // Patch the config to set max_session_wall_clock_minutes = 0.05 (3s).
+      const configPath = path.join(tmp, ".samo", "config.json");
+      const raw = readFileSync(configPath, "utf8");
+      const cfg = JSON.parse(raw) as Record<string, unknown>;
+      const budget = (cfg["budget"] ?? {}) as Record<string, unknown>;
+      budget["max_session_wall_clock_minutes"] = 0.05; // ~3s
+      cfg["budget"] = budget;
+      writeFileSync(configPath, JSON.stringify(cfg, null, 2));
+
+      const adapter = makeHangingAdapter();
+      const startMs = Date.now();
+
+      // Do NOT pass maxSessionWallClockMs — must read from config.
+      const result = await runNew(
+        {
+          cwd: tmp,
+          slug: "cfg-wc",
+          idea: "config wall clock test",
+          explain: false,
+          resolvers: acceptResolvers(),
+          now: "2026-04-19T10:00:00Z",
+        },
+        adapter,
+      );
+      const elapsedMs = Date.now() - startMs;
+
+      expect(elapsedMs).toBeLessThan(10_000);
+      expect(result.exitCode).toBe(4);
+      expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+    },
+    12_000,
+  );
+
+  test(
+    "session that completes within wall-clock cap exits 0",
+    async () => {
+      // Fast-responding adapter that completes immediately.
+      const personaJson = JSON.stringify({
+        persona: 'Veteran "CLI engineer" expert',
+        rationale: "fast",
+      });
+      const questionsJson = JSON.stringify({
+        questions: [{ id: "q1", text: "scope?", options: ["narrow", "wide"] }],
+      });
+      let callCount = 0;
+      const fastAdapter: Adapter = {
+        vendor: "fake-fast",
+        detect: (): Promise<DetectResult> => Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+        auth_status: (): Promise<AuthStatus> => Promise.resolve({ authenticated: true, subscription_auth: false }),
+        supports_structured_output: () => true,
+        supports_effort: (_level: EffortLevel) => true,
+        models: (): Promise<readonly ModelInfo[]> => Promise.resolve([{ id: "fake", family: "fake" }]),
+        ask: (_input: AskInput): Promise<AskOutput> => {
+          const c = callCount++;
+          const answer = c === 0 ? personaJson : questionsJson;
+          return Promise.resolve({ answer, usage: null, effort_used: "max" });
+        },
+        critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
+          Promise.resolve({ findings: [], summary: "ok", suggested_next_version: "0.1.1", usage: null, effort_used: "max" }),
+        revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+          Promise.resolve({ spec: "# SPEC\n\nok.", ready: true, rationale: "done", decisions: [], usage: null, effort_used: "max" }),
+      };
+
+      const result = await runNew(
+        {
+          cwd: tmp,
+          slug: "fast-run",
+          idea: "fast test",
+          explain: false,
+          resolvers: acceptResolvers(),
+          now: "2026-04-19T10:00:00Z",
+          // 10-minute cap — should be more than enough.
+          maxSessionWallClockMs: 600_000,
+        },
+        fastAdapter,
+      );
+
+      expect(result.exitCode).toBe(0);
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
## Summary

- **Lever A**: `buildAskPrompt`/`buildRevisePrompt` now inject a `## Project idea (AUTHORITATIVE ...)` block when `idea` + `slug` are present. The directive is explicit: IDEA wins over slug; NOT-X disclaimers must be honored strictly.
- **Lever B**: `ClaudeReviewerBAdapter.critique()` carries the original idea in the prompt via a new `IDEA-CONTRADICTION CHECK` directive; Reviewer B is instructed to flag `contradiction` findings (severity: major) when the spec reintroduces a disclaimed class, quoting both the disclaimer and the offending section.
- **State pipeline**: `state.input.idea` is written at first state.json write (immediately, not at commit) so `iterate` and `resume` thread it into every subsequent prompt call without requiring `--idea` re-supply.

Closes #85

## Manual repro on `todo-stream` (v0.4.0 behavior)

Idea used: `CLI that greps TODO/FIXME/HACK comments from source with git blame. NOT a todo-list app, NOT CRUD storage.`

**Spec heading list:**
```
# todo-stream — SPEC v0.1
## 1. Goal & Why It's Needed
## 2. User Stories
## 3. Scope (v0.1)
## 4. Architecture
## 5. Implementation Details
## 6. Tests Plan
## 7. Team
## 8. Implementation Plan
## 9. Distribution & Packaging
## 10. Risks & Mitigations
## 11. Changelog
```

**Key evidence — v0.3.1 regression is gone:**

- `§4 Architecture`: Rust with `clap`, `libgit2`, `tree-sitter` — **no "Go packages"**.
- `§5 Implementation Details`: data flow over Walker → Extractor → Blamer → Filter → Emitter — **no "baseline add", no CRUD storage**.
- Spec explicitly says: *"This is NOT a todo-list application"* and *"This is NOT a CRUD store. It has no database, no server, no sync."*

## Test plan

- [x] 21 new tests across 2 files (`lead-prompt-idea-precedence.test.ts`, `reviewer-b-idea-contradictions.test.ts`) — all GREEN
- [x] Full suite: 1309 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run format:check` — clean
- [x] `bun run lint` (eslint on changed files) — clean
- [ ] CI green — waiting for checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)