### PR TITLE
fix(cli): auto-commit initial draft on samospec new (#94)

### DIFF
--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -23,6 +23,7 @@
 //     protected branch (createSpecBranch throws with exit 2; specCommit
 //     additionally refuses).
 
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
@@ -32,7 +33,11 @@ import { CodexAdapter } from "../adapter/codex.ts";
 import type { Adapter } from "../adapter/types.ts";
 import { discoverContext } from "../context/discover.ts";
 import { contextJsonPath } from "../context/provenance.ts";
-import { createSpecBranch } from "../git/branch.ts";
+import {
+  SPEC_BRANCH_PREFIX,
+  branchExists,
+  createSpecBranch,
+} from "../git/branch.ts";
 import { specCommit } from "../git/commit.ts";
 import { ensureHasCommit } from "../git/ensure-has-commit.ts";
 import { ProtectedBranchError, GitLayerUsageError } from "../git/errors.ts";
@@ -415,6 +420,22 @@ export async function runNew(
     }
     if (branchResult.kind === "created") {
       notice(`branch created: ${branchResult.branch}`);
+    } else if (branchResult.kind === "exists") {
+      // #94: a prior crashed run left this branch behind. Check it out
+      // so the v0.1 draft lands on the right ref and is not silently
+      // skipped.
+      try {
+        checkoutExistingBranch(branchResult.branch, input.cwd);
+        notice(
+          `branch ${branchResult.branch} already exists — checked out to resume on it.`,
+        );
+      } catch (err) {
+        notice(
+          `branch creation skipped (${branchResult.reason}); ` +
+            `could not check out existing ${branchResult.branch}: ` +
+            `${err instanceof Error ? err.message : String(err)}.`,
+        );
+      }
     } else if (branchResult.kind === "skipped") {
       notice(`branch creation skipped (${branchResult.reason}).`);
     } else if (branchResult.kind === "stub") {
@@ -733,8 +754,14 @@ export async function runNew(
     writeState(statePath, state);
 
     // ---------- first commit on samospec/<slug> ----------
+    //
+    // #94: commit whenever we're sitting on a real spec branch —
+    // either freshly created OR one that survived a prior crashed run
+    // and was just checked out. The previous gate skipped the commit
+    // on the `exists` path, leaving `state.json.round_state=committed`
+    // untrue against a dirty working tree.
 
-    if (branchResult.kind === "created") {
+    if (branchResult.kind === "created" || branchResult.kind === "exists") {
       try {
         specCommit({
           repoPath: input.cwd,
@@ -897,9 +924,31 @@ function runPreflight(args: {
 
 type BranchCreation =
   | { kind: "created"; branch: string }
+  | { kind: "exists"; branch: string; reason: string }
   | { kind: "skipped"; reason: string }
   | { kind: "stub"; branch: string }
   | { kind: "protected"; branch: string };
+
+/**
+ * #94: when `createSpecBranch` reports that `samospec/<slug>` already
+ * exists (a prior crashed run left it behind), we check it out so the
+ * v0.1 draft commit lands on the right ref. Kept local — the git layer
+ * only exposes create-new semantics, and this is a new.ts-only recovery
+ * path.
+ */
+function checkoutExistingBranch(branch: string, repoPath: string): void {
+  const result = spawnSync("git", ["checkout", branch], {
+    cwd: repoPath,
+    encoding: "utf8",
+  });
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(
+      `git checkout ${branch} failed with status ${String(result.status)}: ${
+        result.stderr ?? ""
+      }`,
+    );
+  }
+}
 
 function createBranch(input: RunNewInput): BranchCreation {
   if (input.enableBranchCreation === true) {
@@ -915,6 +964,13 @@ function createBranch(input: RunNewInput): BranchCreation {
   } catch (err) {
     if (err instanceof ProtectedBranchError) {
       return { kind: "protected", branch: err.branchName };
+    }
+    // Issue #94: a `samospec/<slug>` branch surviving a prior crashed
+    // run is a recoverable condition — check it out and commit on it
+    // below rather than silently dropping the auto-commit.
+    const target = `${SPEC_BRANCH_PREFIX}${input.slug}`;
+    if (err instanceof GitLayerUsageError && branchExists(target, input.cwd)) {
+      return { kind: "exists", branch: target, reason: err.message };
     }
     if (err instanceof GitLayerUsageError) {
       return { kind: "skipped", reason: err.message };

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -405,7 +405,7 @@ export async function runNew(
     //   - default: try the real `createSpecBranch`. Outside a git repo
     //     this throws; we catch + surface "branch creation skipped"
     //     so legacy tests that don't initialize a git repo still run.
-    const branchResult = createBranch(input);
+    let branchResult = createBranch(input);
     if (branchResult.kind === "protected") {
       errors.push(
         `samospec: refusing to branch on protected branch '${branchResult.branch}'. ` +
@@ -424,17 +424,43 @@ export async function runNew(
       // #94: a prior crashed run left this branch behind. Check it out
       // so the v0.1 draft lands on the right ref and is not silently
       // skipped.
+      //
+      // PR #99 review must-fix: if the checkout itself fails (e.g. a
+      // dirty working tree on the caller's feature branch would be
+      // overwritten by the checkout), HEAD stays on the caller's branch.
+      // We MUST demote the branchResult to "skipped" so the downstream
+      // commit gate does not fire `specCommit` and leak the v0.1 draft
+      // onto `feat/...`. Abort the whole run with exit 2 (same class as
+      // the protected-branch refusal path) so the caller knows no work
+      // landed and can resolve the conflict before retrying.
       try {
         checkoutExistingBranch(branchResult.branch, input.cwd);
         notice(
           `branch ${branchResult.branch} already exists — checked out to resume on it.`,
         );
       } catch (err) {
-        notice(
-          `branch creation skipped (${branchResult.reason}); ` +
-            `could not check out existing ${branchResult.branch}: ` +
-            `${err instanceof Error ? err.message : String(err)}.`,
+        const detail = err instanceof Error ? err.message : String(err);
+        const existing = branchResult.branch;
+        branchResult = {
+          kind: "skipped",
+          reason:
+            `could not check out existing ${existing} ` +
+            `(create-branch error: ${branchResult.reason}; ` +
+            `checkout error: ${detail})`,
+        };
+        errors.push(
+          `samospec: branch '${existing}' already exists but ` +
+            `\`git checkout ${existing}\` failed: ${detail}. ` +
+            `Aborting to avoid committing the v0.1 draft onto the ` +
+            `current branch. Resolve the conflict (e.g. stash or ` +
+            `commit local changes, or delete/rename ${existing}) ` +
+            `and rerun \`samospec new ${input.slug}\`.`,
         );
+        return {
+          exitCode: 2,
+          stdout: lines.join("\n"),
+          stderr: `${errors.join("\n")}\n`,
+        };
       }
     } else if (branchResult.kind === "skipped") {
       notice(`branch creation skipped (${branchResult.reason}).`);

--- a/tests/cli/new-auto-commit-94.test.ts
+++ b/tests/cli/new-auto-commit-94.test.ts
@@ -226,4 +226,90 @@ describe("samospec new — auto-commits initial draft (#94)", () => {
     const spec = readFileSync(path.join(slugDir, "SPEC.md"), "utf8");
     expect(spec).toContain("# break-reminder spec");
   });
+
+  // Regression for the must-fix flagged on PR #99 review: when the
+  // recovery path enters the `branchResult.kind === "exists"` branch but
+  // `checkoutExistingBranch` throws (e.g. a dirty working tree blocks the
+  // checkout), HEAD stays on the caller's feature branch. Previously the
+  // commit gate still fired `specCommit`, silently leaking the v0.1 spec
+  // commit onto `feat/...`. The fix must abort the commit in this case
+  // (no new commit on feat, no "committed" claim in state.json).
+  test("does not leak v0.1 commit to feat branch when checkoutExistingBranch fails", async () => {
+    // Seed `samospec/spec-test` with a committed file at a path that
+    // also exists, uncommitted, on `feat/spec-test`. `git checkout
+    // samospec/spec-test` will then refuse, simulating the checkout
+    // failure the reviewer flagged.
+    repo.run(["checkout", "-b", "samospec/spec-test"]);
+    writeFileSync(path.join(tmp, "conflict.txt"), "spec-branch content\n");
+    repo.run(["add", "conflict.txt"]);
+    repo.run(["commit", "-m", "chore: seed conflict.txt on spec branch"]);
+
+    repo.run(["checkout", "feat/spec-test"]);
+    // Dirty local change at the same path that would be overwritten by
+    // the checkout — vanilla git refuses this without --force.
+    writeFileSync(path.join(tmp, "conflict.txt"), "feat-local content\n");
+
+    // Sanity preconditions: we start on feat/spec-test, and the HEAD
+    // commit there is the `.samo` init commit from beforeEach.
+    expect(repo.currentBranch()).toBe("feat/spec-test");
+    const headBeforeRes = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    expect(headBeforeRes.status).toBe(0);
+    const featHeadBefore = (headBeforeRes.stdout ?? "").trim();
+    expect(featHeadBefore.length).toBeGreaterThan(0);
+
+    const { adapter } = makeAdapter({
+      answers: [
+        personaJson("test engineer"),
+        questionsJson([{ id: "q1", text: "framework?" }]),
+      ],
+    });
+
+    await runNew(
+      {
+        cwd: tmp,
+        slug: "spec-test",
+        idea: "break reminder",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-21T20:00:00Z",
+      },
+      adapter,
+    );
+
+    // We are still on feat/spec-test — the checkout failure must have
+    // kept us here rather than silently advancing onto samospec/spec-test.
+    expect(repo.currentBranch()).toBe("feat/spec-test");
+
+    // (a) No new commit must have landed on feat/spec-test. HEAD must
+    // be unchanged from before `runNew`.
+    const headAfterRes = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    expect(headAfterRes.status).toBe(0);
+    expect((headAfterRes.stdout ?? "").trim()).toBe(featHeadBefore);
+
+    // Defensive: the HEAD commit subject on feat/spec-test must NOT be
+    // the samospec draft commit subject (no leakage).
+    const headSubjectRes = spawnSync("git", ["log", "-1", "--format=%s"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    expect(headSubjectRes.status).toBe(0);
+    expect((headSubjectRes.stdout ?? "").trim()).not.toBe(
+      "spec(spec-test): draft v0.1",
+    );
+
+    // (b) state.json.round_state must not lie about a clean "committed"
+    // outcome when no commit was made.
+    const st = readState(
+      path.join(tmp, ".samo", "spec", "spec-test", "state.json"),
+    );
+    if (st !== null) {
+      expect(st.round_state).not.toBe("committed");
+    }
+  });
 });

--- a/tests/cli/new-auto-commit-94.test.ts
+++ b/tests/cli/new-auto-commit-94.test.ts
@@ -185,11 +185,10 @@ describe("samospec new — auto-commits initial draft (#94)", () => {
 
     // (a) A new HEAD commit exists whose subject follows Conventional
     // Commits + SPEC §8 grammar (`spec(<slug>): draft v0.1`).
-    const headSubject = spawnSync(
-      "git",
-      ["log", "-1", "--format=%s"],
-      { cwd: tmp, encoding: "utf8" },
-    );
+    const headSubject = spawnSync("git", ["log", "-1", "--format=%s"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
     expect(headSubject.status).toBe(0);
     expect((headSubject.stdout ?? "").trim()).toBe(
       "spec(spec-test): draft v0.1",

--- a/tests/cli/new-auto-commit-94.test.ts
+++ b/tests/cli/new-auto-commit-94.test.ts
@@ -1,0 +1,230 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Regression test for issue #94: `samospec new <slug>` must auto-commit
+// its initial draft so that `state.json.round_state === "committed"` is
+// truthful with respect to the git tree.
+//
+// Acceptance criteria (from the issue):
+//   (a) a new HEAD commit exists after `new` on the spec branch
+//   (b) the commit includes `.samo/spec/<slug>/SPEC.md` + siblings
+//   (c) `state.json.round_state === "committed"` is backed by a real
+//       clean tree
+//   (d) `git status --porcelain` is empty under `.samo/spec/<slug>/`
+//
+// The happy-path e2e in new.e2e.test.ts already covers the simple case
+// where branch creation succeeds. This file pins the harder scenario
+// surfaced in issue #93 item 2 → 3: a previous crashed run left the
+// `samospec/<slug>` branch behind, so `createSpecBranch` fails with a
+// collision. Before the fix, `runNew` silently skipped the commit
+// (kind === "skipped"), wrote every artifact, and claimed
+// `round_state = "committed"` while the tree was entirely untracked.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  ReviseInput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+import { runInit } from "../../src/cli/init.ts";
+import { readState } from "../../src/state/store.ts";
+import { createTempRepo, type TempRepo } from "../git/helpers/tempRepo.ts";
+
+// ---------- fixture builders ----------
+
+function askOut(answer: string): AskOutput {
+  return { answer, usage: null, effort_used: "max" };
+}
+
+function personaJson(skill: string): string {
+  return JSON.stringify({
+    persona: `Veteran "${skill}" expert`,
+    rationale: "pragmatic choice",
+  });
+}
+
+function questionsJson(items: readonly { id: string; text: string }[]): string {
+  return JSON.stringify({
+    questions: items.map((q) => ({
+      id: q.id,
+      text: q.text,
+      options: ["opt A", "opt B"],
+    })),
+  });
+}
+
+const SAMPLE_SPEC =
+  "# break-reminder spec\n\n" +
+  "## Goal\n\nRemind developers to take breaks.\n\n" +
+  "## Scope\n\n- CLI\n\n";
+
+function reviseOut(): ReviseOutput {
+  return {
+    spec: SAMPLE_SPEC,
+    ready: false,
+    rationale: "v0.1 draft complete",
+    usage: null,
+    effort_used: "max",
+  };
+}
+
+interface MakeAdapterArgs {
+  readonly answers: readonly string[];
+}
+
+function makeAdapter(args: MakeAdapterArgs): {
+  adapter: Adapter;
+} {
+  const base = createFakeAdapter();
+  let askCall = 0;
+  const adapter: Adapter = {
+    ...base,
+    ask: (_input: AskInput): Promise<AskOutput> => {
+      const a =
+        args.answers[askCall] ?? args.answers[args.answers.length - 1] ?? "";
+      askCall += 1;
+      return Promise.resolve(askOut(a));
+    },
+    revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+      Promise.resolve(reviseOut()),
+  };
+  return { adapter };
+}
+
+function acceptResolver(): ChoiceResolvers {
+  return {
+    persona: () => Promise.resolve({ kind: "accept" }),
+    question: () => Promise.resolve({ choice: "decide for me" }),
+  };
+}
+
+// ---------- sandbox ----------
+
+let repo: TempRepo;
+let tmp: string;
+
+beforeEach(() => {
+  // Match the issue repro: main with an initial commit, then a feature
+  // branch, then samospec init committed so only the spec dir is new.
+  repo = createTempRepo({ initialBranch: "main" });
+  tmp = repo.dir;
+  repo.run(["checkout", "-b", "feat/spec-test"]);
+  runInit({ cwd: tmp });
+  repo.run(["add", ".samo"]);
+  repo.run(["commit", "-m", "chore: init .samo"]);
+});
+
+afterEach(() => {
+  repo.cleanup();
+});
+
+// ---------- regression test ----------
+
+describe("samospec new — auto-commits initial draft (#94)", () => {
+  test("commit happens + tree clean under .samo/spec/<slug>/ after a prior crashed run left samospec/<slug> behind", async () => {
+    // Simulate issue #93 item 2 → 3: a previous `new` crashed at persona
+    // (or later) but not before `createSpecBranch` created the branch.
+    // Back on the feature branch, the slug dir exists with some leftover
+    // content. The user reruns with --force, which archives the old dir.
+    repo.run(["checkout", "-b", "samospec/spec-test"]);
+    repo.run(["checkout", "feat/spec-test"]);
+
+    // Leftover slug dir (pretend the old run partly wrote files here).
+    mkdirSync(path.join(tmp, ".samo", "spec", "spec-test"), {
+      recursive: true,
+    });
+    writeFileSync(
+      path.join(tmp, ".samo", "spec", "spec-test", "leftover.txt"),
+      "old\n",
+    );
+
+    const { adapter } = makeAdapter({
+      answers: [
+        personaJson("test engineer"),
+        questionsJson([{ id: "q1", text: "framework?" }]),
+      ],
+    });
+
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "spec-test",
+        idea: "break reminder",
+        explain: false,
+        force: true,
+        resolvers: acceptResolver(),
+        now: "2026-04-21T20:00:00Z",
+      },
+      adapter,
+    );
+
+    expect(result.exitCode).toBe(0);
+
+    const slugDir = path.join(tmp, ".samo", "spec", "spec-test");
+
+    // (c) state.json says committed AND is backed by a real commit.
+    const st = readState(path.join(slugDir, "state.json"));
+    expect(st).not.toBeNull();
+    expect(st!.round_state).toBe("committed");
+
+    // (d) `git status --porcelain` is empty under `.samo/spec/<slug>/`.
+    const statusRes = spawnSync(
+      "git",
+      ["status", "--porcelain", path.join(".samo", "spec", "spec-test")],
+      { cwd: tmp, encoding: "utf8" },
+    );
+    expect(statusRes.status).toBe(0);
+    expect((statusRes.stdout ?? "").trim()).toBe("");
+
+    // (a) A new HEAD commit exists whose subject follows Conventional
+    // Commits + SPEC §8 grammar (`spec(<slug>): draft v0.1`).
+    const headSubject = spawnSync(
+      "git",
+      ["log", "-1", "--format=%s"],
+      { cwd: tmp, encoding: "utf8" },
+    );
+    expect(headSubject.status).toBe(0);
+    expect((headSubject.stdout ?? "").trim()).toBe(
+      "spec(spec-test): draft v0.1",
+    );
+
+    // (b) The HEAD commit's diff-tree includes SPEC.md + siblings under
+    // the slug dir — and nothing outside of it.
+    const filesRes = spawnSync(
+      "git",
+      ["show", "--pretty=", "--name-only", "HEAD"],
+      { cwd: tmp, encoding: "utf8" },
+    );
+    expect(filesRes.status).toBe(0);
+    const files = (filesRes.stdout ?? "")
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    const expected = [
+      ".samo/spec/spec-test/SPEC.md",
+      ".samo/spec/spec-test/TLDR.md",
+      ".samo/spec/spec-test/state.json",
+      ".samo/spec/spec-test/interview.json",
+      ".samo/spec/spec-test/context.json",
+      ".samo/spec/spec-test/decisions.md",
+      ".samo/spec/spec-test/changelog.md",
+    ];
+    for (const f of expected) {
+      expect(files).toContain(f);
+    }
+    for (const f of files) {
+      expect(f.startsWith(".samo/spec/spec-test/")).toBe(true);
+    }
+
+    // Sanity: SPEC.md persisted the lead's draft verbatim.
+    const spec = readFileSync(path.join(slugDir, "SPEC.md"), "utf8");
+    expect(spec).toContain("# break-reminder spec");
+  });
+});


### PR DESCRIPTION
Closes #94.

## Summary

- `samospec new` was silently skipping the v0.1 draft commit whenever `createSpecBranch` threw (the common path: a prior crashed run left `samospec/<slug>` behind), while still stamping `state.json.round_state === "committed"`. Downstream `iterate` then tripped the \"Uncommitted edits detected\" prompt — which deadlocks on non-TTY stdin (#93 item 4).
- Fix: when the only reason branch creation failed is that `samospec/<slug>` already exists, we check out the existing branch and proceed to commit on it (matching iterate's commit-on-current-branch pattern). Protected-branch refusal still wins via `specCommit`'s pre-existing check.
- Non-git-repo callers (legacy skeleton tests that never `git init`) still hit the `skipped` no-op path, so no existing tests regress.

## Test plan

```bash
bun test tests/cli/new-auto-commit-94.test.ts  # the regression test
bun test                                        # full suite
```

Red test (before fix) failed on assertion (d):

```
expect(received).toBe(expected)
Expected: ""
Received: "?? .samo/spec/spec-test/"

(fail) samospec new — auto-commits initial draft (#94) > commit happens + tree clean under .samo/spec/<slug>/ after a prior crashed run left samospec/<slug> behind

 0 pass
 1 fail
 5 expect() calls
```

Green (after fix) — isolated + full suite:

```
Ran 1 test across 1 file.   [tests/cli/new-auto-commit-94.test.ts]
 1 pass, 0 fail, 23 expect() calls

Ran 1326 tests across 134 files.   [full suite]
 1326 pass, 0 fail, 8784 expect() calls
```

Also clean: `bun run lint`, `bun run typecheck`, `bun run format:check`.

## Trade-offs

- For the `exists` recovery I use a direct `git checkout <branch>` (local helper in `new.ts`) rather than extending the git layer, since this is a `new`-only recovery path and the git layer's branch API deliberately exposes create-new semantics only. If the project prefers to centralise this, moving `checkoutExistingBranch` into `src/git/branch.ts` is a trivial follow-up.
- Issue #93 items beyond this one (off-topic interview, stale `state.json` during iterate, `#?` decisions placeholder, etc.) remain open — this PR is strictly scoped to #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)