### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.4.0] - 2026-04-21
+
+### Added
+
+- (describe additions)
+
+### Fixed
+
+- (describe fixes)
+
+### Changed
+
+- (describe changes)
+
 ## [0.3.1] - 2026-04-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samospec",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Git-native CLI that turns a rough idea into a reviewed, versioned specification document.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release prep. Minor bump for #86 (behavioral change: idea precedence over slug + reviewer-B contradiction detection).