### PR TITLE
fix(cli): unify next-action across status / TLDR / iterate (#96)

### DIFF
--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -61,6 +61,7 @@ import {
   type LockHandle,
   LockContendedError,
 } from "../state/lock.ts";
+import { computeNextAction } from "../state/next-action.ts";
 import { writeState } from "../state/store.ts";
 import { stateSchema, type State } from "../state/types.ts";
 import { specPaths } from "./new.ts";
@@ -374,6 +375,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
             state: currentState,
             roundsRun: Math.max(0, roundsRun - 1),
             statePath: paths.statePath,
+            tldrPath: paths.tldrPath,
+            specPath: paths.specPath,
             now: input.now,
           });
         }
@@ -399,6 +402,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
               state: currentState,
               roundsRun: Math.max(0, roundsRun - 1),
               statePath: paths.statePath,
+              tldrPath: paths.tldrPath,
+              specPath: paths.specPath,
               now: input.now,
               exitCodeOverride: 0,
             });
@@ -446,6 +451,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
               state: currentState,
               roundsRun: Math.max(0, roundsRun - 1),
               statePath: paths.statePath,
+              tldrPath: paths.tldrPath,
+              specPath: paths.specPath,
               now: input.now,
               exitCodeOverride: 0,
             });
@@ -543,6 +550,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
               state: currentState,
               roundsRun,
               statePath: paths.statePath,
+              tldrPath: paths.tldrPath,
+              specPath: paths.specPath,
               now: input.now,
             });
           }
@@ -558,6 +567,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
             state: currentState,
             roundsRun,
             statePath: paths.statePath,
+            tldrPath: paths.tldrPath,
+            specPath: paths.specPath,
             now: input.now,
           });
         }
@@ -571,9 +582,21 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
         if (roundOutcome.revisedSpec !== undefined) {
           const newSpec = ensureTrailingNewline(roundOutcome.revisedSpec);
           writeFileSync(paths.specPath, newSpec, "utf8");
+          // TLDR is re-rendered in finishIterate once `exit` is set so
+          // the Next-action section reflects convergence. Render here
+          // with a provisional committed-but-not-yet-exited state so a
+          // mid-loop `samospec status` sees a coherent file between
+          // rounds (#96).
+          const provisional: State = {
+            ...currentState,
+            round_state: "committed",
+            round_index: roundIndex,
+            exit: null,
+            updated_at: input.now,
+          };
           writeFileSync(
             paths.tldrPath,
-            renderTldr(newSpec, { slug: input.slug }),
+            renderTldr(newSpec, { slug: input.slug, state: provisional }),
             "utf8",
           );
 
@@ -787,6 +810,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
             state: currentState,
             roundsRun,
             statePath: paths.statePath,
+            tldrPath: paths.tldrPath,
+            specPath: paths.specPath,
             now: input.now,
           });
         }
@@ -1056,6 +1081,10 @@ interface FinishArgs {
   readonly statePath: string;
   readonly now: string;
   readonly exitCodeOverride?: number;
+  /** Optional — when set, TLDR.md is re-rendered with the final state
+   *  so its Next-action section reflects the exit reason (#96). */
+  readonly tldrPath?: string;
+  readonly specPath?: string;
 }
 
 function finishIterate(args: FinishArgs): IterateResult {
@@ -1070,30 +1099,31 @@ function finishIterate(args: FinishArgs): IterateResult {
     updated_at: args.now,
   };
   writeState(args.statePath, withExit);
+
+  // Re-render TLDR.md so its Next-action section matches the exit
+  // reason (#96). Guarded by tldrPath/specPath presence and existence
+  // checks so the unit tests that feed a synthetic state without a
+  // tldr file on disk still work.
+  if (
+    args.tldrPath !== undefined &&
+    args.specPath !== undefined &&
+    existsSync(args.specPath) &&
+    existsSync(args.tldrPath)
+  ) {
+    const spec = readFileSync(args.specPath, "utf8");
+    writeFileSync(
+      args.tldrPath,
+      renderTldr(spec, { slug: withExit.slug, state: withExit }),
+      "utf8",
+    );
+  }
+
   const stream = exitCode === 0 ? args.lines : args.errLines;
   stream.push(args.message);
 
-  // Next-step hints (#71).
-  const slug = args.state.slug;
-  const SUCCESS_REASONS: readonly StopReason[] = [
-    "max-rounds",
-    "ready",
-    "semantic-convergence",
-    "lead-ignoring-critiques",
-  ];
-  if (SUCCESS_REASONS.includes(args.reason)) {
-    args.lines.push(`next: samospec publish ${slug}`);
-  } else if (
-    args.reason === "reviewers-exhausted" ||
-    args.reason === "wall-clock" ||
-    args.reason === "budget" ||
-    args.reason === "sigint"
-  ) {
-    args.lines.push(
-      `next: samospec iterate ${slug}` +
-        ` (or edit .samo/spec/${slug}/SPEC.md and retry)`,
-    );
-  }
+  // Next-step hint (#71 + #96). Single shared helper so iterate's
+  // stdout tail never disagrees with `samospec status` or TLDR.md.
+  args.lines.push(`next: ${computeNextAction(withExit, withExit.slug)}`);
 
   return {
     exitCode,

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -681,8 +681,9 @@ export async function runNew(
     // SPEC.md: lead's draft verbatim.
     writeFileSync(specPath, ensureTrailingNewline(draft.spec), "utf8");
 
-    // TLDR.md: heuristic render.
-    const tldr = renderTldr(draft.spec, { slug: input.slug });
+    // TLDR.md: heuristic render. Pass state so the Next-action section
+    // is derived from state via computeNextAction (#96).
+    const tldr = renderTldr(draft.spec, { slug: input.slug, state });
     writeFileSync(tldrPath, tldr, "utf8");
 
     // decisions.md: empty seed; populated by the review loop.

--- a/src/cli/resume.ts
+++ b/src/cli/resume.ts
@@ -343,7 +343,7 @@ export async function runResume(
       writeFileSync(paths.specPath, ensureTrailingNewline(draft.spec), "utf8");
       writeFileSync(
         paths.tldrPath,
-        renderTldr(draft.spec, { slug: input.slug }),
+        renderTldr(draft.spec, { slug: input.slug, state: nextState }),
         "utf8",
       );
       if (!existsSync(paths.decisionsPath)) {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -24,6 +24,7 @@ import { existsSync, readFileSync } from "node:fs";
 
 import type { Adapter, AuthStatus, Usage } from "../adapter/types.ts";
 import { loadPersistedConsent } from "../git/push-consent.ts";
+import { computeNextAction } from "../state/next-action.ts";
 import { stateSchema } from "../state/types.ts";
 import {
   detectDegradedResolution,
@@ -214,28 +215,6 @@ export async function runStatus(input: StatusInput): Promise<StatusResult> {
 }
 
 // ---------- helpers ----------
-
-function computeNextAction(state: State, slug: string): string {
-  if (state.round_state === "lead_terminal") {
-    return `edit .samo/spec/${slug}/SPEC.md manually to recover`;
-  }
-  if (state.phase === "draft" && state.round_state === "committed") {
-    return `run \`samospec iterate\` to start the review loop`;
-  }
-  if (state.phase === "review_loop" && state.round_state === "committed") {
-    return `run \`samospec iterate\` to continue reviewing`;
-  }
-  if (state.round_state === "running") {
-    return `run \`samospec resume ${slug}\` to recover from an in-flight round`;
-  }
-  if (state.round_state === "reviews_collected") {
-    return `run \`samospec resume ${slug}\` to finalize the lead revision`;
-  }
-  if (state.round_state === "lead_revised") {
-    return `run \`samospec resume ${slug}\` to commit the lead's revision`;
-  }
-  return "";
-}
 
 function fmtMinutes(ms: number): string {
   const mins = ms / 60000;

--- a/src/render/tldr.ts
+++ b/src/render/tldr.ts
@@ -15,12 +15,24 @@
 //     Otherwise, a placeholder pointing the reader at SPEC.md.
 //   - scope: bullet list of every top-level `## ` heading in the spec,
 //     excluding `## Goal` (which is rendered above).
-//   - next-action: always "resume with `samospec resume <slug>`" so the
-//     committed TL;DR links the next step without depending on the
-//     author's prose.
+//   - next-action: derived from state via `computeNextAction` (Issue #96)
+//     so TLDR.md, `samospec status`, and the `iterate` stdout tail
+//     always agree on the recommendation. When `state` is omitted the
+//     renderer falls back to the old pre-state resume hint so pure-spec
+//     unit tests still work.
+
+import { computeNextAction } from "../state/next-action.ts";
+import type { State } from "../state/types.ts";
 
 export interface RenderTldrOpts {
   readonly slug: string;
+  /**
+   * When provided, the Next-action section is derived from state via
+   * `computeNextAction`. Callers (iterate / new / resume) that have a
+   * State in hand SHOULD pass it so TLDR.md stays consistent with
+   * status and iterate's stdout.
+   */
+  readonly state?: State;
 }
 
 /**
@@ -51,10 +63,23 @@ export function renderTldr(spec: string, opts: RenderTldrOpts): string {
 
   lines.push("## Next action");
   lines.push("");
-  lines.push(`resume with \`samospec resume ${opts.slug}\``);
+  lines.push(nextActionLine(opts));
   lines.push("");
 
   return lines.join("\n");
+}
+
+/**
+ * Render the Next-action section body. When `state` is provided, route
+ * through the shared `computeNextAction` helper so the TLDR.md file
+ * never disagrees with `samospec status` or `iterate` stdout (#96).
+ * Without state, fall back to the pre-#96 resume hint.
+ */
+function nextActionLine(opts: RenderTldrOpts): string {
+  if (opts.state !== undefined) {
+    return `\`${computeNextAction(opts.state, opts.slug)}\``;
+  }
+  return `resume with \`samospec resume ${opts.slug}\``;
 }
 
 /**

--- a/src/state/next-action.ts
+++ b/src/state/next-action.ts
@@ -1,0 +1,107 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §10 + Issue #96 — single source of truth for the "next action"
+ * hint shared by `samospec iterate` stdout tail, `samospec status`, and
+ * the `.samo/spec/<slug>/TLDR.md` renderer. All three surfaces MUST
+ * consult this helper so the user sees one consistent recommendation.
+ *
+ * Decision order (first match wins):
+ *
+ *   1. Already published (phase = "publish" AND published_at set) →
+ *      `already published as <version>` (or `already published` when
+ *      no version is recorded).
+ *   2. `lead_terminal` — either round_state = "lead_terminal" or the
+ *      persisted exit.reason starts with "lead-terminal". Manual edit
+ *      is the only recovery path per SPEC §7.
+ *   3. Converged success — exit.reason ∈ READY_REASONS → publish.
+ *   4. Halted but recoverable — exit.reason ∈ RECOVERABLE_REASONS →
+ *      run iterate again.
+ *   5. Generic / unknown exit reason with a non-null exit → iterate.
+ *   6. In-flight round (round_state ∉ committed, exit = null) → resume.
+ *   7. Committed round with no exit → iterate (either pre-iterate from
+ *      draft phase or mid-review-loop ready for the next round).
+ *
+ * The function is pure: no I/O, no side effects, deterministic on input.
+ */
+
+import type { State } from "./types.ts";
+
+/**
+ * Stop reasons that mean the spec has converged and the next user
+ * action is `samospec publish <slug>`. These correspond to SPEC §12
+ * conditions 1 + 3 + 4 + 5 — all cases where the review loop exited
+ * cleanly with a spec ready to ship.
+ */
+const READY_REASONS: ReadonlySet<string> = new Set([
+  "ready",
+  "max-rounds",
+  "semantic-convergence",
+  "lead-ignoring-critiques",
+]);
+
+/**
+ * Stop reasons that interrupted the loop without converging. The user
+ * should re-invoke `samospec iterate` (or edit SPEC.md and retry).
+ */
+const RECOVERABLE_REASONS: ReadonlySet<string> = new Set([
+  "wall-clock",
+  "budget",
+  "sigint",
+  "reviewers-exhausted",
+  "push-consent-interrupted",
+]);
+
+/**
+ * Compute the canonical single-line next-action string for a given
+ * state. Callers prepend their own presentation prefix (e.g. "next: "
+ * for iterate stdout and "- next: " for status); the return value here
+ * is the action alone.
+ */
+export function computeNextAction(state: State, slug: string): string {
+  // 1. Published terminal state.
+  if (state.phase === "publish" && state.published_at !== undefined) {
+    const version = state.published_version;
+    if (version !== undefined && version.length > 0) {
+      return `already published as ${version}`;
+    }
+    return "already published";
+  }
+
+  // 2. lead_terminal — either the current round_state or an exit reason
+  //    that flags terminal refusal. SPEC §7 sub-reasons are serialized
+  //    as "lead-terminal:<sub>" so we match by prefix.
+  if (state.round_state === "lead_terminal") {
+    return `edit .samo/spec/${slug}/SPEC.md manually to recover`;
+  }
+  if (state.exit?.reason.startsWith("lead-terminal") === true) {
+    return `edit .samo/spec/${slug}/SPEC.md manually to recover`;
+  }
+
+  // 3-5. An exit has been persisted — route by reason.
+  if (state.exit !== null) {
+    if (READY_REASONS.has(state.exit.reason)) {
+      return `samospec publish ${slug}`;
+    }
+    if (RECOVERABLE_REASONS.has(state.exit.reason)) {
+      return `samospec iterate ${slug}`;
+    }
+    // Unknown / future exit reason — safe fallback is the same
+    // recoverable hint so no surface ever shows a blank next-action.
+    return `samospec iterate ${slug}`;
+  }
+
+  // 6. In-flight round: any non-committed round_state (planned /
+  //    running / reviews_collected / lead_revised) means a prior
+  //    process aborted mid-round. Resume recovers without losing work.
+  if (state.round_state !== "committed") {
+    return `samospec resume ${slug}`;
+  }
+
+  // 7. Committed, no exit. Covers:
+  //    - pre-iterate (phase=draft, round_index=0)
+  //    - mid-review-loop ready for the next round (phase=review_loop,
+  //      round_index>=1, no exit)
+  //    Both route to `samospec iterate`.
+  return `samospec iterate ${slug}`;
+}

--- a/tests/cli/status.next-action.test.ts
+++ b/tests/cli/status.next-action.test.ts
@@ -1,0 +1,121 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * RED integration test for #96: `samospec status` must consult
+ * `state.json.exit.reason` and print the canonical next-action string
+ * shared with `iterate` stdout and `TLDR.md`.
+ *
+ * Converged state (exit.reason = "ready", exit.code = 0) must yield
+ * `- next: samospec publish <slug>`.
+ *
+ * Previously status printed "run `samospec iterate` to start the review
+ * loop" regardless of exit state.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import { runStatus } from "../../src/cli/status.ts";
+import { writeState } from "../../src/state/store.ts";
+import type { State } from "../../src/state/types.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-status-next-"));
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function seedConverged(slug: string): void {
+  const slugDir = path.join(tmp, ".samo", "spec", slug);
+  mkdirSync(slugDir, { recursive: true });
+  const state: State = {
+    slug,
+    phase: "review_loop",
+    round_index: 3,
+    version: "0.4.0",
+    persona: { skill: slug, accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: { code: 0, reason: "ready", round_index: 3 },
+    created_at: "2026-04-19T12:00:00Z",
+    updated_at: "2026-04-19T12:10:00Z",
+  };
+  writeState(path.join(slugDir, "state.json"), state);
+  writeFileSync(path.join(slugDir, "SPEC.md"), "# SPEC\n", "utf8");
+}
+
+function seedPreIterate(slug: string): void {
+  const slugDir = path.join(tmp, ".samo", "spec", slug);
+  mkdirSync(slugDir, { recursive: true });
+  const state: State = {
+    slug,
+    phase: "draft",
+    round_index: 0,
+    version: "0.1.0",
+    persona: { skill: slug, accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: "2026-04-19T12:00:00Z",
+    updated_at: "2026-04-19T12:00:00Z",
+  };
+  writeState(path.join(slugDir, "state.json"), state);
+  writeFileSync(path.join(slugDir, "SPEC.md"), "# SPEC\n", "utf8");
+}
+
+describe("cli/status — next action is unified (#96)", () => {
+  test("converged (exit.reason=ready) -> next: samospec publish <slug>", async () => {
+    const slug = "refunds";
+    seedConverged(slug);
+    const res = await runStatus({
+      cwd: tmp,
+      slug,
+      now: "2026-04-19T12:10:00Z",
+      adapters: [
+        { role: "lead", adapter: createFakeAdapter({}) },
+        { role: "reviewer_a", adapter: createFakeAdapter({}) },
+        { role: "reviewer_b", adapter: createFakeAdapter({}) },
+      ],
+      sessionStartedAtMs: 0,
+      nowMs: 0,
+    });
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain(`next: samospec publish ${slug}`);
+    // The old ad-hoc strings must not appear.
+    expect(res.stdout).not.toContain("start the review loop");
+    expect(res.stdout).not.toContain("continue reviewing");
+  });
+
+  test("pre-iterate -> next: samospec iterate <slug>", async () => {
+    const slug = "refunds";
+    seedPreIterate(slug);
+    const res = await runStatus({
+      cwd: tmp,
+      slug,
+      now: "2026-04-19T12:10:00Z",
+      adapters: [
+        { role: "lead", adapter: createFakeAdapter({}) },
+        { role: "reviewer_a", adapter: createFakeAdapter({}) },
+        { role: "reviewer_b", adapter: createFakeAdapter({}) },
+      ],
+      sessionStartedAtMs: 0,
+      nowMs: 0,
+    });
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain(`next: samospec iterate ${slug}`);
+  });
+});

--- a/tests/render/tldr.next-action.test.ts
+++ b/tests/render/tldr.next-action.test.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * RED integration test for #96: `.samo/spec/<slug>/TLDR.md` Next-action
+ * section must reflect the canonical string for the current state, not
+ * the hard-coded "resume with samospec resume <slug>".
+ *
+ * In particular, when state is converged (exit.reason = "ready") the
+ * TLDR must say `samospec publish <slug>`.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { renderTldr } from "../../src/render/tldr.ts";
+import type { State } from "../../src/state/types.ts";
+
+const SLUG = "refunds";
+const NOW = "2026-04-19T12:00:00Z";
+
+function baseState(override: Partial<State> = {}): State {
+  const base: State = {
+    slug: SLUG,
+    phase: "review_loop",
+    round_index: 0,
+    version: "0.1.0",
+    persona: { skill: SLUG, accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: NOW,
+    updated_at: NOW,
+  };
+  return { ...base, ...override };
+}
+
+const SPEC = "# demo\n\n## Goal\n\nShip it.\n\n## Scope\n\n- one\n";
+
+describe("renderTldr — next action reflects state (#96)", () => {
+  test("converged (exit.reason=ready) -> samospec publish <slug>", () => {
+    const state = baseState({
+      phase: "review_loop",
+      round_index: 3,
+      round_state: "committed",
+      exit: { code: 0, reason: "ready", round_index: 3 },
+    });
+    const out = renderTldr(SPEC, { slug: SLUG, state });
+    expect(out).toContain(`samospec publish ${SLUG}`);
+    expect(out).not.toContain(`samospec resume ${SLUG}`);
+  });
+
+  test("pre-iterate -> samospec iterate <slug>", () => {
+    const state = baseState({
+      phase: "draft",
+      round_index: 0,
+      round_state: "committed",
+      exit: null,
+    });
+    const out = renderTldr(SPEC, { slug: SLUG, state });
+    expect(out).toContain(`samospec iterate ${SLUG}`);
+  });
+
+  test("mid-round in-flight -> samospec resume <slug>", () => {
+    const state = baseState({
+      phase: "review_loop",
+      round_index: 1,
+      round_state: "running",
+      exit: null,
+    });
+    const out = renderTldr(SPEC, { slug: SLUG, state });
+    expect(out).toContain(`samospec resume ${SLUG}`);
+  });
+
+  test("capped on wall-clock -> samospec iterate <slug>", () => {
+    const state = baseState({
+      phase: "review_loop",
+      round_index: 2,
+      round_state: "committed",
+      exit: { code: 4, reason: "wall-clock", round_index: 2 },
+    });
+    const out = renderTldr(SPEC, { slug: SLUG, state });
+    expect(out).toContain(`samospec iterate ${SLUG}`);
+  });
+});

--- a/tests/state/next-action.test.ts
+++ b/tests/state/next-action.test.ts
@@ -1,0 +1,286 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * RED tests for #96: a single `computeNextAction(state, slug)` helper must
+ * return one canonical next-action string per state shape. Three surfaces
+ * (`iterate` stdout tail, `samospec status`, `.samo/spec/<slug>/TLDR.md`)
+ * currently disagree — they must all route through this helper.
+ *
+ * Canonical next-action strings by state shape:
+ *
+ *   - converged (exit.reason ∈ ready / max-rounds / semantic-convergence /
+ *     lead-ignoring-critiques) → `samospec publish <slug>`
+ *   - published (phase=publish AND published_at set)               → none
+ *   - lead_terminal (round_state=lead_terminal OR exit.reason lead-terminal)
+ *         → `edit .samo/spec/<slug>/SPEC.md manually to recover`
+ *   - capped on rounds (exit.reason max-rounds — already covered above,
+ *     success). Here: "capped on wall-clock / budget / sigint /
+ *     reviewers-exhausted / push-consent-interrupted" → `samospec iterate
+ *     <slug>`
+ *   - pre-iterate (phase=draft AND round_index=0 AND exit=null
+ *     AND round_state=committed)                          → `samospec iterate
+ *     <slug>`
+ *   - mid-round committed (phase=review_loop AND round_state=committed
+ *     AND exit=null)                                      → `samospec iterate
+ *     <slug>`
+ *   - mid-round in-flight (round_state ∈ planned/running/reviews_collected/
+ *     lead_revised AND exit=null)                         → `samospec resume
+ *     <slug>`
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { computeNextAction } from "../../src/state/next-action.ts";
+import type { State } from "../../src/state/types.ts";
+
+const SLUG = "my-spec";
+const NOW = "2026-04-19T12:00:00Z";
+
+function baseState(override: Partial<State> = {}): State {
+  const base: State = {
+    slug: SLUG,
+    phase: "review_loop",
+    round_index: 0,
+    version: "0.1.0",
+    persona: { skill: SLUG, accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: NOW,
+    updated_at: NOW,
+  };
+  return { ...base, ...override };
+}
+
+interface Row {
+  readonly name: string;
+  readonly state: State;
+  readonly expected: string;
+}
+
+describe("computeNextAction — table-driven", () => {
+  const rows: readonly Row[] = [
+    {
+      name: "pre-iterate: phase=draft, round_index=0, no exit",
+      state: baseState({
+        phase: "draft",
+        round_index: 0,
+        round_state: "committed",
+        exit: null,
+      }),
+      expected: `samospec iterate ${SLUG}`,
+    },
+    {
+      name: "mid-round committed (review_loop, no exit) -> iterate",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 2,
+        round_state: "committed",
+        exit: null,
+      }),
+      expected: `samospec iterate ${SLUG}`,
+    },
+    {
+      name: "mid-round in-flight (planned) -> resume",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 1,
+        round_state: "planned",
+        exit: null,
+      }),
+      expected: `samospec resume ${SLUG}`,
+    },
+    {
+      name: "mid-round in-flight (running) -> resume",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 1,
+        round_state: "running",
+        exit: null,
+      }),
+      expected: `samospec resume ${SLUG}`,
+    },
+    {
+      name: "mid-round in-flight (reviews_collected) -> resume",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 1,
+        round_state: "reviews_collected",
+        exit: null,
+      }),
+      expected: `samospec resume ${SLUG}`,
+    },
+    {
+      name: "mid-round in-flight (lead_revised) -> resume",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 1,
+        round_state: "lead_revised",
+        exit: null,
+      }),
+      expected: `samospec resume ${SLUG}`,
+    },
+    {
+      name: "converged: exit.reason=ready -> publish",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 3,
+        round_state: "committed",
+        exit: { code: 0, reason: "ready", round_index: 3 },
+      }),
+      expected: `samospec publish ${SLUG}`,
+    },
+    {
+      name: "converged: exit.reason=max-rounds -> publish",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 10,
+        round_state: "committed",
+        exit: { code: 0, reason: "max-rounds", round_index: 10 },
+      }),
+      expected: `samospec publish ${SLUG}`,
+    },
+    {
+      name: "converged: exit.reason=semantic-convergence -> publish",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 5,
+        round_state: "committed",
+        exit: { code: 0, reason: "semantic-convergence", round_index: 5 },
+      }),
+      expected: `samospec publish ${SLUG}`,
+    },
+    {
+      name: "converged: exit.reason=lead-ignoring-critiques -> publish",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 4,
+        round_state: "committed",
+        exit: { code: 4, reason: "lead-ignoring-critiques", round_index: 4 },
+      }),
+      expected: `samospec publish ${SLUG}`,
+    },
+    {
+      name: "capped on wall-clock -> iterate to resume",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 2,
+        round_state: "committed",
+        exit: { code: 4, reason: "wall-clock", round_index: 2 },
+      }),
+      expected: `samospec iterate ${SLUG}`,
+    },
+    {
+      name: "capped on budget -> iterate",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 2,
+        round_state: "committed",
+        exit: { code: 4, reason: "budget", round_index: 2 },
+      }),
+      expected: `samospec iterate ${SLUG}`,
+    },
+    {
+      name: "sigint -> iterate",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 1,
+        round_state: "committed",
+        exit: { code: 3, reason: "sigint", round_index: 1 },
+      }),
+      expected: `samospec iterate ${SLUG}`,
+    },
+    {
+      name: "reviewers-exhausted -> iterate",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 1,
+        round_state: "committed",
+        exit: { code: 4, reason: "reviewers-exhausted", round_index: 1 },
+      }),
+      expected: `samospec iterate ${SLUG}`,
+    },
+    {
+      name: "push-consent-interrupted -> iterate",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 1,
+        round_state: "committed",
+        exit: { code: 3, reason: "push-consent-interrupted", round_index: 1 },
+      }),
+      expected: `samospec iterate ${SLUG}`,
+    },
+    {
+      name: "lead_terminal round_state -> edit manually",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 2,
+        round_state: "lead_terminal",
+        exit: { code: 4, reason: "lead-terminal:refusal", round_index: 3 },
+      }),
+      expected: `edit .samo/spec/${SLUG}/SPEC.md manually to recover`,
+    },
+    {
+      name: "lead-terminal exit reason -> edit manually",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 2,
+        round_state: "committed",
+        exit: { code: 4, reason: "lead-terminal", round_index: 3 },
+      }),
+      expected: `edit .samo/spec/${SLUG}/SPEC.md manually to recover`,
+    },
+    {
+      name: "published: phase=publish with published_at -> already published",
+      state: baseState({
+        phase: "publish",
+        round_index: 5,
+        round_state: "committed",
+        exit: { code: 0, reason: "ready", round_index: 5 },
+        published_at: NOW,
+        published_version: "v1.0",
+      }),
+      expected: `already published as v1.0`,
+    },
+    {
+      name: "generic unknown exit reason -> iterate (safe fallback)",
+      state: baseState({
+        phase: "review_loop",
+        round_index: 1,
+        round_state: "committed",
+        exit: { code: 4, reason: "some-unknown-future-reason", round_index: 1 },
+      }),
+      expected: `samospec iterate ${SLUG}`,
+    },
+  ];
+
+  for (const row of rows) {
+    test(row.name, () => {
+      expect(computeNextAction(row.state, SLUG)).toBe(row.expected);
+    });
+  }
+});
+
+describe("computeNextAction — post-convergence parity (#96 core)", () => {
+  test("any converged exit.reason emits `samospec publish <slug>`", () => {
+    const converged: readonly string[] = [
+      "ready",
+      "max-rounds",
+      "semantic-convergence",
+      "lead-ignoring-critiques",
+    ];
+    for (const reason of converged) {
+      const s = baseState({
+        phase: "review_loop",
+        round_state: "committed",
+        round_index: 3,
+        exit: { code: reason === "lead-ignoring-critiques" ? 4 : 0, reason, round_index: 3 },
+      });
+      expect(computeNextAction(s, SLUG)).toBe(`samospec publish ${SLUG}`);
+    }
+  });
+});

--- a/tests/state/next-action.test.ts
+++ b/tests/state/next-action.test.ts
@@ -278,7 +278,11 @@ describe("computeNextAction — post-convergence parity (#96 core)", () => {
         phase: "review_loop",
         round_state: "committed",
         round_index: 3,
-        exit: { code: reason === "lead-ignoring-critiques" ? 4 : 0, reason, round_index: 3 },
+        exit: {
+          code: reason === "lead-ignoring-critiques" ? 4 : 0,
+          reason,
+          round_index: 3,
+        },
       });
       expect(computeNextAction(s, SLUG)).toBe(`samospec publish ${SLUG}`);
     }


### PR DESCRIPTION
Closes #96

## Summary

- Adds shared `computeNextAction(state, slug)` helper in `src/state/next-action.ts` — single source of truth for the "what's next" hint.
- `samospec status`, `TLDR.md` renderer, and `samospec iterate` stdout tail all route through it, so a converged run now prints `samospec publish <slug>` on all three surfaces (previously each printed something different).
- `finishIterate` re-renders `TLDR.md` after writing the final `exit`, so a ready-exit TLDR.md reflects the new canonical next-action instead of the stale pre-exit resume hint.

## Test plan

- Red: `bun test tests/state/next-action.test.ts tests/cli/status.next-action.test.ts tests/render/tldr.next-action.test.ts` fails (module missing; status and TLDR emit old ad-hoc strings). See commit `test(cli): red — unify next-action across status / TLDR / iterate (#96)`.
- Green: same tests pass. Full `bun test`: 1351 pass / 0 fail / 8867 expect() calls.
- `bun run typecheck`, `bun run lint`, `bun run format:check` all clean.

Test table covers: pre-iterate, mid-round committed, in-flight (planned/running/reviews_collected/lead_revised), converged (ready / max-rounds / semantic-convergence / lead-ignoring-critiques), capped (wall-clock / budget / sigint / reviewers-exhausted / push-consent-interrupted), lead_terminal (round_state and exit.reason), published, and a generic-unknown fallback.