### PR TITLE
fix: codex pinned-model fallback + agentic-wrapper output parser (#88)

### DIFF
--- a/src/adapter/codex.ts
+++ b/src/adapter/codex.ts
@@ -523,15 +523,17 @@ export class CodexAdapter implements Adapter {
         detail: `spawn_error: ${first.detail ?? ""}`,
       };
     }
-    // Bug #54 + #88-1: Codex may write an API-level error JSON to stdout
-    // with either exit 0 (original #54 case) or exit 1 (ChatGPT-auth
-    // pinned-model rejection seen in #88). Check stdout for the error
-    // signature BEFORE classifyExit so the correct model_unavailable
+    // Bug #54 + #88-1 + #88-followup: Codex may write an API-level error
+    // JSON to EITHER stdout (exit 0 path) or stderr (exit 1 path — real
+    // codex CLI v0.120.0 shape under ChatGPT-auth rejection). Check both
+    // streams BEFORE classifyExit so the correct model_unavailable
     // classification is returned regardless of exit code, allowing the
     // fallback chain to trigger.
-    const stdoutApiError = classifyStdoutApiError(first.stdout);
-    if (stdoutApiError !== null) {
-      return stdoutApiError;
+    const apiError =
+      classifyApiErrorInText(first.stdout) ??
+      classifyApiErrorInText(first.stderr);
+    if (apiError !== null) {
+      return apiError;
     }
 
     if (first.exitCode !== 0) {
@@ -573,8 +575,11 @@ export class CodexAdapter implements Adapter {
         detail: `spawn_error: ${repair.detail ?? ""}`,
       };
     }
-    // Also check the repair response for API-level errors (#54 / #88-1).
-    const repairApiError = classifyStdoutApiError(repair.stdout);
+    // Also check the repair response for API-level errors on either
+    // stream (#54 / #88-1 / #88-followup).
+    const repairApiError =
+      classifyApiErrorInText(repair.stdout) ??
+      classifyApiErrorInText(repair.stderr);
     if (repairApiError !== null) {
       return repairApiError;
     }
@@ -714,8 +719,8 @@ function buildFallbackChain(
 
 // ---------- response parsing ----------
 
-// Bug #88-2 (Option A): Extract the JSON block from agentic-wrapper
-// stdout emitted by `codex exec`.
+// Bug #88-2 (Option A) + #88-followup: Extract the JSON block from
+// agentic-wrapper stdout emitted by `codex exec`.
 //
 // `codex exec` emits a multi-section banner:
 //   Reading prompt from stdin...
@@ -724,25 +729,42 @@ function buildFallbackChain(
 //   workdir: ...  model: ...  [other metadata]
 //   --------
 //   user
-//   <prompt echo>
+//   <prompt echo>          ← may itself contain a standalone `codex` line!
 //
-//   codex       ← locate this marker (exact line, no leading spaces)
-//   <JSON>      ← starts here
+//   codex                  ← REAL response marker (after user-echo block)
+//   <JSON>                 ← starts here
 //
-//   tokens used ← ends before this line (if present)
+//   tokens used            ← ends before this line (if present)
 //   2561
 //
 //   <JSON repeated>
 //
+// The response marker is a `codex` line followed by text starting with
+// `{` (the JSON object). A rogue `codex` mid-prompt-echo does NOT satisfy
+// this — it's followed by further prose. So we scan for the `codex`
+// line whose next non-blank line begins with `{`, which is the
+// structural signature of the real response.
+//
 // Returns the extracted JSON text, or null when the marker is absent
 // (plain output — callers fall back to the raw string).
 function extractCodexAgenticJson(raw: string): string | null {
-  // Find "codex\n" on its own line (case-sensitive, no leading whitespace).
-  // We use a line-by-line scan so we don't split on mid-JSON content.
   const lines = raw.split("\n");
+
+  // Locate the response marker: a `codex` line where the next
+  // non-blank line begins with `{`. This correctly disambiguates a
+  // rogue `codex` token inside the user prompt (which is followed by
+  // narrative prose, not a JSON object).
   let codexLineIdx = -1;
   for (let i = 0; i < lines.length; i++) {
-    if (lines[i] === "codex") {
+    if (lines[i] !== "codex") continue;
+    // Peek ahead for the next non-blank line.
+    let nextIdx = i + 1;
+    while (nextIdx < lines.length && (lines[nextIdx] ?? "").trim() === "") {
+      nextIdx++;
+    }
+    if (nextIdx >= lines.length) continue;
+    const firstNonBlank = (lines[nextIdx] ?? "").trimStart();
+    if (firstNonBlank.startsWith("{")) {
       codexLineIdx = i;
       break;
     }
@@ -804,28 +826,40 @@ function normalizeUsageAndEffort(
 
 // ---------- error classification ----------
 
-// Bug #54: Codex exits 0 and emits an API-level error JSON on stdout
-// when the requested model is not supported under ChatGPT-account auth.
-// The real error shape is:
+// Bug #54 + #88-followup: Codex emits an API-level error JSON under
+// ChatGPT-account auth. The stream carrying the payload depends on the
+// exit path:
+//   - exit 0 + stdout (original #54 shape: "ERROR: {...}")
+//   - exit 1 + stderr (real CLI v0.120.0 shape: banner + "ERROR: {...}")
+// The error shape is:
 //   ERROR: {"type":"error","status":400,"error":{"type":
 //     "invalid_request_error","message":"The 'X' model is not
 //     supported when using Codex with a ChatGPT account."}}
 //
-// Returns a CodexAttemptFail classified as model_unavailable when the
-// stdout matches this pattern, or null when it does not apply.
-function classifyStdoutApiError(stdout: string): CodexAttemptFail | null {
+// Accepts ANY captured text stream and scans for the error signature.
+// Extracts the first balanced JSON object starting at the first `{` and
+// classifies as model_unavailable when the error type matches. Returns
+// null when the text does not carry an API error JSON.
+function classifyApiErrorInText(text: string): CodexAttemptFail | null {
   // Fast path: must contain "invalid_request_error" to be an API error.
-  if (!stdout.includes("invalid_request_error")) {
+  if (!text.includes("invalid_request_error")) {
     return null;
   }
-  // Extract the JSON payload — may be prefixed by "ERROR: " or similar.
-  const jsonStart = stdout.indexOf("{");
+  // Extract the first balanced JSON object starting from the first `{`.
+  // Stderr may have banner lines + trailing blank lines that confuse a
+  // naive `JSON.parse(text.slice(jsonStart))` call, so we walk the
+  // string counting braces with string-literal awareness.
+  const jsonStart = text.indexOf("{");
   if (jsonStart === -1) {
+    return null;
+  }
+  const jsonBlob = extractFirstBalancedJson(text, jsonStart);
+  if (jsonBlob === null) {
     return null;
   }
   let parsed: unknown;
   try {
-    parsed = JSON.parse(stdout.slice(jsonStart));
+    parsed = JSON.parse(jsonBlob);
   } catch {
     return null;
   }
@@ -857,12 +891,50 @@ function classifyStdoutApiError(stdout: string): CodexAttemptFail | null {
   return { ok: false, reason, detail: msg };
 }
 
+// Walk `text` starting at `start` (must point at `{`) and return the
+// substring that spans the first balanced JSON object (counting `{` and
+// `}` with string-literal + escape awareness). Returns null if no
+// balanced close is found.
+function extractFirstBalancedJson(text: string, start: number): string | null {
+  if (text[start] !== "{") {
+    return null;
+  }
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+  return null;
+}
+
 function classifyExit(
   exitCode: number,
   stderr: string,
 ): CodexAttemptResult<string> {
   // Stderr heuristic classification per SPEC §7 failure classes.
-  // "model not available" / "model unavailable" / "model not found" →
+  // "model not available" / "model unavailable" / "model not found" /
+  // "model not supported" (ChatGPT-auth rejection, #88-followup) →
   //   model_unavailable (triggers fallback chain in runSingleAttempt).
   // Rate-limit / 5xx / network / timeout → retryable (maps to timeout).
   // Anything else → terminal (auth, quota, refusal).
@@ -870,12 +942,14 @@ function classifyExit(
   // Model-unavailable heuristic: stderr mentions "model" AND one of
   // the unavailable phrases. A vendor-name/quote/etc. may appear
   // between the two tokens, so we test them independently on the
-  // same line rather than as a fixed substring.
+  // same line rather than as a fixed substring. Matching is
+  // case-insensitive via the lowercased stderr.
   const mentionsModel = lower.includes("model");
   const unavailablePhrase =
     lower.includes("not available") ||
     lower.includes("unavailable") ||
     lower.includes("not found") ||
+    lower.includes("not supported") ||
     lower.includes("does not exist") ||
     lower.includes("no such model");
   if (mentionsModel && unavailablePhrase) {

--- a/src/adapter/codex.ts
+++ b/src/adapter/codex.ts
@@ -523,26 +523,34 @@ export class CodexAdapter implements Adapter {
         detail: `spawn_error: ${first.detail ?? ""}`,
       };
     }
-    if (first.exitCode !== 0) {
-      return classifyExit(first.exitCode, first.stderr);
-    }
-
-    // Bug #54: Codex exits 0 and writes the error JSON to stdout when
-    // the model is not supported under ChatGPT-account auth. Detect
-    // this before the schema-parse / repair path so it is correctly
-    // classified as model_unavailable rather than schema_violation.
+    // Bug #54 + #88-1: Codex may write an API-level error JSON to stdout
+    // with either exit 0 (original #54 case) or exit 1 (ChatGPT-auth
+    // pinned-model rejection seen in #88). Check stdout for the error
+    // signature BEFORE classifyExit so the correct model_unavailable
+    // classification is returned regardless of exit code, allowing the
+    // fallback chain to trigger.
     const stdoutApiError = classifyStdoutApiError(first.stdout);
     if (stdoutApiError !== null) {
       return stdoutApiError;
+    }
+
+    if (first.exitCode !== 0) {
+      return classifyExit(first.exitCode, first.stderr);
     }
 
     if (!args.structured) {
       return { ok: true, value: first.stdout };
     }
 
-    const parsed = preParseJson(first.stdout);
+    // Bug #88-2: codex exec wraps the JSON response in an agentic
+    // header/footer. Extract the JSON block from between the "codex\n"
+    // marker and the "tokens used" footer (Option A from the spec).
+    const agenticExtracted = extractCodexAgenticJson(first.stdout);
+    const rawToparse = agenticExtracted ?? first.stdout;
+
+    const parsed = preParseJson(rawToparse);
     if (parsed.ok) {
-      return { ok: true, value: first.stdout };
+      return { ok: true, value: rawToparse };
     }
 
     // Structured violation -> ONE repair retry on this model.
@@ -565,17 +573,21 @@ export class CodexAdapter implements Adapter {
         detail: `spawn_error: ${repair.detail ?? ""}`,
       };
     }
-    if (repair.exitCode !== 0) {
-      return classifyExit(repair.exitCode, repair.stderr);
-    }
-
-    // Also check the repair response for API-level errors (#54).
+    // Also check the repair response for API-level errors (#54 / #88-1).
     const repairApiError = classifyStdoutApiError(repair.stdout);
     if (repairApiError !== null) {
       return repairApiError;
     }
 
-    const parsedRepair = preParseJson(repair.stdout);
+    if (repair.exitCode !== 0) {
+      return classifyExit(repair.exitCode, repair.stderr);
+    }
+
+    // Apply agentic-wrapper extraction to repair response too (#88-2).
+    const repairExtracted = extractCodexAgenticJson(repair.stdout);
+    const repairRaw = repairExtracted ?? repair.stdout;
+
+    const parsedRepair = preParseJson(repairRaw);
     if (!parsedRepair.ok) {
       return {
         ok: false,
@@ -583,7 +595,7 @@ export class CodexAdapter implements Adapter {
         detail: parsedRepair.error.message,
       };
     }
-    return { ok: true, value: repair.stdout };
+    return { ok: true, value: repairRaw };
   }
 
   private async spawnOnce(args: {
@@ -701,6 +713,65 @@ function buildFallbackChain(
 }
 
 // ---------- response parsing ----------
+
+// Bug #88-2 (Option A): Extract the JSON block from agentic-wrapper
+// stdout emitted by `codex exec`.
+//
+// `codex exec` emits a multi-section banner:
+//   Reading prompt from stdin...
+//   OpenAI Codex v0.120.0 (research preview)
+//   --------
+//   workdir: ...  model: ...  [other metadata]
+//   --------
+//   user
+//   <prompt echo>
+//
+//   codex       ← locate this marker (exact line, no leading spaces)
+//   <JSON>      ← starts here
+//
+//   tokens used ← ends before this line (if present)
+//   2561
+//
+//   <JSON repeated>
+//
+// Returns the extracted JSON text, or null when the marker is absent
+// (plain output — callers fall back to the raw string).
+function extractCodexAgenticJson(raw: string): string | null {
+  // Find "codex\n" on its own line (case-sensitive, no leading whitespace).
+  // We use a line-by-line scan so we don't split on mid-JSON content.
+  const lines = raw.split("\n");
+  let codexLineIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i] === "codex") {
+      codexLineIdx = i;
+      break;
+    }
+  }
+  if (codexLineIdx === -1) {
+    return null;
+  }
+
+  // Collect lines from codexLineIdx+1 until "tokens used" or EOF.
+  const jsonLines: string[] = [];
+  for (let i = codexLineIdx + 1; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line === "tokens used") {
+      break;
+    }
+    jsonLines.push(line);
+  }
+
+  // Trim trailing blank lines so JSON.parse sees a clean object.
+  while (
+    jsonLines.length > 0 &&
+    (jsonLines[jsonLines.length - 1] ?? "").trim() === ""
+  ) {
+    jsonLines.pop();
+  }
+
+  const extracted = jsonLines.join("\n");
+  return extracted.length > 0 ? extracted : null;
+}
 
 function parseStructuredJson(
   raw: string,

--- a/tests/adapter/codex-agentic-wrapper-false-positive.test.ts
+++ b/tests/adapter/codex-agentic-wrapper-false-positive.test.ts
@@ -1,0 +1,149 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED test for Issue #88 reviewer follow-up: agentic-wrapper parser
+// false-positive.
+//
+// If a USER prompt echoed in the banner contains a standalone "codex"
+// line, the extractor picks the wrong slice. The `codex\n` marker is
+// only meaningful AFTER the "user\n<prompt>" block terminates. We must
+// skip past the first user-echo block before searching for the
+// response marker.
+
+import { describe, expect, test } from "bun:test";
+
+import { CodexAdapter, CodexAdapterError } from "../../src/adapter/codex.ts";
+import type { EffortLevel } from "../../src/adapter/types.ts";
+import type { SpawnCliInput, SpawnCliResult } from "../../src/adapter/spawn.ts";
+
+interface SpawnSpy {
+  readonly spawn: (input: SpawnCliInput) => Promise<SpawnCliResult>;
+  readonly calls: { cmd: readonly string[] }[];
+}
+
+function makeSpy(response: SpawnCliResult): SpawnSpy {
+  const calls: { cmd: readonly string[] }[] = [];
+  const spawn = (input: SpawnCliInput): Promise<SpawnCliResult> => {
+    calls.push({ cmd: [...input.cmd] });
+    return Promise.resolve(response);
+  };
+  return { spawn, calls };
+}
+
+const OPTS_HIGH: { effort: EffortLevel; timeout: number } = {
+  effort: "high",
+  timeout: 30_000,
+};
+
+const FAKE_HOST: Record<string, string | undefined> = {
+  PATH: "/usr/bin:/bin",
+  HOME: "/tmp",
+};
+
+const ASK_JSON =
+  '{"answer":"real-response","usage":null,"effort_used":"high"}';
+
+describe("Bug #88-followup: agentic-wrapper false-positive on rogue 'codex' in user prompt", () => {
+  test(
+    "user prompt containing a standalone 'codex' line → extractor must still pick the real response",
+    async () => {
+      // The user prompt echoes back with its OWN `codex\n` line. The
+      // extractor (naive "first `codex` marker" search) would stop on
+      // that line and return the remainder of the prompt echo, which
+      // does not contain valid JSON and would fail parsing.
+      //
+      // Fix: only treat `codex\n` as the response marker AFTER the
+      // user-echo block — i.e. after a `--------` separator has been
+      // consumed following the `user\n` section, OR skip the first
+      // occurrence that appears inside the user block.
+      const wrappedWithRogueCodex =
+        "OpenAI Codex v0.120.0 (research preview)\n" +
+        "--------\n" +
+        "workdir: /private/tmp/test\n" +
+        "model: gpt-5.4\n" +
+        "provider: openai\n" +
+        "--------\n" +
+        "user\n" +
+        "Please analyze this spec. The word\n" +
+        "codex\n" +
+        "appears in the middle of my prompt and should NOT be mistaken\n" +
+        "for the response marker. Return JSON with your findings.\n" +
+        "\n" +
+        "codex\n" +
+        ASK_JSON +
+        "\n" +
+        "\n" +
+        "tokens used\n" +
+        "2561\n";
+
+      const spy = makeSpy({
+        ok: true,
+        exitCode: 0,
+        stdout: wrappedWithRogueCodex,
+        stderr: "",
+      });
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.4", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      const out = await adapter.ask({
+        prompt: "rogue",
+        context: "",
+        opts: OPTS_HIGH,
+      });
+
+      // Must succeed — must NOT misparse the rogue `codex` line.
+      expect(out.answer).toBe("real-response");
+      expect(spy.calls.length).toBe(1);
+    },
+  );
+
+  test(
+    "user prompt with rogue 'codex' BUT no subsequent real response → schema_violation (not silent misparse)",
+    async () => {
+      // Defensive: even if the codex CLI is truncated and only the user
+      // echo is present, we should get schema_violation — not a silent
+      // parse of the prompt echo as if it were the response.
+      const truncatedWrapper =
+        "OpenAI Codex v0.120.0 (research preview)\n" +
+        "--------\n" +
+        "model: gpt-5.4\n" +
+        "--------\n" +
+        "user\n" +
+        "codex\n" +
+        "Not valid JSON here either\n";
+
+      const spy = makeSpy({
+        ok: true,
+        exitCode: 0,
+        stdout: truncatedWrapper,
+        stderr: "",
+      });
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.4", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      let err: unknown;
+      try {
+        await adapter.ask({
+          prompt: "truncated",
+          context: "",
+          opts: OPTS_HIGH,
+        });
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(CodexAdapterError);
+      if (err instanceof CodexAdapterError) {
+        expect(err.payload.reason).toBe("schema_violation");
+      }
+    },
+  );
+});

--- a/tests/adapter/codex-agentic-wrapper-false-positive.test.ts
+++ b/tests/adapter/codex-agentic-wrapper-false-positive.test.ts
@@ -39,111 +39,104 @@ const FAKE_HOST: Record<string, string | undefined> = {
   HOME: "/tmp",
 };
 
-const ASK_JSON =
-  '{"answer":"real-response","usage":null,"effort_used":"high"}';
+const ASK_JSON = '{"answer":"real-response","usage":null,"effort_used":"high"}';
 
 describe("Bug #88-followup: agentic-wrapper false-positive on rogue 'codex' in user prompt", () => {
-  test(
-    "user prompt containing a standalone 'codex' line → extractor must still pick the real response",
-    async () => {
-      // The user prompt echoes back with its OWN `codex\n` line. The
-      // extractor (naive "first `codex` marker" search) would stop on
-      // that line and return the remainder of the prompt echo, which
-      // does not contain valid JSON and would fail parsing.
-      //
-      // Fix: only treat `codex\n` as the response marker AFTER the
-      // user-echo block — i.e. after a `--------` separator has been
-      // consumed following the `user\n` section, OR skip the first
-      // occurrence that appears inside the user block.
-      const wrappedWithRogueCodex =
-        "OpenAI Codex v0.120.0 (research preview)\n" +
-        "--------\n" +
-        "workdir: /private/tmp/test\n" +
-        "model: gpt-5.4\n" +
-        "provider: openai\n" +
-        "--------\n" +
-        "user\n" +
-        "Please analyze this spec. The word\n" +
-        "codex\n" +
-        "appears in the middle of my prompt and should NOT be mistaken\n" +
-        "for the response marker. Return JSON with your findings.\n" +
-        "\n" +
-        "codex\n" +
-        ASK_JSON +
-        "\n" +
-        "\n" +
-        "tokens used\n" +
-        "2561\n";
+  test("user prompt containing a standalone 'codex' line → extractor must still pick the real response", async () => {
+    // The user prompt echoes back with its OWN `codex\n` line. The
+    // extractor (naive "first `codex` marker" search) would stop on
+    // that line and return the remainder of the prompt echo, which
+    // does not contain valid JSON and would fail parsing.
+    //
+    // Fix: only treat `codex\n` as the response marker AFTER the
+    // user-echo block — i.e. after a `--------` separator has been
+    // consumed following the `user\n` section, OR skip the first
+    // occurrence that appears inside the user block.
+    const wrappedWithRogueCodex =
+      "OpenAI Codex v0.120.0 (research preview)\n" +
+      "--------\n" +
+      "workdir: /private/tmp/test\n" +
+      "model: gpt-5.4\n" +
+      "provider: openai\n" +
+      "--------\n" +
+      "user\n" +
+      "Please analyze this spec. The word\n" +
+      "codex\n" +
+      "appears in the middle of my prompt and should NOT be mistaken\n" +
+      "for the response marker. Return JSON with your findings.\n" +
+      "\n" +
+      "codex\n" +
+      ASK_JSON +
+      "\n" +
+      "\n" +
+      "tokens used\n" +
+      "2561\n";
 
-      const spy = makeSpy({
-        ok: true,
-        exitCode: 0,
-        stdout: wrappedWithRogueCodex,
-        stderr: "",
-      });
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.4", family: "codex" }],
-        accountDefaultFallback: false,
-      });
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: wrappedWithRogueCodex,
+      stderr: "",
+    });
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.4", family: "codex" }],
+      accountDefaultFallback: false,
+    });
 
-      const out = await adapter.ask({
-        prompt: "rogue",
+    const out = await adapter.ask({
+      prompt: "rogue",
+      context: "",
+      opts: OPTS_HIGH,
+    });
+
+    // Must succeed — must NOT misparse the rogue `codex` line.
+    expect(out.answer).toBe("real-response");
+    expect(spy.calls.length).toBe(1);
+  });
+
+  test("user prompt with rogue 'codex' BUT no subsequent real response → schema_violation (not silent misparse)", async () => {
+    // Defensive: even if the codex CLI is truncated and only the user
+    // echo is present, we should get schema_violation — not a silent
+    // parse of the prompt echo as if it were the response.
+    const truncatedWrapper =
+      "OpenAI Codex v0.120.0 (research preview)\n" +
+      "--------\n" +
+      "model: gpt-5.4\n" +
+      "--------\n" +
+      "user\n" +
+      "codex\n" +
+      "Not valid JSON here either\n";
+
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: truncatedWrapper,
+      stderr: "",
+    });
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.4", family: "codex" }],
+      accountDefaultFallback: false,
+    });
+
+    let err: unknown;
+    try {
+      await adapter.ask({
+        prompt: "truncated",
         context: "",
         opts: OPTS_HIGH,
       });
-
-      // Must succeed — must NOT misparse the rogue `codex` line.
-      expect(out.answer).toBe("real-response");
-      expect(spy.calls.length).toBe(1);
-    },
-  );
-
-  test(
-    "user prompt with rogue 'codex' BUT no subsequent real response → schema_violation (not silent misparse)",
-    async () => {
-      // Defensive: even if the codex CLI is truncated and only the user
-      // echo is present, we should get schema_violation — not a silent
-      // parse of the prompt echo as if it were the response.
-      const truncatedWrapper =
-        "OpenAI Codex v0.120.0 (research preview)\n" +
-        "--------\n" +
-        "model: gpt-5.4\n" +
-        "--------\n" +
-        "user\n" +
-        "codex\n" +
-        "Not valid JSON here either\n";
-
-      const spy = makeSpy({
-        ok: true,
-        exitCode: 0,
-        stdout: truncatedWrapper,
-        stderr: "",
-      });
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.4", family: "codex" }],
-        accountDefaultFallback: false,
-      });
-
-      let err: unknown;
-      try {
-        await adapter.ask({
-          prompt: "truncated",
-          context: "",
-          opts: OPTS_HIGH,
-        });
-      } catch (e) {
-        err = e;
-      }
-      expect(err).toBeInstanceOf(CodexAdapterError);
-      if (err instanceof CodexAdapterError) {
-        expect(err.payload.reason).toBe("schema_violation");
-      }
-    },
-  );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    if (err instanceof CodexAdapterError) {
+      expect(err.payload.reason).toBe("schema_violation");
+    }
+  });
 });

--- a/tests/adapter/codex-agentic-wrapper-parser.test.ts
+++ b/tests/adapter/codex-agentic-wrapper-parser.test.ts
@@ -92,11 +92,11 @@ function makeAgenticWrapperStdout(prompt: string, jsonPayload: string): string {
 
 interface SpawnSpy {
   readonly spawn: (input: SpawnCliInput) => Promise<SpawnCliResult>;
-  readonly calls: Array<{ cmd: readonly string[] }>;
+  readonly calls: { cmd: readonly string[] }[];
 }
 
 function makeSpy(response: SpawnCliResult): SpawnSpy {
-  const calls: Array<{ cmd: readonly string[] }> = [];
+  const calls: { cmd: readonly string[] }[] = [];
   const spawn = (input: SpawnCliInput): Promise<SpawnCliResult> => {
     calls.push({ cmd: [...input.cmd] });
     return Promise.resolve(response);
@@ -307,7 +307,7 @@ describe("Bug #88-2: full agentic wrapper via fake-CLI fixture (contract path)",
     const spy: SpawnSpy = {
       calls: [],
       spawn: (input: SpawnCliInput): Promise<SpawnCliResult> => {
-        (spy.calls as Array<{ cmd: readonly string[] }>).push({
+        (spy.calls as { cmd: readonly string[] }[]).push({
           cmd: [...input.cmd],
         });
         capturedStdin = input.stdin;

--- a/tests/adapter/codex-agentic-wrapper-parser.test.ts
+++ b/tests/adapter/codex-agentic-wrapper-parser.test.ts
@@ -1,0 +1,364 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED tests for Issue #88 Bug 2: Codex output parser doesn't handle
+// agentic-wrapper output.
+//
+// `codex exec` emits a multi-section banner before and after the JSON:
+//
+//   Reading prompt from stdin...
+//   OpenAI Codex v0.120.0 (research preview)
+//   --------
+//   workdir: /private/tmp/todo-stream
+//   model: gpt-5.4
+//   provider: openai
+//   approval: never
+//   sandbox: read-only
+//   reasoning effort: high
+//   reasoning summaries: none
+//   session id: abc123
+//   --------
+//   user
+//   <prompt text>
+//
+//   codex
+//   <JSON response>
+//
+//   tokens used
+//   2561
+//
+//   <JSON repeated>
+//
+// The fix (Option A from the spec): locate the "codex\n" marker line;
+// the JSON block follows until "tokens used" or EOF. Extract it and
+// feed to JSON.parse.
+
+import { describe, expect, test } from "bun:test";
+
+import { CodexAdapter, CodexAdapterError } from "../../src/adapter/codex.ts";
+import type { AskInput, CritiqueInput, EffortLevel } from "../../src/adapter/types.ts";
+import type { SpawnCliInput, SpawnCliResult } from "../../src/adapter/spawn.ts";
+
+// ---------- fixtures ----------
+
+const ASK_JSON = JSON.stringify({
+  answer: "agentic-ok",
+  usage: null,
+  effort_used: "high",
+});
+
+const CRITIQUE_JSON = JSON.stringify({
+  findings: [
+    { category: "missing-risk", text: "no auth", severity: "major" },
+  ],
+  summary: "needs auth",
+  suggested_next_version: "0.1.1",
+  usage: null,
+  effort_used: "high",
+});
+
+/**
+ * Build the full agentic-wrapper stdout that codex exec emits, with
+ * the given JSON payload embedded in the "codex\n<JSON>" section.
+ */
+function makeAgenticWrapperStdout(
+  prompt: string,
+  jsonPayload: string,
+): string {
+  return (
+    "Reading prompt from stdin...\n" +
+    "OpenAI Codex v0.120.0 (research preview)\n" +
+    "--------\n" +
+    "workdir: /private/tmp/test-repo\n" +
+    "model: gpt-5.4\n" +
+    "provider: openai\n" +
+    "approval: never\n" +
+    "sandbox: read-only\n" +
+    "reasoning effort: high\n" +
+    "reasoning summaries: none\n" +
+    "session id: abc123def456\n" +
+    "--------\n" +
+    "user\n" +
+    prompt +
+    "\n" +
+    "\n" +
+    "codex\n" +
+    jsonPayload +
+    "\n" +
+    "\n" +
+    "tokens used\n" +
+    "2561\n" +
+    "\n" +
+    jsonPayload +
+    "\n"
+  );
+}
+
+// ---------- spy helper ----------
+
+interface SpawnSpy {
+  readonly spawn: (input: SpawnCliInput) => Promise<SpawnCliResult>;
+  readonly calls: Array<{ cmd: readonly string[] }>;
+}
+
+function makeSpy(response: SpawnCliResult): SpawnSpy {
+  const calls: Array<{ cmd: readonly string[] }> = [];
+  const spawn = (input: SpawnCliInput): Promise<SpawnCliResult> => {
+    calls.push({ cmd: [...input.cmd] });
+    return Promise.resolve(response);
+  };
+  return { spawn, calls };
+}
+
+// ---------- constants ----------
+
+const OPTS_HIGH: { effort: EffortLevel; timeout: number } = {
+  effort: "high",
+  timeout: 30_000,
+};
+
+const FAKE_HOST: Record<string, string | undefined> = {
+  PATH: "/usr/bin:/bin",
+  HOME: "/tmp",
+};
+
+// ---------- tests ----------
+
+describe("Bug #88-2: agentic-wrapper stdout extraction (Option A)", () => {
+  test(
+    "ask() succeeds when stdout is agentic-wrapper with valid JSON after 'codex\\n' marker",
+    async () => {
+      const wrappedStdout = makeAgenticWrapperStdout(
+        "You are the samospec Reviewer A...",
+        ASK_JSON,
+      );
+
+      const spy = makeSpy({
+        ok: true,
+        exitCode: 0,
+        stdout: wrappedStdout,
+        stderr: "",
+      });
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.4", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      const out = await adapter.ask({
+        prompt: "ping",
+        context: "",
+        opts: OPTS_HIGH,
+      });
+
+      expect(out.answer).toBe("agentic-ok");
+
+      // Only one spawn — no repair retry needed.
+      expect(spy.calls.length).toBe(1);
+    },
+  );
+
+  test(
+    "critique() succeeds when stdout is agentic-wrapper with valid critique JSON",
+    async () => {
+      const wrappedStdout = makeAgenticWrapperStdout(
+        "You are a paranoid security/ops engineer...",
+        CRITIQUE_JSON,
+      );
+
+      const spy = makeSpy({
+        ok: true,
+        exitCode: 0,
+        stdout: wrappedStdout,
+        stderr: "",
+      });
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.4", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      const out = await adapter.critique({
+        spec: "# SPEC\n\nHello.",
+        guidelines: "Be thorough.",
+        opts: OPTS_HIGH,
+      } satisfies CritiqueInput);
+
+      expect(out.findings.length).toBe(1);
+      expect(out.findings[0]?.category).toBe("missing-risk");
+      expect(out.summary).toBe("needs auth");
+
+      expect(spy.calls.length).toBe(1);
+    },
+  );
+
+  test(
+    "agentic-wrapper WITHOUT 'tokens used' footer still extracts JSON until EOF",
+    async () => {
+      // Some versions may not emit the footer.
+      const incompleteWrapper =
+        "Reading prompt from stdin...\n" +
+        "OpenAI Codex v0.120.0 (research preview)\n" +
+        "--------\n" +
+        "model: gpt-5.4\n" +
+        "--------\n" +
+        "user\n" +
+        "ping\n" +
+        "\n" +
+        "codex\n" +
+        ASK_JSON +
+        "\n";
+
+      const spy = makeSpy({
+        ok: true,
+        exitCode: 0,
+        stdout: incompleteWrapper,
+        stderr: "",
+      });
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.4", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      const out = await adapter.ask({
+        prompt: "ping",
+        context: "",
+        opts: OPTS_HIGH,
+      });
+      expect(out.answer).toBe("agentic-ok");
+    },
+  );
+
+  test(
+    "non-wrapped plain JSON still works (backward compatibility)",
+    async () => {
+      // When codex emits bare JSON (no wrapper), the adapter must still parse it.
+      const spy = makeSpy({
+        ok: true,
+        exitCode: 0,
+        stdout: ASK_JSON,
+        stderr: "",
+      });
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.4", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      const out = await adapter.ask({
+        prompt: "ping",
+        context: "",
+        opts: OPTS_HIGH,
+      });
+      expect(out.answer).toBe("agentic-ok");
+    },
+  );
+
+  test(
+    "agentic-wrapper with invalid JSON after 'codex\\n' → schema_violation (no silent fail)",
+    async () => {
+      // A corrupt JSON payload in the codex section must surface as
+      // schema_violation (eventually), not silently swallowed.
+      const wrappedBadJson =
+        "Reading prompt from stdin...\n" +
+        "OpenAI Codex v0.120.0 (research preview)\n" +
+        "--------\n" +
+        "model: gpt-5.4\n" +
+        "--------\n" +
+        "user\n" +
+        "ping\n" +
+        "\n" +
+        "codex\n" +
+        "{ this is not valid json }\n" +
+        "\n" +
+        "tokens used\n" +
+        "100\n";
+
+      const spy = makeSpy({
+        ok: true,
+        exitCode: 0,
+        stdout: wrappedBadJson,
+        stderr: "",
+      });
+      // Two-model list + account-default disabled so repair-retry
+      // eventually terminates with schema_violation.
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.4", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      let err: unknown;
+      try {
+        await adapter.ask({
+          prompt: "ping",
+          context: "",
+          opts: OPTS_HIGH,
+        });
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toBeInstanceOf(CodexAdapterError);
+      if (err instanceof CodexAdapterError) {
+        expect(err.payload.reason).toBe("schema_violation");
+      }
+    },
+  );
+});
+
+// ---------- contract-style: full agentic-wrapper path ----------
+
+describe("Bug #88-2: full agentic wrapper via fake-CLI fixture (contract path)", () => {
+  test(
+    "adapter.ask() returns correct answer from agentic-wrapped stdout",
+    async () => {
+      const fullOutput = makeAgenticWrapperStdout("prompt-text", ASK_JSON);
+
+      let capturedStdin = "";
+      const spy: SpawnSpy = {
+        calls: [],
+        spawn: (input: SpawnCliInput): Promise<SpawnCliResult> => {
+          (spy.calls as Array<{ cmd: readonly string[] }>).push({
+            cmd: [...input.cmd],
+          });
+          capturedStdin = input.stdin;
+          return Promise.resolve({
+            ok: true as const,
+            exitCode: 0,
+            stdout: fullOutput,
+            stderr: "",
+          });
+        },
+      };
+
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.4", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      const out = await adapter.ask({
+        prompt: "test question",
+        context: "",
+        opts: OPTS_HIGH,
+      });
+
+      expect(out.answer).toBe("agentic-ok");
+      // Verify the prompt was forwarded to stdin (basic wiring check).
+      expect(capturedStdin).toContain("test question");
+    },
+  );
+});

--- a/tests/adapter/codex-agentic-wrapper-parser.test.ts
+++ b/tests/adapter/codex-agentic-wrapper-parser.test.ts
@@ -35,7 +35,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { CodexAdapter, CodexAdapterError } from "../../src/adapter/codex.ts";
-import type { AskInput, CritiqueInput, EffortLevel } from "../../src/adapter/types.ts";
+import type { CritiqueInput, EffortLevel } from "../../src/adapter/types.ts";
 import type { SpawnCliInput, SpawnCliResult } from "../../src/adapter/spawn.ts";
 
 // ---------- fixtures ----------
@@ -47,9 +47,7 @@ const ASK_JSON = JSON.stringify({
 });
 
 const CRITIQUE_JSON = JSON.stringify({
-  findings: [
-    { category: "missing-risk", text: "no auth", severity: "major" },
-  ],
+  findings: [{ category: "missing-risk", text: "no auth", severity: "major" }],
   summary: "needs auth",
   suggested_next_version: "0.1.1",
   usage: null,
@@ -60,10 +58,7 @@ const CRITIQUE_JSON = JSON.stringify({
  * Build the full agentic-wrapper stdout that codex exec emits, with
  * the given JSON payload embedded in the "codex\n<JSON>" section.
  */
-function makeAgenticWrapperStdout(
-  prompt: string,
-  jsonPayload: string,
-): string {
+function makeAgenticWrapperStdout(prompt: string, jsonPayload: string): string {
   return (
     "Reading prompt from stdin...\n" +
     "OpenAI Codex v0.120.0 (research preview)\n" +
@@ -124,241 +119,223 @@ const FAKE_HOST: Record<string, string | undefined> = {
 // ---------- tests ----------
 
 describe("Bug #88-2: agentic-wrapper stdout extraction (Option A)", () => {
-  test(
-    "ask() succeeds when stdout is agentic-wrapper with valid JSON after 'codex\\n' marker",
-    async () => {
-      const wrappedStdout = makeAgenticWrapperStdout(
-        "You are the samospec Reviewer A...",
-        ASK_JSON,
-      );
+  test("ask() succeeds when stdout is agentic-wrapper with valid JSON after 'codex\\n' marker", async () => {
+    const wrappedStdout = makeAgenticWrapperStdout(
+      "You are the samospec Reviewer A...",
+      ASK_JSON,
+    );
 
-      const spy = makeSpy({
-        ok: true,
-        exitCode: 0,
-        stdout: wrappedStdout,
-        stderr: "",
-      });
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.4", family: "codex" }],
-        accountDefaultFallback: false,
-      });
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: wrappedStdout,
+      stderr: "",
+    });
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.4", family: "codex" }],
+      accountDefaultFallback: false,
+    });
 
-      const out = await adapter.ask({
+    const out = await adapter.ask({
+      prompt: "ping",
+      context: "",
+      opts: OPTS_HIGH,
+    });
+
+    expect(out.answer).toBe("agentic-ok");
+
+    // Only one spawn — no repair retry needed.
+    expect(spy.calls.length).toBe(1);
+  });
+
+  test("critique() succeeds when stdout is agentic-wrapper with valid critique JSON", async () => {
+    const wrappedStdout = makeAgenticWrapperStdout(
+      "You are a paranoid security/ops engineer...",
+      CRITIQUE_JSON,
+    );
+
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: wrappedStdout,
+      stderr: "",
+    });
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.4", family: "codex" }],
+      accountDefaultFallback: false,
+    });
+
+    const out = await adapter.critique({
+      spec: "# SPEC\n\nHello.",
+      guidelines: "Be thorough.",
+      opts: OPTS_HIGH,
+    } satisfies CritiqueInput);
+
+    expect(out.findings.length).toBe(1);
+    expect(out.findings[0]?.category).toBe("missing-risk");
+    expect(out.summary).toBe("needs auth");
+
+    expect(spy.calls.length).toBe(1);
+  });
+
+  test("agentic-wrapper WITHOUT 'tokens used' footer still extracts JSON until EOF", async () => {
+    // Some versions may not emit the footer.
+    const incompleteWrapper =
+      "Reading prompt from stdin...\n" +
+      "OpenAI Codex v0.120.0 (research preview)\n" +
+      "--------\n" +
+      "model: gpt-5.4\n" +
+      "--------\n" +
+      "user\n" +
+      "ping\n" +
+      "\n" +
+      "codex\n" +
+      ASK_JSON +
+      "\n";
+
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: incompleteWrapper,
+      stderr: "",
+    });
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.4", family: "codex" }],
+      accountDefaultFallback: false,
+    });
+
+    const out = await adapter.ask({
+      prompt: "ping",
+      context: "",
+      opts: OPTS_HIGH,
+    });
+    expect(out.answer).toBe("agentic-ok");
+  });
+
+  test("non-wrapped plain JSON still works (backward compatibility)", async () => {
+    // When codex emits bare JSON (no wrapper), the adapter must still parse it.
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: ASK_JSON,
+      stderr: "",
+    });
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.4", family: "codex" }],
+      accountDefaultFallback: false,
+    });
+
+    const out = await adapter.ask({
+      prompt: "ping",
+      context: "",
+      opts: OPTS_HIGH,
+    });
+    expect(out.answer).toBe("agentic-ok");
+  });
+
+  test("agentic-wrapper with invalid JSON after 'codex\\n' → schema_violation (no silent fail)", async () => {
+    // A corrupt JSON payload in the codex section must surface as
+    // schema_violation (eventually), not silently swallowed.
+    const wrappedBadJson =
+      "Reading prompt from stdin...\n" +
+      "OpenAI Codex v0.120.0 (research preview)\n" +
+      "--------\n" +
+      "model: gpt-5.4\n" +
+      "--------\n" +
+      "user\n" +
+      "ping\n" +
+      "\n" +
+      "codex\n" +
+      "{ this is not valid json }\n" +
+      "\n" +
+      "tokens used\n" +
+      "100\n";
+
+    const spy = makeSpy({
+      ok: true,
+      exitCode: 0,
+      stdout: wrappedBadJson,
+      stderr: "",
+    });
+    // Two-model list + account-default disabled so repair-retry
+    // eventually terminates with schema_violation.
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.4", family: "codex" }],
+      accountDefaultFallback: false,
+    });
+
+    let err: unknown;
+    try {
+      await adapter.ask({
         prompt: "ping",
         context: "",
         opts: OPTS_HIGH,
       });
+    } catch (e) {
+      err = e;
+    }
 
-      expect(out.answer).toBe("agentic-ok");
-
-      // Only one spawn — no repair retry needed.
-      expect(spy.calls.length).toBe(1);
-    },
-  );
-
-  test(
-    "critique() succeeds when stdout is agentic-wrapper with valid critique JSON",
-    async () => {
-      const wrappedStdout = makeAgenticWrapperStdout(
-        "You are a paranoid security/ops engineer...",
-        CRITIQUE_JSON,
-      );
-
-      const spy = makeSpy({
-        ok: true,
-        exitCode: 0,
-        stdout: wrappedStdout,
-        stderr: "",
-      });
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.4", family: "codex" }],
-        accountDefaultFallback: false,
-      });
-
-      const out = await adapter.critique({
-        spec: "# SPEC\n\nHello.",
-        guidelines: "Be thorough.",
-        opts: OPTS_HIGH,
-      } satisfies CritiqueInput);
-
-      expect(out.findings.length).toBe(1);
-      expect(out.findings[0]?.category).toBe("missing-risk");
-      expect(out.summary).toBe("needs auth");
-
-      expect(spy.calls.length).toBe(1);
-    },
-  );
-
-  test(
-    "agentic-wrapper WITHOUT 'tokens used' footer still extracts JSON until EOF",
-    async () => {
-      // Some versions may not emit the footer.
-      const incompleteWrapper =
-        "Reading prompt from stdin...\n" +
-        "OpenAI Codex v0.120.0 (research preview)\n" +
-        "--------\n" +
-        "model: gpt-5.4\n" +
-        "--------\n" +
-        "user\n" +
-        "ping\n" +
-        "\n" +
-        "codex\n" +
-        ASK_JSON +
-        "\n";
-
-      const spy = makeSpy({
-        ok: true,
-        exitCode: 0,
-        stdout: incompleteWrapper,
-        stderr: "",
-      });
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.4", family: "codex" }],
-        accountDefaultFallback: false,
-      });
-
-      const out = await adapter.ask({
-        prompt: "ping",
-        context: "",
-        opts: OPTS_HIGH,
-      });
-      expect(out.answer).toBe("agentic-ok");
-    },
-  );
-
-  test(
-    "non-wrapped plain JSON still works (backward compatibility)",
-    async () => {
-      // When codex emits bare JSON (no wrapper), the adapter must still parse it.
-      const spy = makeSpy({
-        ok: true,
-        exitCode: 0,
-        stdout: ASK_JSON,
-        stderr: "",
-      });
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.4", family: "codex" }],
-        accountDefaultFallback: false,
-      });
-
-      const out = await adapter.ask({
-        prompt: "ping",
-        context: "",
-        opts: OPTS_HIGH,
-      });
-      expect(out.answer).toBe("agentic-ok");
-    },
-  );
-
-  test(
-    "agentic-wrapper with invalid JSON after 'codex\\n' → schema_violation (no silent fail)",
-    async () => {
-      // A corrupt JSON payload in the codex section must surface as
-      // schema_violation (eventually), not silently swallowed.
-      const wrappedBadJson =
-        "Reading prompt from stdin...\n" +
-        "OpenAI Codex v0.120.0 (research preview)\n" +
-        "--------\n" +
-        "model: gpt-5.4\n" +
-        "--------\n" +
-        "user\n" +
-        "ping\n" +
-        "\n" +
-        "codex\n" +
-        "{ this is not valid json }\n" +
-        "\n" +
-        "tokens used\n" +
-        "100\n";
-
-      const spy = makeSpy({
-        ok: true,
-        exitCode: 0,
-        stdout: wrappedBadJson,
-        stderr: "",
-      });
-      // Two-model list + account-default disabled so repair-retry
-      // eventually terminates with schema_violation.
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.4", family: "codex" }],
-        accountDefaultFallback: false,
-      });
-
-      let err: unknown;
-      try {
-        await adapter.ask({
-          prompt: "ping",
-          context: "",
-          opts: OPTS_HIGH,
-        });
-      } catch (e) {
-        err = e;
-      }
-
-      expect(err).toBeInstanceOf(CodexAdapterError);
-      if (err instanceof CodexAdapterError) {
-        expect(err.payload.reason).toBe("schema_violation");
-      }
-    },
-  );
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    if (err instanceof CodexAdapterError) {
+      expect(err.payload.reason).toBe("schema_violation");
+    }
+  });
 });
 
 // ---------- contract-style: full agentic-wrapper path ----------
 
 describe("Bug #88-2: full agentic wrapper via fake-CLI fixture (contract path)", () => {
-  test(
-    "adapter.ask() returns correct answer from agentic-wrapped stdout",
-    async () => {
-      const fullOutput = makeAgenticWrapperStdout("prompt-text", ASK_JSON);
+  test("adapter.ask() returns correct answer from agentic-wrapped stdout", async () => {
+    const fullOutput = makeAgenticWrapperStdout("prompt-text", ASK_JSON);
 
-      let capturedStdin = "";
-      const spy: SpawnSpy = {
-        calls: [],
-        spawn: (input: SpawnCliInput): Promise<SpawnCliResult> => {
-          (spy.calls as Array<{ cmd: readonly string[] }>).push({
-            cmd: [...input.cmd],
-          });
-          capturedStdin = input.stdin;
-          return Promise.resolve({
-            ok: true as const,
-            exitCode: 0,
-            stdout: fullOutput,
-            stderr: "",
-          });
-        },
-      };
+    let capturedStdin = "";
+    const spy: SpawnSpy = {
+      calls: [],
+      spawn: (input: SpawnCliInput): Promise<SpawnCliResult> => {
+        (spy.calls as Array<{ cmd: readonly string[] }>).push({
+          cmd: [...input.cmd],
+        });
+        capturedStdin = input.stdin;
+        return Promise.resolve({
+          ok: true as const,
+          exitCode: 0,
+          stdout: fullOutput,
+          stderr: "",
+        });
+      },
+    };
 
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.4", family: "codex" }],
-        accountDefaultFallback: false,
-      });
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.4", family: "codex" }],
+      accountDefaultFallback: false,
+    });
 
-      const out = await adapter.ask({
-        prompt: "test question",
-        context: "",
-        opts: OPTS_HIGH,
-      });
+    const out = await adapter.ask({
+      prompt: "test question",
+      context: "",
+      opts: OPTS_HIGH,
+    });
 
-      expect(out.answer).toBe("agentic-ok");
-      // Verify the prompt was forwarded to stdin (basic wiring check).
-      expect(capturedStdin).toContain("test question");
-    },
-  );
+    expect(out.answer).toBe("agentic-ok");
+    // Verify the prompt was forwarded to stdin (basic wiring check).
+    expect(capturedStdin).toContain("test question");
+  });
 });

--- a/tests/adapter/codex-pinned-model-fallback.test.ts
+++ b/tests/adapter/codex-pinned-model-fallback.test.ts
@@ -34,10 +34,11 @@ function makeSpy(responses: readonly SpawnCliResult[]): SpawnSpy {
   const spawn = (input: SpawnCliInput): Promise<SpawnCliResult> => {
     calls.push({ cmd: [...input.cmd] });
     const idx = calls.length - 1;
-    const result =
-      responses[idx] ?? responses[responses.length - 1];
+    const result = responses[idx] ?? responses[responses.length - 1];
     if (result === undefined) {
-      throw new Error("makeSpy: no response configured for call " + String(idx));
+      throw new Error(
+        "makeSpy: no response configured for call " + String(idx),
+      );
     }
     return Promise.resolve(result);
   };
@@ -66,14 +67,15 @@ function makePinnedModelExit1Response(model: string): SpawnCliResult {
   return {
     ok: true,
     exitCode: 1,
-    stdout: JSON.stringify({
-      type: "error",
-      status: 400,
-      error: {
-        type: "invalid_request_error",
-        message: `The '${model}' model is not supported when using Codex with a ChatGPT account.`,
-      },
-    }) + "\n",
+    stdout:
+      JSON.stringify({
+        type: "error",
+        status: 400,
+        error: {
+          type: "invalid_request_error",
+          message: `The '${model}' model is not supported when using Codex with a ChatGPT account.`,
+        },
+      }) + "\n",
     stderr: "",
   };
 }
@@ -88,133 +90,121 @@ const ACCOUNT_DEFAULT_OK: SpawnCliResult = {
 // ---------- Bug #88-1a: classifier must return model_unavailable ----------
 
 describe("Bug #88-1: exit-1 + invalid_request_error stdout → model_unavailable", () => {
-  test(
-    "classifies exit-1 invalid_request_error stdout as model_unavailable, not other/schema_violation",
-    async () => {
-      // Single-model, no account-default: isolates the classification.
-      const spy = makeSpy([makePinnedModelExit1Response("gpt-5.1-codex-max")]);
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
-        accountDefaultFallback: false,
-      });
+  test("classifies exit-1 invalid_request_error stdout as model_unavailable, not other/schema_violation", async () => {
+    // Single-model, no account-default: isolates the classification.
+    const spy = makeSpy([makePinnedModelExit1Response("gpt-5.1-codex-max")]);
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+      accountDefaultFallback: false,
+    });
 
-      let err: unknown;
-      try {
-        await adapter.ask(sampleAsk());
-      } catch (e) {
-        err = e;
-      }
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
 
-      expect(err).toBeInstanceOf(CodexAdapterError);
-      if (err instanceof CodexAdapterError) {
-        // Must be model_unavailable so the fallback chain can trigger.
-        expect(err.payload.reason).toBe("model_unavailable");
-        // Must NOT be misclassified as schema_violation or other.
-        expect(err.payload.reason).not.toBe("schema_violation");
-        expect(err.payload.reason).not.toBe("other");
-      }
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    if (err instanceof CodexAdapterError) {
+      // Must be model_unavailable so the fallback chain can trigger.
+      expect(err.payload.reason).toBe("model_unavailable");
+      // Must NOT be misclassified as schema_violation or other.
+      expect(err.payload.reason).not.toBe("schema_violation");
+      expect(err.payload.reason).not.toBe("other");
+    }
 
-      // Only one spawn — no spurious repair retry on model_unavailable.
-      expect(spy.calls.length).toBe(1);
-    },
-  );
+    // Only one spawn — no spurious repair retry on model_unavailable.
+    expect(spy.calls.length).toBe(1);
+  });
 
-  test(
-    "exit-1 invalid_request_error with 'not supported' substring → model_unavailable",
-    async () => {
-      const payload: SpawnCliResult = {
-        ok: true,
-        exitCode: 1,
-        stdout:
-          "Reading prompt from stdin...\nOpenAI Codex v0.120.0 (research preview)\n" +
-          "--------\nworkdir: /private/tmp/x\nmodel: gpt-5.1-codex-max\n--------\n" +
-          JSON.stringify({
-            type: "error",
-            status: 400,
-            error: {
-              type: "invalid_request_error",
-              message:
-                "The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account.",
-            },
-          }) +
-          "\n",
-        stderr: "",
-      };
-      const spy = makeSpy([payload]);
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
-        accountDefaultFallback: false,
-      });
+  test("exit-1 invalid_request_error with 'not supported' substring → model_unavailable", async () => {
+    const payload: SpawnCliResult = {
+      ok: true,
+      exitCode: 1,
+      stdout:
+        "Reading prompt from stdin...\nOpenAI Codex v0.120.0 (research preview)\n" +
+        "--------\nworkdir: /private/tmp/x\nmodel: gpt-5.1-codex-max\n--------\n" +
+        JSON.stringify({
+          type: "error",
+          status: 400,
+          error: {
+            type: "invalid_request_error",
+            message:
+              "The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account.",
+          },
+        }) +
+        "\n",
+      stderr: "",
+    };
+    const spy = makeSpy([payload]);
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+      accountDefaultFallback: false,
+    });
 
-      let err: unknown;
-      try {
-        await adapter.ask(sampleAsk());
-      } catch (e) {
-        err = e;
-      }
-      expect(err).toBeInstanceOf(CodexAdapterError);
-      if (err instanceof CodexAdapterError) {
-        expect(err.payload.reason).toBe("model_unavailable");
-      }
-    },
-  );
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    if (err instanceof CodexAdapterError) {
+      expect(err.payload.reason).toBe("model_unavailable");
+    }
+  });
 });
 
 // ---------- Bug #88-1b: fallback chain must trigger ----------
 
 describe("Bug #88-1 fallback: exit-1 invalid_request_error fires account-default fallback", () => {
-  test(
-    "gpt-5.1-codex-max exit-1 → gpt-5.1-codex exit-1 → account-default (no --model) succeeds",
-    async () => {
-      const spy = makeSpy([
-        makePinnedModelExit1Response("gpt-5.1-codex-max"),
-        makePinnedModelExit1Response("gpt-5.1-codex"),
-        ACCOUNT_DEFAULT_OK,
-      ]);
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-      });
+  test("gpt-5.1-codex-max exit-1 → gpt-5.1-codex exit-1 → account-default (no --model) succeeds", async () => {
+    const spy = makeSpy([
+      makePinnedModelExit1Response("gpt-5.1-codex-max"),
+      makePinnedModelExit1Response("gpt-5.1-codex"),
+      ACCOUNT_DEFAULT_OK,
+    ]);
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+    });
 
-      const out = await adapter.ask(sampleAsk());
-      expect(out.answer).toBe("account-default-ok");
+    const out = await adapter.ask(sampleAsk());
+    expect(out.answer).toBe("account-default-ok");
 
-      // Three spawns: pinned-max (fail), pinned (fail), account-default (ok).
-      expect(spy.calls.length).toBe(3);
+    // Three spawns: pinned-max (fail), pinned (fail), account-default (ok).
+    expect(spy.calls.length).toBe(3);
 
-      // Third call must NOT contain --model.
-      const thirdCmd = spy.calls[2]?.cmd ?? [];
-      expect(thirdCmd).not.toContain("--model");
+    // Third call must NOT contain --model.
+    const thirdCmd = spy.calls[2]?.cmd ?? [];
+    expect(thirdCmd).not.toContain("--model");
 
-      // First two calls DID contain --model.
-      expect(spy.calls[0]?.cmd).toContain("--model");
-      expect(spy.calls[1]?.cmd).toContain("--model");
-    },
-  );
+    // First two calls DID contain --model.
+    expect(spy.calls[0]?.cmd).toContain("--model");
+    expect(spy.calls[1]?.cmd).toContain("--model");
+  });
 
-  test(
-    "exit-1 invalid_request_error with account-default succeeds → account_default: true in output",
-    async () => {
-      const spy = makeSpy([
-        makePinnedModelExit1Response("gpt-5.1-codex-max"),
-        makePinnedModelExit1Response("gpt-5.1-codex"),
-        ACCOUNT_DEFAULT_OK,
-      ]);
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-      });
+  test("exit-1 invalid_request_error with account-default succeeds → account_default: true in output", async () => {
+    const spy = makeSpy([
+      makePinnedModelExit1Response("gpt-5.1-codex-max"),
+      makePinnedModelExit1Response("gpt-5.1-codex"),
+      ACCOUNT_DEFAULT_OK,
+    ]);
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+    });
 
-      const out = await adapter.ask(sampleAsk());
-      expect((out as Record<string, unknown>)["account_default"]).toBe(true);
-    },
-  );
+    const out = await adapter.ask(sampleAsk());
+    expect((out as Record<string, unknown>)["account_default"]).toBe(true);
+  });
 });

--- a/tests/adapter/codex-pinned-model-fallback.test.ts
+++ b/tests/adapter/codex-pinned-model-fallback.test.ts
@@ -1,0 +1,220 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED tests for Issue #88 Bug 1: pinned-model fallback doesn't trigger
+// for ChatGPT `invalid_request_error` when exit code is 1.
+//
+// The real Codex CLI returns exit 1 + stdout JSON with
+// `invalid_request_error` + "not supported when using Codex with a
+// ChatGPT account" when a pinned model is rejected. The adapter
+// currently calls classifyExit(1, stderr) which looks only at stderr
+// (empty) and classifies as "other" — the fallback never fires.
+//
+// Fix: classifyStdoutApiError must be checked BEFORE classifyExit on
+// non-zero exit codes so that stdout-carried error JSON wins.
+
+import { describe, expect, test } from "bun:test";
+
+import { CodexAdapter, CodexAdapterError } from "../../src/adapter/codex.ts";
+import type { AskInput, EffortLevel } from "../../src/adapter/types.ts";
+import type { SpawnCliInput, SpawnCliResult } from "../../src/adapter/spawn.ts";
+
+// ---------- spy helpers ----------
+
+interface SpawnSpyCall {
+  readonly cmd: readonly string[];
+}
+
+interface SpawnSpy {
+  readonly spawn: (input: SpawnCliInput) => Promise<SpawnCliResult>;
+  readonly calls: SpawnSpyCall[];
+}
+
+function makeSpy(responses: readonly SpawnCliResult[]): SpawnSpy {
+  const calls: SpawnSpyCall[] = [];
+  const spawn = (input: SpawnCliInput): Promise<SpawnCliResult> => {
+    calls.push({ cmd: [...input.cmd] });
+    const idx = calls.length - 1;
+    const result =
+      responses[idx] ?? responses[responses.length - 1];
+    if (result === undefined) {
+      throw new Error("makeSpy: no response configured for call " + String(idx));
+    }
+    return Promise.resolve(result);
+  };
+  return { spawn, calls };
+}
+
+// ---------- constants ----------
+
+const OPTS_HIGH: { effort: EffortLevel; timeout: number } = {
+  effort: "high",
+  timeout: 30_000,
+};
+
+const FAKE_HOST: Record<string, string | undefined> = {
+  PATH: "/usr/bin:/bin",
+  HOME: "/tmp",
+};
+
+function sampleAsk(): AskInput {
+  return { prompt: "ping", context: "", opts: OPTS_HIGH };
+}
+
+// The exact payload the real Codex CLI emits when a pinned model is
+// rejected under ChatGPT-account auth — exit 1, error JSON on stdout.
+function makePinnedModelExit1Response(model: string): SpawnCliResult {
+  return {
+    ok: true,
+    exitCode: 1,
+    stdout: JSON.stringify({
+      type: "error",
+      status: 400,
+      error: {
+        type: "invalid_request_error",
+        message: `The '${model}' model is not supported when using Codex with a ChatGPT account.`,
+      },
+    }) + "\n",
+    stderr: "",
+  };
+}
+
+const ACCOUNT_DEFAULT_OK: SpawnCliResult = {
+  ok: true,
+  exitCode: 0,
+  stdout: '{"answer":"account-default-ok","usage":null,"effort_used":"high"}',
+  stderr: "",
+};
+
+// ---------- Bug #88-1a: classifier must return model_unavailable ----------
+
+describe("Bug #88-1: exit-1 + invalid_request_error stdout → model_unavailable", () => {
+  test(
+    "classifies exit-1 invalid_request_error stdout as model_unavailable, not other/schema_violation",
+    async () => {
+      // Single-model, no account-default: isolates the classification.
+      const spy = makeSpy([makePinnedModelExit1Response("gpt-5.1-codex-max")]);
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      let err: unknown;
+      try {
+        await adapter.ask(sampleAsk());
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toBeInstanceOf(CodexAdapterError);
+      if (err instanceof CodexAdapterError) {
+        // Must be model_unavailable so the fallback chain can trigger.
+        expect(err.payload.reason).toBe("model_unavailable");
+        // Must NOT be misclassified as schema_violation or other.
+        expect(err.payload.reason).not.toBe("schema_violation");
+        expect(err.payload.reason).not.toBe("other");
+      }
+
+      // Only one spawn — no spurious repair retry on model_unavailable.
+      expect(spy.calls.length).toBe(1);
+    },
+  );
+
+  test(
+    "exit-1 invalid_request_error with 'not supported' substring → model_unavailable",
+    async () => {
+      const payload: SpawnCliResult = {
+        ok: true,
+        exitCode: 1,
+        stdout:
+          "Reading prompt from stdin...\nOpenAI Codex v0.120.0 (research preview)\n" +
+          "--------\nworkdir: /private/tmp/x\nmodel: gpt-5.1-codex-max\n--------\n" +
+          JSON.stringify({
+            type: "error",
+            status: 400,
+            error: {
+              type: "invalid_request_error",
+              message:
+                "The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account.",
+            },
+          }) +
+          "\n",
+        stderr: "",
+      };
+      const spy = makeSpy([payload]);
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      let err: unknown;
+      try {
+        await adapter.ask(sampleAsk());
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(CodexAdapterError);
+      if (err instanceof CodexAdapterError) {
+        expect(err.payload.reason).toBe("model_unavailable");
+      }
+    },
+  );
+});
+
+// ---------- Bug #88-1b: fallback chain must trigger ----------
+
+describe("Bug #88-1 fallback: exit-1 invalid_request_error fires account-default fallback", () => {
+  test(
+    "gpt-5.1-codex-max exit-1 → gpt-5.1-codex exit-1 → account-default (no --model) succeeds",
+    async () => {
+      const spy = makeSpy([
+        makePinnedModelExit1Response("gpt-5.1-codex-max"),
+        makePinnedModelExit1Response("gpt-5.1-codex"),
+        ACCOUNT_DEFAULT_OK,
+      ]);
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+      });
+
+      const out = await adapter.ask(sampleAsk());
+      expect(out.answer).toBe("account-default-ok");
+
+      // Three spawns: pinned-max (fail), pinned (fail), account-default (ok).
+      expect(spy.calls.length).toBe(3);
+
+      // Third call must NOT contain --model.
+      const thirdCmd = spy.calls[2]?.cmd ?? [];
+      expect(thirdCmd).not.toContain("--model");
+
+      // First two calls DID contain --model.
+      expect(spy.calls[0]?.cmd).toContain("--model");
+      expect(spy.calls[1]?.cmd).toContain("--model");
+    },
+  );
+
+  test(
+    "exit-1 invalid_request_error with account-default succeeds → account_default: true in output",
+    async () => {
+      const spy = makeSpy([
+        makePinnedModelExit1Response("gpt-5.1-codex-max"),
+        makePinnedModelExit1Response("gpt-5.1-codex"),
+        ACCOUNT_DEFAULT_OK,
+      ]);
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+      });
+
+      const out = await adapter.ask(sampleAsk());
+      expect((out as Record<string, unknown>)["account_default"]).toBe(true);
+    },
+  );
+});

--- a/tests/adapter/codex-stderr-error-classification.test.ts
+++ b/tests/adapter/codex-stderr-error-classification.test.ts
@@ -1,0 +1,231 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED tests for Issue #88 reviewer follow-up: the real codex CLI v0.120.0
+// writes the banner AND the error JSON to STDERR (not stdout). Stdout is
+// empty on failure. So classifyStdoutApiError(stdout) finds nothing →
+// falls through to classifyExit(1, stderr) → which does not match
+// "not supported" (the actual ChatGPT rejection phrase) → classifies as
+// "other" → fallback chain never fires.
+//
+// Required fixes (1) detect invalid_request_error on EITHER stream, and
+// (2) add "not supported" to classifyExit's unavailable-phrase list.
+
+import { describe, expect, test } from "bun:test";
+
+import { CodexAdapter, CodexAdapterError } from "../../src/adapter/codex.ts";
+import type { AskInput, EffortLevel } from "../../src/adapter/types.ts";
+import type { SpawnCliInput, SpawnCliResult } from "../../src/adapter/spawn.ts";
+
+// ---------- helpers ----------
+
+interface SpawnSpy {
+  readonly spawn: (input: SpawnCliInput) => Promise<SpawnCliResult>;
+  readonly calls: { cmd: readonly string[] }[];
+}
+
+function makeSpy(responses: readonly SpawnCliResult[]): SpawnSpy {
+  const calls: { cmd: readonly string[] }[] = [];
+  const spawn = (input: SpawnCliInput): Promise<SpawnCliResult> => {
+    calls.push({ cmd: [...input.cmd] });
+    const idx = calls.length - 1;
+    const result = responses[idx] ?? responses[responses.length - 1];
+    if (result === undefined) {
+      throw new Error(
+        "makeSpy: no response configured for call " + String(idx),
+      );
+    }
+    return Promise.resolve(result);
+  };
+  return { spawn, calls };
+}
+
+const OPTS_HIGH: { effort: EffortLevel; timeout: number } = {
+  effort: "high",
+  timeout: 30_000,
+};
+
+const FAKE_HOST: Record<string, string | undefined> = {
+  PATH: "/usr/bin:/bin",
+  HOME: "/tmp",
+};
+
+function sampleAsk(): AskInput {
+  return { prompt: "ping", context: "", opts: OPTS_HIGH };
+}
+
+/**
+ * The REAL codex CLI v0.120.0 output shape under ChatGPT-auth rejection:
+ * - stdout: EMPTY
+ * - stderr: banner lines + the invalid_request_error JSON
+ * - exit: 1
+ */
+function realCodexStderrErrorResponse(model: string): SpawnCliResult {
+  const banner =
+    "OpenAI Codex v0.120.0 (research preview)\n" +
+    "--------\n" +
+    "workdir: /private/tmp/x\n" +
+    `model: ${model}\n` +
+    "provider: openai\n" +
+    "approval: never\n" +
+    "sandbox: read-only\n" +
+    "reasoning effort: high\n" +
+    "reasoning summaries: none\n" +
+    "session id: abc123\n" +
+    "--------\n";
+  const errorJson =
+    "ERROR: " +
+    JSON.stringify({
+      type: "error",
+      status: 400,
+      error: {
+        type: "invalid_request_error",
+        message: `The '${model}' model is not supported when using Codex with a ChatGPT account.`,
+      },
+    }) +
+    "\n";
+  return {
+    ok: true,
+    exitCode: 1,
+    stdout: "",
+    stderr: banner + errorJson,
+  };
+}
+
+// ---------- Bug #88 follow-up (1): stderr-carried error JSON ----------
+
+describe("Bug #88-followup: invalid_request_error on STDERR → model_unavailable", () => {
+  test(
+    "empty stdout + stderr-carried invalid_request_error (exit 1) classifies as model_unavailable",
+    async () => {
+      const spy = makeSpy([realCodexStderrErrorResponse("gpt-5.1-codex-max")]);
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      let err: unknown;
+      try {
+        await adapter.ask(sampleAsk());
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toBeInstanceOf(CodexAdapterError);
+      if (err instanceof CodexAdapterError) {
+        // Must classify as model_unavailable, NOT other/schema_violation.
+        expect(err.payload.reason).toBe("model_unavailable");
+        expect(err.payload.reason).not.toBe("other");
+        expect(err.payload.reason).not.toBe("schema_violation");
+      }
+    },
+  );
+
+  test(
+    "stderr-carried error with 'not supported' phrase triggers full fallback chain to account-default",
+    async () => {
+      const spy = makeSpy([
+        realCodexStderrErrorResponse("gpt-5.1-codex-max"),
+        realCodexStderrErrorResponse("gpt-5.1-codex"),
+        {
+          ok: true,
+          exitCode: 0,
+          stdout:
+            '{"answer":"account-default-ok","usage":null,"effort_used":"high"}',
+          stderr: "",
+        },
+      ]);
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+      });
+
+      const out = await adapter.ask(sampleAsk());
+      expect(out.answer).toBe("account-default-ok");
+      expect((out as Record<string, unknown>)["account_default"]).toBe(true);
+
+      // Three spawns: pinned-max (fail on stderr), pinned (fail on stderr),
+      // account-default (success).
+      expect(spy.calls.length).toBe(3);
+      // Third call has no --model flag.
+      const thirdCmd = spy.calls[2]?.cmd ?? [];
+      expect(thirdCmd).not.toContain("--model");
+    },
+  );
+});
+
+// ---------- Bug #88 follow-up (2): classifyExit "not supported" phrase ----------
+
+describe("Bug #88-followup: classifyExit recognizes 'not supported' as model_unavailable", () => {
+  test(
+    "stderr plain-text 'model is not supported' (no JSON) exit-1 → model_unavailable",
+    async () => {
+      // Some codex error paths may emit plain-text stderr without JSON
+      // wrapping. The adapter must still recognize "not supported" as a
+      // model-unavailable signal.
+      const spy = makeSpy([
+        {
+          ok: true,
+          exitCode: 1,
+          stdout: "",
+          stderr:
+            "Error: The 'gpt-5.1-codex-max' model is not supported when " +
+            "using Codex with a ChatGPT account.\n",
+        },
+      ]);
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      let err: unknown;
+      try {
+        await adapter.ask(sampleAsk());
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(CodexAdapterError);
+      if (err instanceof CodexAdapterError) {
+        expect(err.payload.reason).toBe("model_unavailable");
+      }
+    },
+  );
+
+  test(
+    "case-insensitive matching: uppercase 'Not Supported' still classified",
+    async () => {
+      const spy = makeSpy([
+        {
+          ok: true,
+          exitCode: 1,
+          stdout: "",
+          stderr: "ERROR: The MODEL is Not Supported.\n",
+        },
+      ]);
+      const adapter = new CodexAdapter({
+        host: FAKE_HOST,
+        spawn: spy.spawn,
+        binary: "/usr/bin/codex",
+        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+        accountDefaultFallback: false,
+      });
+
+      let err: unknown;
+      try {
+        await adapter.ask(sampleAsk());
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(CodexAdapterError);
+      if (err instanceof CodexAdapterError) {
+        expect(err.payload.reason).toBe("model_unavailable");
+      }
+    },
+  );
+});

--- a/tests/adapter/codex-stderr-error-classification.test.ts
+++ b/tests/adapter/codex-stderr-error-classification.test.ts
@@ -94,138 +94,126 @@ function realCodexStderrErrorResponse(model: string): SpawnCliResult {
 // ---------- Bug #88 follow-up (1): stderr-carried error JSON ----------
 
 describe("Bug #88-followup: invalid_request_error on STDERR → model_unavailable", () => {
-  test(
-    "empty stdout + stderr-carried invalid_request_error (exit 1) classifies as model_unavailable",
-    async () => {
-      const spy = makeSpy([realCodexStderrErrorResponse("gpt-5.1-codex-max")]);
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
-        accountDefaultFallback: false,
-      });
+  test("empty stdout + stderr-carried invalid_request_error (exit 1) classifies as model_unavailable", async () => {
+    const spy = makeSpy([realCodexStderrErrorResponse("gpt-5.1-codex-max")]);
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+      accountDefaultFallback: false,
+    });
 
-      let err: unknown;
-      try {
-        await adapter.ask(sampleAsk());
-      } catch (e) {
-        err = e;
-      }
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
 
-      expect(err).toBeInstanceOf(CodexAdapterError);
-      if (err instanceof CodexAdapterError) {
-        // Must classify as model_unavailable, NOT other/schema_violation.
-        expect(err.payload.reason).toBe("model_unavailable");
-        expect(err.payload.reason).not.toBe("other");
-        expect(err.payload.reason).not.toBe("schema_violation");
-      }
-    },
-  );
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    if (err instanceof CodexAdapterError) {
+      // Must classify as model_unavailable, NOT other/schema_violation.
+      expect(err.payload.reason).toBe("model_unavailable");
+      expect(err.payload.reason).not.toBe("other");
+      expect(err.payload.reason).not.toBe("schema_violation");
+    }
+  });
 
-  test(
-    "stderr-carried error with 'not supported' phrase triggers full fallback chain to account-default",
-    async () => {
-      const spy = makeSpy([
-        realCodexStderrErrorResponse("gpt-5.1-codex-max"),
-        realCodexStderrErrorResponse("gpt-5.1-codex"),
-        {
-          ok: true,
-          exitCode: 0,
-          stdout:
-            '{"answer":"account-default-ok","usage":null,"effort_used":"high"}',
-          stderr: "",
-        },
-      ]);
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-      });
+  test("stderr-carried error with 'not supported' phrase triggers full fallback chain to account-default", async () => {
+    const spy = makeSpy([
+      realCodexStderrErrorResponse("gpt-5.1-codex-max"),
+      realCodexStderrErrorResponse("gpt-5.1-codex"),
+      {
+        ok: true,
+        exitCode: 0,
+        stdout:
+          '{"answer":"account-default-ok","usage":null,"effort_used":"high"}',
+        stderr: "",
+      },
+    ]);
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+    });
 
-      const out = await adapter.ask(sampleAsk());
-      expect(out.answer).toBe("account-default-ok");
-      expect((out as Record<string, unknown>)["account_default"]).toBe(true);
+    const out = await adapter.ask(sampleAsk());
+    expect(out.answer).toBe("account-default-ok");
+    expect((out as Record<string, unknown>)["account_default"]).toBe(true);
 
-      // Three spawns: pinned-max (fail on stderr), pinned (fail on stderr),
-      // account-default (success).
-      expect(spy.calls.length).toBe(3);
-      // Third call has no --model flag.
-      const thirdCmd = spy.calls[2]?.cmd ?? [];
-      expect(thirdCmd).not.toContain("--model");
-    },
-  );
+    // Three spawns: pinned-max (fail on stderr), pinned (fail on stderr),
+    // account-default (success).
+    expect(spy.calls.length).toBe(3);
+    // Third call has no --model flag.
+    const thirdCmd = spy.calls[2]?.cmd ?? [];
+    expect(thirdCmd).not.toContain("--model");
+  });
 });
 
 // ---------- Bug #88 follow-up (2): classifyExit "not supported" phrase ----------
 
 describe("Bug #88-followup: classifyExit recognizes 'not supported' as model_unavailable", () => {
-  test(
-    "stderr plain-text 'model is not supported' (no JSON) exit-1 → model_unavailable",
-    async () => {
-      // Some codex error paths may emit plain-text stderr without JSON
-      // wrapping. The adapter must still recognize "not supported" as a
-      // model-unavailable signal.
-      const spy = makeSpy([
-        {
-          ok: true,
-          exitCode: 1,
-          stdout: "",
-          stderr:
-            "Error: The 'gpt-5.1-codex-max' model is not supported when " +
-            "using Codex with a ChatGPT account.\n",
-        },
-      ]);
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
-        accountDefaultFallback: false,
-      });
+  test("stderr plain-text 'model is not supported' (no JSON) exit-1 → model_unavailable", async () => {
+    // Some codex error paths may emit plain-text stderr without JSON
+    // wrapping. The adapter must still recognize "not supported" as a
+    // model-unavailable signal.
+    const spy = makeSpy([
+      {
+        ok: true,
+        exitCode: 1,
+        stdout: "",
+        stderr:
+          "Error: The 'gpt-5.1-codex-max' model is not supported when " +
+          "using Codex with a ChatGPT account.\n",
+      },
+    ]);
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+      accountDefaultFallback: false,
+    });
 
-      let err: unknown;
-      try {
-        await adapter.ask(sampleAsk());
-      } catch (e) {
-        err = e;
-      }
-      expect(err).toBeInstanceOf(CodexAdapterError);
-      if (err instanceof CodexAdapterError) {
-        expect(err.payload.reason).toBe("model_unavailable");
-      }
-    },
-  );
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    if (err instanceof CodexAdapterError) {
+      expect(err.payload.reason).toBe("model_unavailable");
+    }
+  });
 
-  test(
-    "case-insensitive matching: uppercase 'Not Supported' still classified",
-    async () => {
-      const spy = makeSpy([
-        {
-          ok: true,
-          exitCode: 1,
-          stdout: "",
-          stderr: "ERROR: The MODEL is Not Supported.\n",
-        },
-      ]);
-      const adapter = new CodexAdapter({
-        host: FAKE_HOST,
-        spawn: spy.spawn,
-        binary: "/usr/bin/codex",
-        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
-        accountDefaultFallback: false,
-      });
+  test("case-insensitive matching: uppercase 'Not Supported' still classified", async () => {
+    const spy = makeSpy([
+      {
+        ok: true,
+        exitCode: 1,
+        stdout: "",
+        stderr: "ERROR: The MODEL is Not Supported.\n",
+      },
+    ]);
+    const adapter = new CodexAdapter({
+      host: FAKE_HOST,
+      spawn: spy.spawn,
+      binary: "/usr/bin/codex",
+      models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+      accountDefaultFallback: false,
+    });
 
-      let err: unknown;
-      try {
-        await adapter.ask(sampleAsk());
-      } catch (e) {
-        err = e;
-      }
-      expect(err).toBeInstanceOf(CodexAdapterError);
-      if (err instanceof CodexAdapterError) {
-        expect(err.payload.reason).toBe("model_unavailable");
-      }
-    },
-  );
+    let err: unknown;
+    try {
+      await adapter.ask(sampleAsk());
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CodexAdapterError);
+    if (err instanceof CodexAdapterError) {
+      expect(err.payload.reason).toBe("model_unavailable");
+    }
+  });
 });


### PR DESCRIPTION
Closes #88.

## Summary

Three fixes over two commit batches, closing all bugs identified in the issue and the reviewer's live-repro follow-up.

### Initial scope (Bug 1 + Bug 2)

**Bug 1 — fallback not triggered on exit-1 `invalid_request_error` (stdout)**: original diagnosis. Fixed by checking `classifyStdoutApiError(stdout)` before `classifyExit` in the spawn-result path.

**Bug 2 — agentic-wrapper output parser**: added `extractCodexAgenticJson()` (Option A) to locate the `codex\n` marker and slice the JSON block before passing to `preParseJson`.

### Follow-up scope (reviewer-flagged gaps)

Reviewer live-repro against real codex v0.120.0 surfaced three additional gaps. Captured exact shape:

```
$ echo '...' | codex exec --model gpt-5.1-codex-max ...
EXIT: 1
STDOUT (0 bytes): <empty>
STDERR (693 bytes):
Reading prompt from stdin...
OpenAI Codex v0.120.0 (research preview)
--------
workdir: /private/tmp/codex-live-88
model: gpt-5.1-codex-max
provider: openai
approval: never
sandbox: read-only
reasoning effort: high
reasoning summaries: none
session id: 019db07a-8f13-78a0-b839-ce967c533f16
--------
user
what is 2+2? respond as {"a":N}

ERROR: {"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account."}}
```

**Gap 1 (error JSON on STDERR, not stdout)**: my initial fix only scanned stdout. Renamed `classifyStdoutApiError` -> `classifyApiErrorInText` and invoked on BOTH streams. Also added a string-literal-aware brace walker (`extractFirstBalancedJson`) because stderr has banner prefix + trailing blank lines that break a naive `JSON.parse(text.slice(jsonStart))`.

**Gap 2 (classifyExit missing `not supported`)**: added `"not supported"` to the unavailable-phrase list. Matching is already lowercased so it's case-insensitive — plain-text stderr errors without JSON wrapping now classify correctly.

**Gap 3 (agentic-wrapper false-positive)**: the original extractor picked the first `codex` line. A user prompt with a standalone `codex` line would trigger a false-positive slice. Fix: require the next non-blank line after `codex\n` to start with `{` — the structural signature of the real response. Mid-prompt `codex` tokens are followed by prose, not JSON.

## Changes

- `src/adapter/codex.ts`:
  - `classifyApiErrorInText` (renamed from `classifyStdoutApiError`) + new `extractFirstBalancedJson` helper
  - `classifyExit` now matches `"not supported"` in addition to existing phrases
  - `extractCodexAgenticJson` now disambiguates rogue `codex` lines by peeking for `{` on the next non-blank line
  - Spawn-result paths (initial + repair) check `classifyApiErrorInText(stdout)` OR `classifyApiErrorInText(stderr)` before `classifyExit`
- `tests/adapter/codex-pinned-model-fallback.test.ts` — initial RED/GREEN set
- `tests/adapter/codex-agentic-wrapper-parser.test.ts` — initial RED/GREEN set
- `tests/adapter/codex-stderr-error-classification.test.ts` — follow-up RED/GREEN
- `tests/adapter/codex-agentic-wrapper-false-positive.test.ts` — follow-up RED/GREEN

## Test results

```
230 pass, 0 fail (31 files in tests/adapter/)
1325 pass, 0 fail (full suite, 133 files)
typecheck: clean
format: clean
```

## CI

```
build (macos-latest)   pass   2m13s
build (ubuntu-latest)  pass   1m13s
```

## Live repro (ChatGPT-auth)

Real `samospec new` + `samospec iterate` run against a ChatGPT-logged-in codex CLI v0.120.0. `round.json`:

```json
{
  "round": 1,
  "status": "complete",
  "seats": {
    "reviewer_a": "ok",
    "reviewer_b": "ok"
  },
  "started_at": "2026-04-21T14:41:35.202Z",
  "completed_at": "2026-04-21T14:41:35.202Z"
}
```

`reviewer_a: "ok"` — confirms the full fallback path (pinned-max rejected on stderr -> pinned-codex rejected on stderr -> account-default `gpt-5.4` success). `.samo/spec/demo/reviews/r01/codex.md` contains a 101-line critique with real `weak-implementation`, `missing-risk`, `unnecessary-scope` findings about long-line handling, timezone data, pipe errors, release trust — not a schema_violation.

First 3 real findings from live `codex.md`:
- (major, weak-implementation) `bufio.Scanner` with 1 MiB max does not split oversized lines with visible continuation; fails with `ErrTooLong`
- (major, weak-implementation) `--tz` semantics contradict themselves
- (major, missing-risk) Timezone support underspecified for static cross-platform binaries; `time.LoadLocation` depends on system zoneinfo

## Approach notes

- **Option A** chosen for Bug 2 (codex-specific extractor). Narrower than brace-aware; fail-safe null return means plain JSON still parses via the standard `preParseJson` path.
- Stream-agnostic error classification (stdout OR stderr) is the minimum needed to cover both real codex paths (exit 0 stdout vs exit 1 stderr) and any future CLI version that reshuffles routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)