### PR TITLE
fix(state): substitute finding IDs in decisions.md (#95)

### DIFF
--- a/src/loop/decisions.ts
+++ b/src/loop/decisions.ts
@@ -114,6 +114,16 @@ export function appendRoundDecisions(input: AppendRoundDecisionsInput): string {
  * Convert a ReviseOutput.decisions array (v0.2.0+) to ReviewDecision[]
  * compatible with appendRoundDecisions. When decisions is absent or empty,
  * returns [] which triggers the "no decisions recorded" fallback.
+ *
+ * Finding-ID substitution (fix for #95): the lead frequently omits
+ * `finding_id` from its decision objects, which previously left a
+ * literal `#?` placeholder in decisions.md. We now assign a
+ * deterministic category-scoped counter (e.g. `ambiguity#1`,
+ * `ambiguity#2`) when `finding_id` is missing. Numbering resets per
+ * call (so per revise/round) and advances in decision-array order, so
+ * the N-th missing-ID decision in category C within a round is
+ * stably labelled `C#N`. Entries that DO carry an explicit
+ * `finding_id` are passed through verbatim.
  */
 export function reviseDecisionsToReviewDecisions(
   decisions: readonly ReviseDecision[] | undefined | null,
@@ -121,11 +131,22 @@ export function reviseDecisionsToReviewDecisions(
   if (decisions === undefined || decisions === null || decisions.length === 0) {
     return [];
   }
-  return decisions.map((d) => ({
-    finding_ref: d.finding_id ?? `${d.category}#?`,
-    decision: d.verdict,
-    rationale: d.rationale,
-  }));
+  const categoryCounters = new Map<string, number>();
+  return decisions.map((d) => {
+    let finding_ref: string;
+    if (typeof d.finding_id === "string" && d.finding_id.length > 0) {
+      finding_ref = d.finding_id;
+    } else {
+      const next = (categoryCounters.get(d.category) ?? 0) + 1;
+      categoryCounters.set(d.category, next);
+      finding_ref = `${d.category}#${String(next)}`;
+    }
+    return {
+      finding_ref,
+      decision: d.verdict,
+      rationale: d.rationale,
+    };
+  });
 }
 
 /** Seed a fresh decisions.md when the new flow didn't write one. */

--- a/src/loop/decisions.ts
+++ b/src/loop/decisions.ts
@@ -124,6 +124,18 @@ export function appendRoundDecisions(input: AppendRoundDecisionsInput): string {
  * the N-th missing-ID decision in category C within a round is
  * stably labelled `C#N`. Entries that DO carry an explicit
  * `finding_id` are passed through verbatim.
+ *
+ * Collision avoidance: the fallback counter skips any numeric slot
+ * already claimed by an explicit `finding_id` in the same category
+ * within this call. We pre-scan explicit IDs of the form
+ * `<category>#<n>` into a per-category set, then advance the counter
+ * past occupied slots on each emit. This guarantees no two decisions
+ * in the same call render the same `<category>#<n>` pair.
+ *
+ * Order dependency (minor, documented): rendered output order in
+ * decisions.md follows the input array order. Callers that want the
+ * round's markdown cross-linkable back to the review must pass the
+ * decision array in the same order the reviewer emitted its findings.
  */
 export function reviseDecisionsToReviewDecisions(
   decisions: readonly ReviseDecision[] | undefined | null,
@@ -131,13 +143,35 @@ export function reviseDecisionsToReviewDecisions(
   if (decisions === undefined || decisions === null || decisions.length === 0) {
     return [];
   }
+  // Pre-scan: collect every numeric slot claimed by an explicit
+  // finding_id of the form `<category>#<n>`, keyed by category.
+  const claimed = new Map<string, Set<number>>();
+  for (const d of decisions) {
+    if (typeof d.finding_id !== "string" || d.finding_id.length === 0) continue;
+    const hashIdx = d.finding_id.lastIndexOf("#");
+    if (hashIdx < 0) continue;
+    const catPart = d.finding_id.slice(0, hashIdx);
+    const numPart = d.finding_id.slice(hashIdx + 1);
+    if (catPart !== d.category) continue;
+    // Strict integer parse: reject empty / non-digit / leading-space.
+    if (!/^[0-9]+$/.test(numPart)) continue;
+    const n = Number.parseInt(numPart, 10);
+    if (!Number.isFinite(n)) continue;
+    const set = claimed.get(d.category) ?? new Set<number>();
+    set.add(n);
+    claimed.set(d.category, set);
+  }
   const categoryCounters = new Map<string, number>();
   return decisions.map((d) => {
     let finding_ref: string;
     if (typeof d.finding_id === "string" && d.finding_id.length > 0) {
       finding_ref = d.finding_id;
     } else {
-      const next = (categoryCounters.get(d.category) ?? 0) + 1;
+      let next = (categoryCounters.get(d.category) ?? 0) + 1;
+      const taken = claimed.get(d.category);
+      if (taken !== undefined) {
+        while (taken.has(next)) next += 1;
+      }
       categoryCounters.set(d.category, next);
       finding_ref = `${d.category}#${String(next)}`;
     }

--- a/tests/loop/changelog-counts.test.ts
+++ b/tests/loop/changelog-counts.test.ts
@@ -7,21 +7,16 @@
 import { test, expect, describe } from "bun:test";
 import {
   countDecisions,
+  reviseDecisionsToReviewDecisions,
   type DecisionCounts,
 } from "../../src/loop/decisions.ts";
 import type { ReviewDecision } from "../../src/loop/decisions.ts";
 import type { ReviseOutput } from "../../src/adapter/types.ts";
 
-// Helper: build ReviewDecision[] from ReviseOutput.decisions
+// Build ReviewDecision[] via the real exported helper so this file
+// stays aligned with production behavior (no `#?` placeholder, #95).
 function toReviewDecisions(reviseOutput: ReviseOutput): ReviewDecision[] {
-  if (!reviseOutput.decisions || reviseOutput.decisions.length === 0) {
-    return [];
-  }
-  return reviseOutput.decisions.map((d) => ({
-    finding_ref: d.finding_id ?? `${d.category}#?`,
-    decision: d.verdict,
-    rationale: d.rationale,
-  }));
+  return reviseDecisionsToReviewDecisions(reviseOutput.decisions);
 }
 
 // Helper: format the changelog line (mirrors what the loop should produce)

--- a/tests/loop/decisions-placeholder.test.ts
+++ b/tests/loop/decisions-placeholder.test.ts
@@ -1,0 +1,156 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Red-first TDD for #95: decisions.md must never contain the literal
+ * `#?` placeholder. When the lead omits `finding_id` from a decision
+ * object, the pipeline assigns a deterministic category-scoped ID so
+ * every entry — accepted, deferred, rejected — ends up cross-linkable.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  appendRoundDecisions,
+  reviseDecisionsToReviewDecisions,
+} from "../../src/loop/decisions.ts";
+import type { ReviseDecision } from "../../src/adapter/types.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-decisions-placeholder-"));
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("decisions.md must not emit '#?' placeholder IDs (#95)", () => {
+  test("missing finding_id yields concrete category-scoped IDs", () => {
+    // Fixture modelled on the repro in issue #95: multiple categories,
+    // multiple findings per category, mixed verdicts — all with no
+    // finding_id (the lead's common output shape today).
+    const leadDecisions: readonly ReviseDecision[] = [
+      {
+        category: "missing-risk",
+        verdict: "accepted",
+        rationale: "Added §3 Threat Model.",
+      },
+      {
+        category: "weak-implementation",
+        verdict: "accepted",
+        rationale: "§5.6 specifies 0600 socket in 0700 dir.",
+      },
+      {
+        category: "ambiguity",
+        verdict: "accepted",
+        rationale: "`grace_s` is defined as a config key.",
+      },
+      {
+        category: "ambiguity",
+        verdict: "deferred",
+        rationale: "Strict-mode escalation semantics deferred to v0.2.",
+      },
+      {
+        category: "contradiction",
+        verdict: "accepted",
+        rationale: "`idle_gap_s` default is now 300 s.",
+      },
+    ];
+
+    const entries = reviseDecisionsToReviewDecisions(leadDecisions);
+    const file = path.join(tmp, "decisions.md");
+    appendRoundDecisions({
+      file,
+      roundNumber: 1,
+      now: "2026-04-21T19:14:21.784Z",
+      entries,
+    });
+
+    const body = readFileSync(file, "utf8");
+
+    // Core requirement from the issue: no literal '#?' anywhere.
+    expect(body).not.toContain("#?");
+
+    // Each entry should render with a concrete numeric ID following
+    // the category label. Category-scoped counters mean we see
+    // ambiguity#1 + ambiguity#2, etc.
+    expect(body).toContain("missing-risk#1");
+    expect(body).toContain("weak-implementation#1");
+    expect(body).toContain("ambiguity#1");
+    expect(body).toContain("ambiguity#2");
+    expect(body).toContain("contradiction#1");
+  });
+
+  test("deferred and rejected findings also get concrete IDs", () => {
+    const leadDecisions: readonly ReviseDecision[] = [
+      {
+        category: "weak-testing",
+        verdict: "deferred",
+        rationale: "Will address in sprint 2.",
+      },
+      {
+        category: "weak-testing",
+        verdict: "rejected",
+        rationale: "Already covered by existing tests.",
+      },
+      {
+        category: "unnecessary-scope",
+        verdict: "rejected",
+        rationale: "Out of v1 scope.",
+      },
+    ];
+
+    const entries = reviseDecisionsToReviewDecisions(leadDecisions);
+    const file = path.join(tmp, "decisions.md");
+    appendRoundDecisions({
+      file,
+      roundNumber: 3,
+      now: "2026-04-21T20:00:00Z",
+      entries,
+    });
+
+    const body = readFileSync(file, "utf8");
+
+    expect(body).not.toContain("#?");
+    expect(body).toContain("- deferred weak-testing#1:");
+    expect(body).toContain("- rejected weak-testing#2:");
+    expect(body).toContain("- rejected unnecessary-scope#1:");
+  });
+
+  test("explicit finding_id from the lead is preserved verbatim", () => {
+    // When the lead *does* emit finding_id, we do not rewrite it —
+    // the substitution only fills in missing IDs.
+    const leadDecisions: readonly ReviseDecision[] = [
+      {
+        finding_id: "codex#7",
+        category: "ambiguity",
+        verdict: "accepted",
+        rationale: "Clarified.",
+      },
+      {
+        category: "ambiguity",
+        verdict: "accepted",
+        rationale: "Also clarified.",
+      },
+    ];
+
+    const entries = reviseDecisionsToReviewDecisions(leadDecisions);
+    const file = path.join(tmp, "decisions.md");
+    appendRoundDecisions({
+      file,
+      roundNumber: 1,
+      now: "2026-04-21T19:00:00Z",
+      entries,
+    });
+
+    const body = readFileSync(file, "utf8");
+
+    expect(body).not.toContain("#?");
+    expect(body).toContain("codex#7");
+    // Missing-ID entry gets a category-scoped fallback number.
+    expect(body).toContain("ambiguity#1");
+  });
+});

--- a/tests/loop/decisions-placeholder.test.ts
+++ b/tests/loop/decisions-placeholder.test.ts
@@ -153,4 +153,98 @@ describe("decisions.md must not emit '#?' placeholder IDs (#95)", () => {
     // Missing-ID entry gets a category-scoped fallback number.
     expect(body).toContain("ambiguity#1");
   });
+
+  test("fallback ID must not collide with explicit same-category ID in the same round", () => {
+    // Reviewer-spotted collision bug: the lead mixes explicit and
+    // missing finding_id values in the same category within one
+    // revise call. The naive per-call counter starts at 1 and would
+    // re-emit `ambiguity#1` for the missing-ID entry, duplicating
+    // the explicit ID. Force the collision two ways:
+    //
+    //   1. Explicit IDs *precede* the missing one — counter starts at
+    //      1 and steps into `ambiguity#1` (already taken) and then
+    //      `ambiguity#3` (also already taken).
+    //   2. A missing-ID entry *precedes* an explicit one — counter
+    //      emits `ambiguity#2` for the missing entry, then the
+    //      explicit `ambiguity#2` later in the same category clashes.
+    //
+    // The renderer must advance past any number already claimed by an
+    // explicit ID in the same (category) scope for this call.
+    const leadDecisions: readonly ReviseDecision[] = [
+      // Case 1: explicit #1 and explicit #3 come first, then missing.
+      {
+        finding_id: "ambiguity#1",
+        category: "ambiguity",
+        verdict: "accepted",
+        rationale: "Explicit #1.",
+      },
+      {
+        finding_id: "ambiguity#3",
+        category: "ambiguity",
+        verdict: "accepted",
+        rationale: "Explicit #3.",
+      },
+      {
+        category: "ambiguity",
+        verdict: "deferred",
+        rationale: "Missing ID — must not collide.",
+      },
+      // Case 2: missing first, then explicit #2 — naive counter
+      // would emit weak-testing#2 for the missing entry.
+      {
+        category: "weak-testing",
+        verdict: "accepted",
+        rationale: "Missing ID first.",
+      },
+      {
+        finding_id: "weak-testing#2",
+        category: "weak-testing",
+        verdict: "rejected",
+        rationale: "Explicit #2 after.",
+      },
+      {
+        category: "weak-testing",
+        verdict: "deferred",
+        rationale: "Second missing — also must not collide.",
+      },
+    ];
+
+    const entries = reviseDecisionsToReviewDecisions(leadDecisions);
+
+    // Pull out every rendered finding_ref in order.
+    const refs = entries.map((e) => e.finding_ref);
+
+    // Core uniqueness invariant per category scope: no two decisions
+    // in the same (category) scope share a rendered ID.
+    const perCategory = new Map<string, Set<string>>();
+    for (const ref of refs) {
+      const [cat] = ref.split("#");
+      if (cat === undefined) continue;
+      const set = perCategory.get(cat) ?? new Set<string>();
+      expect(set.has(ref)).toBe(false);
+      set.add(ref);
+      perCategory.set(cat, set);
+    }
+
+    // Explicit IDs must still be present verbatim.
+    expect(refs).toContain("ambiguity#1");
+    expect(refs).toContain("ambiguity#3");
+    expect(refs).toContain("weak-testing#2");
+
+    // End-to-end: rendered file also contains no duplicates for any
+    // single category.
+    const file = path.join(tmp, "decisions.md");
+    appendRoundDecisions({
+      file,
+      roundNumber: 1,
+      now: "2026-04-21T21:00:00Z",
+      entries,
+    });
+    const body = readFileSync(file, "utf8");
+    expect(body).not.toContain("#?");
+    // ambiguity#1 appears exactly once (from the explicit decision).
+    expect(body.match(/ambiguity#1\b/g)?.length ?? 0).toBe(1);
+    // weak-testing#2 appears exactly once (from the explicit decision).
+    expect(body.match(/weak-testing#2\b/g)?.length ?? 0).toBe(1);
+  });
 });

--- a/tests/loop/decisions-serialize.test.ts
+++ b/tests/loop/decisions-serialize.test.ts
@@ -11,27 +11,18 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   appendRoundDecisions,
+  reviseDecisionsToReviewDecisions,
   type AppendRoundDecisionsInput,
 } from "../../src/loop/decisions.ts";
 import type { ReviseOutput } from "../../src/adapter/types.ts";
 
-// Helper to build decisions from ReviseOutput.decisions array
+// Build decisions from ReviseOutput.decisions via the real exported
+// helper so this file stays aligned with production behavior — notably
+// the `#?`-placeholder-free substitution landed in #95.
 function decisionsFromReviseOutput(
   reviseOutput: ReviseOutput,
 ): AppendRoundDecisionsInput["entries"] {
-  if (
-    reviseOutput.decisions === undefined ||
-    reviseOutput.decisions === null ||
-    reviseOutput.decisions.length === 0
-  ) {
-    return [];
-  }
-  // Map from ReviseOutput decision format to ReviewDecision format
-  return reviseOutput.decisions.map((d) => ({
-    finding_ref: d.finding_id ?? `${d.category}#?`,
-    decision: d.verdict,
-    rationale: d.rationale,
-  }));
+  return reviseDecisionsToReviewDecisions(reviseOutput.decisions);
 }
 
 let tmpDir: string;


### PR DESCRIPTION
Closes #95.

## Summary

- When the lead omits `finding_id` from its `ReviseOutput.decisions` entries, `reviseDecisionsToReviewDecisions` now assigns a deterministic category-scoped counter (`ambiguity#1`, `ambiguity#2`, ...) instead of emitting the literal `#?` placeholder.
- Numbering resets per revise call (so per round) and advances in decision-array order, giving every accepted / deferred / rejected line a stable, cross-linkable ID.
- When the lead DOES emit `finding_id`, it is passed through verbatim — the substitution only fills in missing IDs. No reviewer-prompt contract change.

## Test plan

- [x] `bun test tests/loop/decisions-placeholder.test.ts` — three RED tests at `99ee1a3` asserting (a) no `#?` in output, (b) deferred & rejected verdicts also get IDs, (c) explicit `finding_id` preserved. Red evidence: all three failed with `Expected to not contain: "#?"` against output matching the issue repro.
- [x] Green at `98ac73b`: 3 pass / 0 fail, 13 expect() calls.
- [x] Full suite: `bun test` — 1328 pass / 0 fail.
- [x] `bun run lint` clean, `bun run typecheck` clean, `bun run format:check` clean.