### PR TITLE
fix(state): record real round.json started/completed_at timestamps (#100)

### DIFF
--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -472,8 +472,11 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
         const ideaForRound = state.input?.idea;
 
         // Run the round.
+        // #100: thread a wall-clock source so round.json records real
+        // started_at / completed_at instead of a single frozen `now`.
         const roundOutcome = await runRound({
           now: input.now,
+          nowFn: (): string => new Date(nowMsFn()).toISOString(),
           roundNumber: roundIndex,
           dirs,
           specText: currentSpec,

--- a/src/loop/round.ts
+++ b/src/loop/round.ts
@@ -111,6 +111,14 @@ export interface RoundDirs {
 
 export interface RunRoundInput {
   readonly now: string;
+  /**
+   * Optional wall-clock source used for `started_at` / `completed_at`
+   * in `round.json` (#100). When provided, called at the start of the
+   * round (for `started_at`) and again at the terminal write — either
+   * the completion write OR the abandoned/abort write — so the two
+   * fields capture real wall-clock timestamps. Falls back to `now`.
+   */
+  readonly nowFn?: () => string;
   readonly roundNumber: number;
   readonly dirs: RoundDirs;
   /** Current SPEC.md contents fed into critique/revise. */

--- a/src/loop/round.ts
+++ b/src/loop/round.ts
@@ -370,19 +370,28 @@ export function readRoundJson(file: string): RoundSidecar | null {
  *     status=complete before calling the lead.
  */
 export async function runRound(input: RunRoundInput): Promise<RunRoundOutcome> {
-  const { dirs, roundNumber, adapters, now } = input;
+  const { dirs, roundNumber, adapters } = input;
 
   mkdirSync(dirs.roundDir, { recursive: true });
 
   const critiqueTimeout = input.critiqueTimeoutMs ?? CRITIQUE_TIMEOUT_MS;
   const reviseTimeout = input.reviseTimeoutMs ?? REVISE_TIMEOUT_MS;
 
+  // #100: capture wall-clock timestamps for round.json. `startedAt` is
+  // taken once here (right before the adapter fan-out begins); each
+  // terminal write below calls `clock()` again to stamp a truthful
+  // `completed_at`. When no `nowFn` is supplied we degrade to the single
+  // `input.now` value (legacy behavior) — fine for tests that don't
+  // advance time, but the iterate CLI now threads a real clock through.
+  const clock: () => string = input.nowFn ?? ((): string => input.now);
+  const startedAt = clock();
+
   // Seed round.json at `planned`.
   const initial: RoundSidecar = {
     round: roundNumber,
     status: "planned",
     seats: { reviewer_a: "pending", reviewer_b: "pending" },
-    started_at: now,
+    started_at: startedAt,
   };
   writeRoundJson(dirs.roundJson, initial);
 
@@ -431,6 +440,8 @@ export async function runRound(input: RunRoundInput): Promise<RunRoundOutcome> {
     // Both seats failed and retry didn't recover. Mark abandoned; the
     // caller decides whether to prompt the user to continue with reduced
     // reviewers or exit per stopping condition #6.
+    // #100: completed_at captures real wall-clock abort time, distinct
+    // from started_at so post-hoc inspection reflects the true window.
     writeRoundJson(dirs.roundJson, {
       ...initial,
       status: "abandoned",
@@ -438,7 +449,7 @@ export async function runRound(input: RunRoundInput): Promise<RunRoundOutcome> {
         reviewer_a: seatToDiskStatus(seatA),
         reviewer_b: seatToDiskStatus(seatB),
       },
-      completed_at: now,
+      completed_at: clock(),
     });
     return {
       roundNumber,
@@ -453,6 +464,8 @@ export async function runRound(input: RunRoundInput): Promise<RunRoundOutcome> {
   }
 
   // Mark as complete before revise runs.
+  // #100: completed_at stamps real wall-clock at finalization, distinct
+  // from started_at so consumers can measure actual round duration.
   const roundComplete: RoundSidecar = {
     round: roundNumber,
     status:
@@ -461,8 +474,8 @@ export async function runRound(input: RunRoundInput): Promise<RunRoundOutcome> {
       reviewer_a: seatToDiskStatus(seatA),
       reviewer_b: seatToDiskStatus(seatB),
     },
-    started_at: now,
-    completed_at: now,
+    started_at: startedAt,
+    completed_at: clock(),
   };
   writeRoundJson(dirs.roundJson, roundComplete);
 

--- a/tests/loop/round.test.ts
+++ b/tests/loop/round.test.ts
@@ -353,6 +353,95 @@ more body`;
   });
 });
 
+// ---------- tests: round.json started_at / completed_at timestamps (#100) ----------
+
+describe("loop/round — round.json records real started/completed timestamps (#100)", () => {
+  test("success path: started_at !== completed_at; completed_at >= started_at + duration", async () => {
+    // Controllable clock: each call returns an ISO string at a known offset
+    // from a fixed base. The first call is the round-start timestamp; a
+    // later call (after reviewers + lead finish) is the completion stamp.
+    const baseMs = Date.parse("2026-04-19T12:00:00Z");
+    let tick = 0;
+    const PHASE_MS = 120_000; // 2 minutes per phase
+    const nowFn = (): string => {
+      const t = new Date(baseMs + tick * PHASE_MS).toISOString();
+      tick += 1;
+      return t;
+    };
+
+    const lead = createFakeAdapter({ revise: READY_REVISE });
+    const revA = createFakeAdapter({ critique: SAMPLE_CRITIQUE });
+    const revB = createFakeAdapter({ critique: SAMPLE_CRITIQUE });
+
+    const dirs = roundDirsFor(tmp, 1);
+    await runRound({
+      now: nowFn(),
+      nowFn,
+      roundNumber: 1,
+      dirs,
+      specText: "# SPEC\n\nv0.1 body",
+      decisionsHistory: [],
+      adapters: { lead, reviewerA: revA, reviewerB: revB },
+    });
+
+    const sidecar = readRoundJson(dirs.roundJson);
+    expect(sidecar).not.toBeNull();
+    expect(sidecar?.status).toBe("complete");
+    expect(sidecar?.started_at).toBeDefined();
+    expect(sidecar?.completed_at).toBeDefined();
+    // The bug: both equal to round-start. Regression-guard.
+    expect(sidecar?.started_at).not.toBe(sidecar?.completed_at);
+    const startedMs = Date.parse(sidecar?.started_at ?? "");
+    const completedMs = Date.parse(sidecar?.completed_at ?? "");
+    expect(completedMs).toBeGreaterThanOrEqual(startedMs + PHASE_MS);
+  });
+
+  test("both-seats-failed path: completed_at captured at abort time, not equal to started_at", async () => {
+    // Same controllable clock: the round-end (abandoned) write must reflect
+    // a real wall-clock timestamp at abort time, not the round-start stamp.
+    const baseMs = Date.parse("2026-04-19T12:00:00Z");
+    let tick = 0;
+    const PHASE_MS = 120_000;
+    const nowFn = (): string => {
+      const t = new Date(baseMs + tick * PHASE_MS).toISOString();
+      tick += 1;
+      return t;
+    };
+
+    const lead = createFakeAdapter({ revise: READY_REVISE });
+    const failing: Adapter = {
+      vendor: "fake",
+      detect: () =>
+        Promise.resolve({ installed: true, version: "x", path: "/x" }),
+      auth_status: () => Promise.resolve({ authenticated: true }),
+      supports_structured_output: () => true,
+      supports_effort: () => true,
+      models: () => Promise.resolve([{ id: "x", family: "fake" }]),
+      ask: () => Promise.reject(new Error("unused")),
+      critique: () => Promise.reject(new Error("persistent-fail")),
+      revise: () => Promise.reject(new Error("unused")),
+    };
+    const dirs = roundDirsFor(tmp, 1);
+    const outcome = await runRound({
+      now: nowFn(),
+      nowFn,
+      roundNumber: 1,
+      dirs,
+      specText: "body",
+      decisionsHistory: [],
+      adapters: { lead, reviewerA: failing, reviewerB: failing },
+    });
+    expect(outcome.roundStopReason).toBe("both_seats_failed_even_after_retry");
+    const sidecar = readRoundJson(dirs.roundJson);
+    expect(sidecar?.status).toBe("abandoned");
+    // Abort-time completed_at is truthful, not a placeholder equal to start.
+    expect(sidecar?.started_at).not.toBe(sidecar?.completed_at);
+    const startedMs = Date.parse(sidecar?.started_at ?? "");
+    const completedMs = Date.parse(sidecar?.completed_at ?? "");
+    expect(completedMs).toBeGreaterThanOrEqual(startedMs + PHASE_MS);
+  });
+});
+
 // ---------- tests: decisions_history is passed through to revise ----------
 
 describe("loop/round — decisions_history passthrough", () => {


### PR DESCRIPTION
Closes #100.

## Summary

- `.samo/spec/<slug>/reviews/r<NN>/round.json` previously wrote both `started_at` and `completed_at` from the single `input.now` captured at round start, producing identical placeholder timestamps on every completed round (bug #93 item 7).
- `runRound` now takes an optional `nowFn` wall-clock source; `started_at` is stamped once at round entry (before adapter fan-out) and `completed_at` is stamped at the terminal round.json write — whether the round lands at `complete` / `partial` (success) or `abandoned` (both-seats-failed abort).
- No schema change: `round.json` already declared both fields with `completed_at` optional. Invariant: whenever `round.json` reaches a terminal status, `completed_at` holds a truthful wall-clock value distinct from `started_at`.

## Test plan

- [x] Red-first TDD (commit `2d81645`): two controllable-clock tests in `tests/loop/round.test.ts` — success path and both-seats-failed path — assert `started_at !== completed_at` and `completed_at - started_at >= phase_duration`.

Red output (before fix):

```
(fail) loop/round — round.json records real started/completed timestamps (#100) > success path: started_at !== completed_at; completed_at >= started_at + duration
  error: expect(received).not.toBe(expected)
  Expected: not "2026-04-19T12:00:00.000Z"

(fail) loop/round — round.json records real started/completed timestamps (#100) > both-seats-failed path: completed_at captured at abort time, not equal to started_at
  error: expect(received).not.toBe(expected)
  Expected: not "2026-04-19T12:00:00.000Z"

 17 pass
 2 fail
Ran 19 tests across 1 file.
```

Green output (after fix, commit `8907a70`):

```
 19 pass
 0 fail
 54 expect() calls
Ran 19 tests across 1 file.
```

Full suite:

```
 1359 pass
 0 fail
 9090 expect() calls
Ran 1359 tests across 138 files.
```

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)