### PR TITLE
feat(cli): emit progress + heartbeat during iterate rounds (#101)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,8 +61,10 @@ const USAGE =
   "                              or 600000 (10 min). On cap, exits 4 with reason\n" +
   "                              `session-wall-clock`.\n" +
   "  resume [<slug>]             Resume an in-progress spec from state.json.\n" +
-  "  iterate [<slug>] [--rounds N] [--no-push] [--remote <name>]\n" +
+  "  iterate [<slug>] [--rounds N] [--no-push] [--remote <name>] [--quiet]\n" +
   "                              Run review rounds until a stopping condition fires.\n" +
+  "                              --quiet suppresses per-phase progress + heartbeat\n" +
+  "                              (default: verbose progress on stderr).\n" +
   "  status [<slug>]             Print phase, round, cost, wall-clock, and next action.\n" +
   "  publish [<slug>] [--no-lint] [--remote <name>]\n" +
   "                              Promote to blueprints/<slug>/SPEC.md, commit, push, open PR.\n" +
@@ -443,6 +445,7 @@ interface IterateArgs {
   readonly rounds?: number;
   readonly noPush: boolean;
   readonly remote: string;
+  readonly quiet: boolean;
 }
 
 function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
@@ -450,6 +453,7 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
   let rounds: number | undefined;
   let noPush = false;
   let remote = "origin";
+  let quiet = false;
   for (let i = 0; i < argv.length; i += 1) {
     const t = argv[i];
     if (t === undefined) continue;
@@ -469,6 +473,12 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
     }
     if (t === "--no-push") {
       noPush = true;
+      continue;
+    }
+    if (t === "--quiet") {
+      // Issue #101: suppress per-phase + heartbeat; final summary still
+      // prints. No-op when combined with `--rounds 0` or similar.
+      quiet = true;
       continue;
     }
     if (t === "--remote") {
@@ -491,6 +501,7 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
     slug,
     noPush,
     remote,
+    quiet,
     ...(rounds !== undefined ? { rounds } : {}),
   };
 }
@@ -616,6 +627,7 @@ async function runIterateCommand(rest: readonly string[]) {
     resolvers: interactiveIterateResolvers(),
     adapters,
     pushOptions,
+    quiet: parsed.quiet,
     ...(parsed.rounds !== undefined ? { maxRounds: parsed.rounds } : {}),
   });
   return {

--- a/src/cli/iterate-progress.ts
+++ b/src/cli/iterate-progress.ts
@@ -171,8 +171,18 @@ export function createProgressReporter(args: {
       // One heartbeat line per active child. Two children (reviewer A +
       // reviewer B in parallel) emit two lines per interval — readers
       // can tell at a glance which one is holding things up.
+      //
+      // Per-child gating (reviewer follow-up on #101): the timer is
+      // aligned to global `setInterval` boundaries, not to individual
+      // child start times. A child that starts 2s before the next tick
+      // would otherwise emit "child — 2s" on that tick, violating the
+      // SPEC §10 "every ~30s of silent work" contract. Suppress the
+      // line until the child has been running for at least one full
+      // interval; subsequent ticks still align with the global cadence.
       for (const child of active.values()) {
-        const elapsedSec = Math.floor((now - child.startedAtMs) / 1000);
+        const elapsedMs = now - child.startedAtMs;
+        if (elapsedMs < intervalMs) continue;
+        const elapsedSec = Math.floor(elapsedMs / 1000);
         args.emit(
           `${formatLabel(child.label)} (${child.identity}) — ${String(elapsedSec)}s`,
         );

--- a/src/cli/iterate-progress.ts
+++ b/src/cli/iterate-progress.ts
@@ -1,0 +1,296 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Issue #101 — progress + heartbeat emitter for `samospec iterate`.
+ *
+ * `runIterate` used to run a round silently for 20+ minutes, then print
+ * three lines at the end. This module centralizes the human-readable
+ * progress output so operators can tell "working" from "hung":
+ *
+ *   - `round <N> starting`
+ *   - `reviewer A (codex) starting`
+ *   - `reviewer A complete (Xs, Y findings)`
+ *   - `reviewer B (...) starting` / `... complete (...)`
+ *   - `lead revise starting` / `lead revise complete (Xs)`
+ *   - Heartbeat every ~30s of silent work, e.g.
+ *     `lead (claude-opus-4-7) — 180s`
+ *     (lists every currently-running child when more than one).
+ *
+ * All lines are emitted to the caller-supplied `emit()` sink, which
+ * `runIterate` routes to stderr. Stdout is never touched here — scripts
+ * parsing the final summary lines on stdout must not break.
+ *
+ * Testability: the heartbeat loop uses an injectable `clock` +
+ * `schedule` so unit tests can drive simulated time forward without
+ * real setInterval / Date.now. Default production wiring calls
+ * `setInterval` and `performance.now()`.
+ */
+
+export interface ProgressClock {
+  /** Monotonic timestamp in milliseconds (real clock or stub). */
+  now(): number;
+}
+
+export interface ProgressSchedulerHandle {
+  cancel(): void;
+}
+
+export type ProgressScheduleFn = (
+  cb: () => void,
+  intervalMs: number,
+) => ProgressSchedulerHandle;
+
+/**
+ * Optional injection surface for tests. Production callers can pass
+ * `{}` (all defaults) or leave the field undefined in IterateInput.
+ */
+export interface ProgressOptions {
+  readonly clock?: ProgressClock;
+  readonly heartbeatIntervalMs?: number;
+  readonly schedule?: ProgressScheduleFn;
+}
+
+export type ChildLabel = "lead" | "reviewer_a" | "reviewer_b";
+
+/**
+ * Snapshot of an active child — used both for heartbeat formatting and
+ * for phase-complete formatting. Identity string appears verbatim in
+ * progress lines, so keep it stable: `<role> (<identity>)`.
+ */
+interface ActiveChild {
+  readonly label: ChildLabel;
+  /** Display identity, e.g. "codex", "claude-opus-4-7". */
+  readonly identity: string;
+  /** Clock timestamp at start — used for elapsed-seconds in heartbeat. */
+  readonly startedAtMs: number;
+}
+
+/**
+ * Emit sink. `runIterate` routes every call to its progress stderr
+ * buffer.
+ */
+export type EmitFn = (line: string) => void;
+
+export interface ProgressReporter {
+  /** `round N starting`. */
+  roundStart(roundNumber: number): void;
+
+  /**
+   * Bracket a reviewer phase. The caller invokes `start()` before
+   * issuing the critique call and `complete()` after the promise
+   * resolves; the returned closures handle timing + heartbeat bookkeeping.
+   */
+  beginReviewer(
+    seat: "reviewer_a" | "reviewer_b",
+    identity: string,
+  ): PhaseHandle<{ findings: number }>;
+
+  /** Bracket the lead revise phase. */
+  beginLead(identity: string): PhaseHandle<undefined>;
+
+  /**
+   * Tear down any active heartbeat interval. Safe to call even when
+   * no children are active or the reporter is in quiet mode.
+   */
+  shutdown(): void;
+}
+
+export interface PhaseHandle<ExtraT> {
+  /** Close the phase and emit the completion line. */
+  complete(extra: ExtraT): void;
+  /**
+   * Close the phase without emitting a completion line (e.g. on
+   * exception before the adapter's promise returned meaningful data).
+   * The caller is responsible for surfacing the failure elsewhere.
+   */
+  abort(): void;
+}
+
+/**
+ * Default heartbeat interval — SPEC language is "~30s of silent work".
+ * Kept as a constant so both the default and the test-injected value
+ * have a single canonical origin.
+ */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000 as const;
+
+export function defaultClock(): ProgressClock {
+  // Monotonic; wraps Bun / Node performance.now when available, else
+  // Date.now (non-monotonic but fine for stdout emission granularity).
+  return {
+    now: () => {
+      if (
+        typeof performance !== "undefined" &&
+        typeof performance.now === "function"
+      ) {
+        return performance.now();
+      }
+      return Date.now();
+    },
+  };
+}
+
+export function defaultSchedule(): ProgressScheduleFn {
+  return (cb, intervalMs) => {
+    const handle = setInterval(cb, intervalMs);
+    // Bun / Node: unref so a stray interval never blocks process exit.
+    if (typeof (handle as { unref?: () => void }).unref === "function") {
+      (handle as { unref: () => void }).unref();
+    }
+    return {
+      cancel: (): void => {
+        clearInterval(handle);
+      },
+    };
+  };
+}
+
+/**
+ * Build a reporter. When `quiet` is true, every method is a no-op
+ * and no timers are scheduled.
+ */
+export function createProgressReporter(args: {
+  readonly emit: EmitFn;
+  readonly quiet: boolean;
+  readonly options?: ProgressOptions;
+}): ProgressReporter {
+  if (args.quiet) return NOOP_REPORTER;
+
+  const clock = args.options?.clock ?? defaultClock();
+  const schedule = args.options?.schedule ?? defaultSchedule();
+  const intervalMs =
+    args.options?.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+
+  const active = new Map<ChildLabel, ActiveChild>();
+  let heartbeat: ProgressSchedulerHandle | null = null;
+
+  const startHeartbeat = (): void => {
+    if (heartbeat !== null) return;
+    heartbeat = schedule(() => {
+      if (active.size === 0) return;
+      const now = clock.now();
+      // One heartbeat line per active child. Two children (reviewer A +
+      // reviewer B in parallel) emit two lines per interval — readers
+      // can tell at a glance which one is holding things up.
+      for (const child of active.values()) {
+        const elapsedSec = Math.floor((now - child.startedAtMs) / 1000);
+        args.emit(
+          `${formatLabel(child.label)} (${child.identity}) — ${String(elapsedSec)}s`,
+        );
+      }
+    }, intervalMs);
+  };
+
+  const stopHeartbeatIfIdle = (): void => {
+    if (active.size === 0 && heartbeat !== null) {
+      heartbeat.cancel();
+      heartbeat = null;
+    }
+  };
+
+  const begin = (label: ChildLabel, identity: string): ActiveChild => {
+    const child: ActiveChild = {
+      label,
+      identity,
+      startedAtMs: clock.now(),
+    };
+    active.set(label, child);
+    startHeartbeat();
+    return child;
+  };
+
+  const end = (label: ChildLabel): ActiveChild | undefined => {
+    const child = active.get(label);
+    active.delete(label);
+    stopHeartbeatIfIdle();
+    return child;
+  };
+
+  return {
+    roundStart(roundNumber: number): void {
+      args.emit(`round ${String(roundNumber)} starting`);
+    },
+
+    beginReviewer(seat, identity) {
+      const child = begin(seat, identity);
+      const seatLetter = seat === "reviewer_a" ? "A" : "B";
+      args.emit(`reviewer ${seatLetter} (${identity}) starting`);
+      let closed = false;
+      return {
+        complete: ({ findings }) => {
+          if (closed) return;
+          closed = true;
+          end(seat);
+          const elapsed = Math.max(
+            0,
+            Math.round((clock.now() - child.startedAtMs) / 1000),
+          );
+          args.emit(
+            `reviewer ${seatLetter} complete (${String(elapsed)}s, ${String(findings)} findings)`,
+          );
+        },
+        abort: () => {
+          if (closed) return;
+          closed = true;
+          end(seat);
+        },
+      };
+    },
+
+    beginLead(identity) {
+      const child = begin("lead", identity);
+      args.emit(`lead revise starting`);
+      void child;
+      let closed = false;
+      return {
+        complete: () => {
+          if (closed) return;
+          closed = true;
+          const c = end("lead");
+          const startAt = c?.startedAtMs ?? clock.now();
+          const elapsed = Math.max(
+            0,
+            Math.round((clock.now() - startAt) / 1000),
+          );
+          args.emit(`lead revise complete (${String(elapsed)}s)`);
+        },
+        abort: () => {
+          if (closed) return;
+          closed = true;
+          end("lead");
+        },
+      };
+    },
+
+    shutdown(): void {
+      active.clear();
+      if (heartbeat !== null) {
+        heartbeat.cancel();
+        heartbeat = null;
+      }
+    },
+  };
+}
+
+const NOOP_REPORTER: ProgressReporter = {
+  roundStart: () => undefined,
+  beginReviewer: () => ({
+    complete: () => undefined,
+    abort: () => undefined,
+  }),
+  beginLead: () => ({
+    complete: () => undefined,
+    abort: () => undefined,
+  }),
+  shutdown: () => undefined,
+};
+
+function formatLabel(label: ChildLabel): string {
+  switch (label) {
+    case "lead":
+      return "lead";
+    case "reviewer_a":
+      return "reviewer A";
+    case "reviewer_b":
+      return "reviewer B";
+  }
+}

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -1194,6 +1194,16 @@ export function readDecisions(file: string): string {
  * paths stay untouched. Identity strings are derived from the
  * adapter's `vendor` + the state's persisted `adapters.<role>.model_id`
  * when available, falling back to `vendor` alone.
+ *
+ * Prototype preservation: real adapters (ClaudeAdapter, CodexAdapter)
+ * are class instances whose methods live on the prototype, not the
+ * instance. `{...adapter}` spread only copies own enumerable
+ * properties, so `detect()`, `models()`, `ask()`, `supports_*` etc.
+ * would silently disappear. We use `Object.create(proto)` to preserve
+ * the original class's prototype chain — `instanceof OriginalClass`
+ * continues to hold, every inherited method remains callable, and
+ * only `critique`/`revise` are overridden as own properties on the
+ * wrapper.
  */
 export function wrapAdaptersForProgress(
   adapters: IterateInput["adapters"],
@@ -1207,48 +1217,64 @@ export function wrapAdaptersForProgress(
   const reviewerBIdentity =
     stateAdapters.reviewer_b?.model_id ?? adapters.reviewerB.vendor;
 
-  return {
-    lead: {
-      ...adapters.lead,
-      revise: async (input) => {
-        const handle = progress.beginLead(leadIdentity);
-        try {
-          const out = await adapters.lead.revise(input);
-          handle.complete(undefined);
-          return out;
-        } catch (err) {
-          handle.abort();
-          throw err;
-        }
-      },
-    },
-    reviewerA: {
-      ...adapters.reviewerA,
-      critique: async (input) => {
-        const handle = progress.beginReviewer("reviewer_a", reviewerAIdentity);
-        try {
-          const out = await adapters.reviewerA.critique(input);
-          handle.complete({ findings: out.findings.length });
-          return out;
-        } catch (err) {
-          handle.abort();
-          throw err;
-        }
-      },
-    },
-    reviewerB: {
-      ...adapters.reviewerB,
-      critique: async (input) => {
-        const handle = progress.beginReviewer("reviewer_b", reviewerBIdentity);
-        try {
-          const out = await adapters.reviewerB.critique(input);
-          handle.complete({ findings: out.findings.length });
-          return out;
-        } catch (err) {
-          handle.abort();
-          throw err;
-        }
-      },
-    },
+  const wrappedLead = cloneWithPrototype(adapters.lead);
+  wrappedLead.revise = async (input) => {
+    const handle = progress.beginLead(leadIdentity);
+    try {
+      const out = await adapters.lead.revise(input);
+      handle.complete(undefined);
+      return out;
+    } catch (err) {
+      handle.abort();
+      throw err;
+    }
   };
+
+  const wrappedReviewerA = cloneWithPrototype(adapters.reviewerA);
+  wrappedReviewerA.critique = async (input) => {
+    const handle = progress.beginReviewer("reviewer_a", reviewerAIdentity);
+    try {
+      const out = await adapters.reviewerA.critique(input);
+      handle.complete({ findings: out.findings.length });
+      return out;
+    } catch (err) {
+      handle.abort();
+      throw err;
+    }
+  };
+
+  const wrappedReviewerB = cloneWithPrototype(adapters.reviewerB);
+  wrappedReviewerB.critique = async (input) => {
+    const handle = progress.beginReviewer("reviewer_b", reviewerBIdentity);
+    try {
+      const out = await adapters.reviewerB.critique(input);
+      handle.complete({ findings: out.findings.length });
+      return out;
+    } catch (err) {
+      handle.abort();
+      throw err;
+    }
+  };
+
+  return {
+    lead: wrappedLead,
+    reviewerA: wrappedReviewerA,
+    reviewerB: wrappedReviewerB,
+  };
+}
+
+/**
+ * Produce a prototype-preserving clone of `source` so that a caller
+ * can override selected methods as own properties without dropping
+ * any of the inherited class methods. The result satisfies
+ * `instanceof source.constructor` and delegates every non-overridden
+ * method through the prototype chain.
+ */
+function cloneWithPrototype<T extends object>(source: T): T {
+  const clone = Object.create(Object.getPrototypeOf(source) as object) as T;
+  // Copy own enumerable properties (e.g. `vendor` set via `this.vendor = ...`
+  // in the constructor). Prototype methods are reached via the prototype
+  // chain so we never copy them explicitly.
+  Object.assign(clone, source);
+  return clone;
 }

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -1195,7 +1195,7 @@ export function readDecisions(file: string): string {
  * adapter's `vendor` + the state's persisted `adapters.<role>.model_id`
  * when available, falling back to `vendor` alone.
  */
-function wrapAdaptersForProgress(
+export function wrapAdaptersForProgress(
   adapters: IterateInput["adapters"],
   state: State,
   progress: ProgressReporter,

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -100,6 +100,11 @@ import {
   classifyLeadTerminal,
   formatLeadTerminalMessage,
 } from "./terminal-messages.ts";
+import {
+  createProgressReporter,
+  type ProgressOptions,
+  type ProgressReporter,
+} from "./iterate-progress.ts";
 
 // ---------- constants ----------
 
@@ -194,6 +199,16 @@ export interface IterateInput {
    * Absent = local-only, no consent prompt, no push attempts.
    */
   readonly pushOptions?: PushOptions;
+  /**
+   * Issue #101: when true, suppress per-phase progress + heartbeat.
+   * Final summary lines still go to stdout. Default: false (verbose).
+   */
+  readonly quiet?: boolean;
+  /**
+   * Issue #101: test-injection surface for clock + scheduler so the
+   * heartbeat can be exercised without real wall-clock sleeps.
+   */
+  readonly progress?: ProgressOptions;
 }
 
 export interface IterateResult {
@@ -216,6 +231,17 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
   const error = (line: string): void => {
     errLines.push(line);
   };
+  // Issue #101: progress + heartbeat stream. Everything the reporter
+  // emits lands on stderr alongside actual errors — never on stdout,
+  // so stdout-parsing scripts don't break. When `quiet: true`, the
+  // reporter returned here is a no-op shim.
+  const progress: ProgressReporter = createProgressReporter({
+    emit: (line: string): void => {
+      errLines.push(line);
+    },
+    quiet: input.quiet ?? false,
+    ...(input.progress !== undefined ? { options: input.progress } : {}),
+  });
 
   const paths = specPaths(input.cwd, input.slug);
 
@@ -471,6 +497,17 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
         // lead's revise() prompt carries the AUTHORITATIVE framing.
         const ideaForRound = state.input?.idea;
 
+        // Issue #101: announce the round and wrap each adapter so its
+        // critique/revise call emits start/complete progress lines +
+        // joins the heartbeat tracker. The wrapper is per-round so
+        // identities (adapter vendor + state model_id) stay fresh.
+        progress.roundStart(roundIndex);
+        const wrappedAdapters = wrapAdaptersForProgress(
+          input.adapters,
+          currentState,
+          progress,
+        );
+
         // Run the round.
         const roundOutcome = await runRound({
           now: input.now,
@@ -478,7 +515,7 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
           dirs,
           specText: currentSpec,
           decisionsHistory,
-          adapters: input.adapters,
+          adapters: wrappedAdapters,
           critiqueTimeoutMs: callTimeouts.criticA_ms,
           reviseTimeoutMs: callTimeouts.revise_ms,
           ...(manualEditDirective !== undefined ? { manualEditDirective } : {}),
@@ -830,6 +867,9 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
     }
   } finally {
     releaseLock(handle);
+    // Issue #101: always tear down the heartbeat timer so a stray
+    // setInterval doesn't keep the process alive past `iterate`.
+    progress.shutdown();
   }
 }
 
@@ -1138,4 +1178,77 @@ function finishIterate(args: FinishArgs): IterateResult {
 // Used by tests: re-read decisions.md into something structured.
 export function readDecisions(file: string): string {
   return readDecisionsFile(file);
+}
+
+// ---------- progress wrapping (#101) ----------
+
+/**
+ * Build progress-aware proxies around the real adapters. Each proxy
+ * forwards the call to its underlying adapter but also:
+ *   - emits a "<role> starting" line before the call
+ *   - joins the heartbeat tracker for the duration of the call
+ *   - emits a "<role> complete (Xs, ...)" line after the call resolves
+ *
+ * The proxy is fully transparent in behaviour — same return values,
+ * same error propagation — so `runRound`'s retry / partial-failure
+ * paths stay untouched. Identity strings are derived from the
+ * adapter's `vendor` + the state's persisted `adapters.<role>.model_id`
+ * when available, falling back to `vendor` alone.
+ */
+function wrapAdaptersForProgress(
+  adapters: IterateInput["adapters"],
+  state: State,
+  progress: ProgressReporter,
+): IterateInput["adapters"] {
+  const stateAdapters = state.adapters ?? {};
+  const leadIdentity = stateAdapters.lead?.model_id ?? adapters.lead.vendor;
+  const reviewerAIdentity =
+    stateAdapters.reviewer_a?.model_id ?? adapters.reviewerA.vendor;
+  const reviewerBIdentity =
+    stateAdapters.reviewer_b?.model_id ?? adapters.reviewerB.vendor;
+
+  return {
+    lead: {
+      ...adapters.lead,
+      revise: async (input) => {
+        const handle = progress.beginLead(leadIdentity);
+        try {
+          const out = await adapters.lead.revise(input);
+          handle.complete(undefined);
+          return out;
+        } catch (err) {
+          handle.abort();
+          throw err;
+        }
+      },
+    },
+    reviewerA: {
+      ...adapters.reviewerA,
+      critique: async (input) => {
+        const handle = progress.beginReviewer("reviewer_a", reviewerAIdentity);
+        try {
+          const out = await adapters.reviewerA.critique(input);
+          handle.complete({ findings: out.findings.length });
+          return out;
+        } catch (err) {
+          handle.abort();
+          throw err;
+        }
+      },
+    },
+    reviewerB: {
+      ...adapters.reviewerB,
+      critique: async (input) => {
+        const handle = progress.beginReviewer("reviewer_b", reviewerBIdentity);
+        try {
+          const out = await adapters.reviewerB.critique(input);
+          handle.complete({ findings: out.findings.length });
+          return out;
+        } catch (err) {
+          handle.abort();
+          throw err;
+        }
+      },
+    },
+  };
 }

--- a/tests/cli/iterate-progress-heartbeat.test.ts
+++ b/tests/cli/iterate-progress-heartbeat.test.ts
@@ -130,8 +130,9 @@ describe("createProgressReporter — per-child heartbeat gating (#101)", () => {
     const b = reporter.beginReviewer("reviewer_b", "claude");
     clock.advance(2_000); // cross the 90s global tick boundary
 
-    const afterBLines = lines
-      .filter((l) => /reviewer B \(claude\) — \d+s$/.test(l));
+    const afterBLines = lines.filter((l) =>
+      /reviewer B \(claude\) — \d+s$/.test(l),
+    );
     // B has been running 2s. Emitting "reviewer B (claude) — 2s" here
     // is the bug. The gate must suppress it.
     expect(afterBLines).toEqual([]);
@@ -188,8 +189,8 @@ describe("createProgressReporter — per-child heartbeat gating (#101)", () => {
     clock2.advance(10_000); // advance to t=98s, CROSSING the 90s tick
     b.complete({ findings: 0 });
 
-    const bHeartbeats = lines2.filter(
-      (l) => /reviewer B \(claude\) — \d+s$/.test(l),
+    const bHeartbeats = lines2.filter((l) =>
+      /reviewer B \(claude\) — \d+s$/.test(l),
     );
     // B ran for 10s total, < 30s intervalMs. No heartbeat must have
     // fired for B. Under the old behaviour the 90s global tick would

--- a/tests/cli/iterate-progress-heartbeat.test.ts
+++ b/tests/cli/iterate-progress-heartbeat.test.ts
@@ -1,0 +1,224 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Issue #101 reviewer follow-up — heartbeat must not spam short
+ * phases.
+ *
+ * The timer is aligned to `setInterval` boundaries, not to per-child
+ * start times. Scenario:
+ *   - Reviewer A starts and runs for 90s; heartbeats fire at 30s, 60s.
+ *   - Reviewer A finishes at 90s. The global interval keeps ticking
+ *     on the 30/60/90/... schedule.
+ *   - Reviewer B starts at 88s — 2s before the next interval tick at
+ *     90s. Under the old behaviour a heartbeat fires at 90s showing
+ *     `reviewer B (...) — 2s`, then another at 120s showing `32s`, etc.
+ *
+ * SPEC says "every ~30s of silent work". A 2s heartbeat violates that
+ * — so the first emission per child must be gated on its per-child
+ * elapsed time >= intervalMs. Later emissions after the first should
+ * still align with the global tick so two parallel children pair up
+ * on the same tick boundary.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  createProgressReporter,
+  type ProgressClock,
+  type ProgressScheduleFn,
+  type ProgressSchedulerHandle,
+} from "../../src/cli/iterate-progress.ts";
+
+interface StubClock extends ProgressClock {
+  advance(ms: number): void;
+}
+
+interface StubScheduler {
+  schedule: ProgressScheduleFn;
+  /** Fire every active interval once, using the current clock time. */
+  fireAll(): void;
+}
+
+function makeStubClockAndScheduler(): {
+  clock: StubClock;
+  scheduler: StubScheduler;
+} {
+  let nowMs = 0;
+  interface Entry {
+    cb: () => void;
+    intervalMs: number;
+    nextFireAt: number;
+    cancelled: boolean;
+  }
+  const entries: Entry[] = [];
+
+  const clock: StubClock = {
+    now: () => nowMs,
+    advance: (ms: number) => {
+      const target = nowMs + ms;
+      while (true) {
+        const live = entries.filter((e) => !e.cancelled);
+        if (live.length === 0) break;
+        const next = live
+          .map((e) => e.nextFireAt)
+          .reduce((a, b) => (a < b ? a : b));
+        if (next > target) break;
+        nowMs = next;
+        for (const e of entries) {
+          if (!e.cancelled && e.nextFireAt === next) {
+            e.cb();
+            e.nextFireAt += e.intervalMs;
+          }
+        }
+      }
+      nowMs = target;
+    },
+  };
+
+  const scheduler: StubScheduler = {
+    schedule: (cb, intervalMs): ProgressSchedulerHandle => {
+      const entry: Entry = {
+        cb,
+        intervalMs,
+        nextFireAt: nowMs + intervalMs,
+        cancelled: false,
+      };
+      entries.push(entry);
+      return {
+        cancel: () => {
+          entry.cancelled = true;
+        },
+      };
+    },
+    fireAll: () => {
+      clock.advance(0);
+    },
+  };
+
+  return { clock, scheduler };
+}
+
+describe("createProgressReporter — per-child heartbeat gating (#101)", () => {
+  test("does NOT emit heartbeat for a child whose elapsed < intervalMs", () => {
+    const { clock, scheduler } = makeStubClockAndScheduler();
+    const lines: string[] = [];
+    const reporter = createProgressReporter({
+      emit: (line) => lines.push(line),
+      quiet: false,
+      options: {
+        clock,
+        heartbeatIntervalMs: 30_000,
+        schedule: scheduler.schedule,
+      },
+    });
+
+    // Reviewer A runs the full 90s window — heartbeats at 30s and 60s.
+    const a = reporter.beginReviewer("reviewer_a", "codex");
+    clock.advance(90_000);
+    a.complete({ findings: 0 });
+
+    // Snapshot the heartbeat lines emitted so far; there should be two
+    // reviewer-A heartbeats (30s, 60s). We will assert B does not
+    // contribute to later lines at 2s elapsed.
+    const heartbeatLines = lines.filter((l) => /— \d+s$/.test(l));
+    expect(heartbeatLines).toEqual([
+      "reviewer A (codex) — 30s",
+      "reviewer A (codex) — 60s",
+    ]);
+
+    // Clock is now at 90s. The global interval's next tick would be
+    // 120s (60 + 30). Reviewer B starts at 88s — 2s BEFORE the next
+    // global tick. Under the buggy behaviour the 90s tick fires a
+    // heartbeat for B at "2s". SPEC says "every ~30s of silent work",
+    // so the first B heartbeat must not fire until elapsedForB >= 30s.
+    clock.advance(-2_000 + 90_000 - clock.now()); // position clock at 88s? actually 90s is current
+    // Easier: advance nothing; start B now at 90s, then step 2s — no
+    // heartbeat expected because B's elapsed would be 2s.
+    const b = reporter.beginReviewer("reviewer_b", "claude");
+    // Step past the 120s global tick boundary; B has only been running
+    // 2s since start at 90s — well under 30s.
+    clock.advance(30_000); // now at 120s, exactly one interval since last tick at 90s
+    // Fire any due schedule events.
+    scheduler.fireAll();
+
+    const afterBLines = lines
+      .filter((l) => /— \d+s$/.test(l))
+      .slice(heartbeatLines.length);
+    // No reviewer-B heartbeat should be present yet — only 30s elapsed
+    // for B since its start; the global tick at this boundary must be
+    // suppressed for B because per-child elapsed < intervalMs would
+    // have held the PREVIOUS tick at 2s (the buggy case). At exactly
+    // elapsed===intervalMs the line is allowed to emit; the test
+    // intentionally stops BEFORE that so the assertion is narrow.
+    // Accept either zero lines or a single B line at exactly 30s, but
+    // NEVER a line at < 30s.
+    for (const line of afterBLines) {
+      const match = /— (\d+)s$/.exec(line);
+      expect(match).not.toBeNull();
+      const secs = Number(match?.[1] ?? "0");
+      expect(secs).toBeGreaterThanOrEqual(30);
+    }
+
+    b.complete({ findings: 0 });
+    reporter.shutdown();
+  });
+
+  test("never emits a heartbeat for a child whose full phase is short", () => {
+    const { clock, scheduler } = makeStubClockAndScheduler();
+    const lines: string[] = [];
+    const reporter = createProgressReporter({
+      emit: (line) => lines.push(line),
+      quiet: false,
+      options: {
+        clock,
+        heartbeatIntervalMs: 30_000,
+        schedule: scheduler.schedule,
+      },
+    });
+
+    // Reviewer A runs 90s to establish the global interval cadence.
+    const a = reporter.beginReviewer("reviewer_a", "codex");
+    clock.advance(90_000);
+    a.complete({ findings: 0 });
+
+    // Start reviewer B at t=90s and let it run only 10s. The global
+    // interval's next tick is at 120s — which would occur after B
+    // completes at t=100s, so nothing to test there. Instead, start B
+    // at t=88s (2s before a tick) to replicate the reviewer's exact
+    // scenario. Adjust clock accordingly by rewinding the scenario.
+    // We simulate "88s before next tick" by starting B at an offset.
+    // Use a fresh reporter so intervals align predictably.
+    const lines2: string[] = [];
+    const { clock: clock2, scheduler: scheduler2 } =
+      makeStubClockAndScheduler();
+    const reporter2 = createProgressReporter({
+      emit: (line) => lines2.push(line),
+      quiet: false,
+      options: {
+        clock: clock2,
+        heartbeatIntervalMs: 30_000,
+        schedule: scheduler2.schedule,
+      },
+    });
+
+    // Long-running lead establishes the global 30/60/90/... cadence.
+    const lead = reporter2.beginLead("claude-opus-4-7");
+    clock2.advance(88_000); // t=88s; two heartbeats already fired at 30s, 60s
+
+    // Reviewer B starts 2s before the next global tick at 90s.
+    const b = reporter2.beginReviewer("reviewer_b", "claude");
+    clock2.advance(10_000); // advance to t=98s, CROSSING the 90s tick
+    b.complete({ findings: 0 });
+
+    const bHeartbeats = lines2.filter(
+      (l) => /reviewer B \(claude\) — \d+s$/.test(l),
+    );
+    // B ran for 10s total, < 30s intervalMs. No heartbeat must have
+    // fired for B. Under the old behaviour the 90s global tick would
+    // have emitted "reviewer B (claude) — 2s".
+    expect(bHeartbeats).toEqual([]);
+
+    lead.complete(undefined);
+    reporter2.shutdown();
+  });
+});

--- a/tests/cli/iterate-progress-heartbeat.test.ts
+++ b/tests/cli/iterate-progress-heartbeat.test.ts
@@ -112,53 +112,31 @@ describe("createProgressReporter — per-child heartbeat gating (#101)", () => {
       },
     });
 
-    // Reviewer A runs the full 90s window — heartbeats at 30s and 60s.
+    // Reviewer A runs 88s — heartbeats fire at 30s and 60s (not at 90s
+    // because we stop 2s short of that tick). This establishes the
+    // global 30/60/90/... interval cadence for the next assertion.
     const a = reporter.beginReviewer("reviewer_a", "codex");
-    clock.advance(90_000);
-    a.complete({ findings: 0 });
-
-    // Snapshot the heartbeat lines emitted so far; there should be two
-    // reviewer-A heartbeats (30s, 60s). We will assert B does not
-    // contribute to later lines at 2s elapsed.
-    const heartbeatLines = lines.filter((l) => /— \d+s$/.test(l));
-    expect(heartbeatLines).toEqual([
+    clock.advance(88_000);
+    const heartbeatLinesAfterA = lines.filter((l) => /— \d+s$/.test(l));
+    expect(heartbeatLinesAfterA).toEqual([
       "reviewer A (codex) — 30s",
       "reviewer A (codex) — 60s",
     ]);
 
-    // Clock is now at 90s. The global interval's next tick would be
-    // 120s (60 + 30). Reviewer B starts at 88s — 2s BEFORE the next
-    // global tick. Under the buggy behaviour the 90s tick fires a
-    // heartbeat for B at "2s". SPEC says "every ~30s of silent work",
-    // so the first B heartbeat must not fire until elapsedForB >= 30s.
-    clock.advance(-2_000 + 90_000 - clock.now()); // position clock at 88s? actually 90s is current
-    // Easier: advance nothing; start B now at 90s, then step 2s — no
-    // heartbeat expected because B's elapsed would be 2s.
+    // Reviewer B starts at t=88s — 2s before the next global tick at
+    // 90s. Under the buggy behaviour the 90s tick fires a heartbeat
+    // for B at "2s". SPEC says "every ~30s of silent work", so the
+    // first B heartbeat must NOT fire at elapsedForB < 30s.
     const b = reporter.beginReviewer("reviewer_b", "claude");
-    // Step past the 120s global tick boundary; B has only been running
-    // 2s since start at 90s — well under 30s.
-    clock.advance(30_000); // now at 120s, exactly one interval since last tick at 90s
-    // Fire any due schedule events.
-    scheduler.fireAll();
+    clock.advance(2_000); // cross the 90s global tick boundary
 
     const afterBLines = lines
-      .filter((l) => /— \d+s$/.test(l))
-      .slice(heartbeatLines.length);
-    // No reviewer-B heartbeat should be present yet — only 30s elapsed
-    // for B since its start; the global tick at this boundary must be
-    // suppressed for B because per-child elapsed < intervalMs would
-    // have held the PREVIOUS tick at 2s (the buggy case). At exactly
-    // elapsed===intervalMs the line is allowed to emit; the test
-    // intentionally stops BEFORE that so the assertion is narrow.
-    // Accept either zero lines or a single B line at exactly 30s, but
-    // NEVER a line at < 30s.
-    for (const line of afterBLines) {
-      const match = /— (\d+)s$/.exec(line);
-      expect(match).not.toBeNull();
-      const secs = Number(match?.[1] ?? "0");
-      expect(secs).toBeGreaterThanOrEqual(30);
-    }
+      .filter((l) => /reviewer B \(claude\) — \d+s$/.test(l));
+    // B has been running 2s. Emitting "reviewer B (claude) — 2s" here
+    // is the bug. The gate must suppress it.
+    expect(afterBLines).toEqual([]);
 
+    a.complete({ findings: 0 });
     b.complete({ findings: 0 });
     reporter.shutdown();
   });

--- a/tests/cli/iterate-progress-wrap.test.ts
+++ b/tests/cli/iterate-progress-wrap.test.ts
@@ -1,0 +1,245 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Issue #101 reviewer follow-up — `wrapAdaptersForProgress` must not
+ * drop the adapter's class prototype.
+ *
+ * The original implementation used object-spread (`{...adapters.lead,
+ * revise: ...}`) to layer on the progress-aware `revise` / `critique`
+ * hooks. On a real `class X implements Adapter` instance this silently
+ * drops every prototype method — `vendor` (own property) survives but
+ * `detect()`, `auth_status()`, `models()`, `ask()`, `supports_*` etc.
+ * disappear. Today the loop only calls `revise` + `critique` so the bug
+ * is latent; any future caller hitting another method would crash with
+ * no compile-time warning because the wrapper still satisfies the
+ * Adapter type structurally.
+ *
+ * The fix must preserve the class prototype AND satisfy `Adapter`
+ * cleanly. These tests pin down the expectation so the object-spread
+ * trap can never come back.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  AuthStatus,
+  CritiqueInput,
+  CritiqueOutput,
+  DetectResult,
+  EffortLevel,
+  ModelInfo,
+  ReviseInput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { wrapAdaptersForProgress } from "../../src/cli/iterate.ts";
+import type { ProgressReporter } from "../../src/cli/iterate-progress.ts";
+import type { State } from "../../src/state/types.ts";
+
+class FakeClassAdapter implements Adapter {
+  readonly vendor: string;
+
+  constructor(vendor: string) {
+    this.vendor = vendor;
+  }
+
+  detect(): Promise<DetectResult> {
+    return Promise.resolve({ installed: true, version: "x", path: "/x" });
+  }
+
+  auth_status(): Promise<AuthStatus> {
+    return Promise.resolve({ authenticated: true });
+  }
+
+  supports_structured_output(): boolean {
+    return true;
+  }
+
+  supports_effort(_level: EffortLevel): boolean {
+    return true;
+  }
+
+  models(): Promise<readonly ModelInfo[]> {
+    return Promise.resolve([{ id: `${this.vendor}-max`, family: this.vendor }]);
+  }
+
+  ask(_input: AskInput): Promise<AskOutput> {
+    return Promise.resolve({
+      answer: "ok",
+      usage: null,
+      effort_used: "max",
+    });
+  }
+
+  critique(_input: CritiqueInput): Promise<CritiqueOutput> {
+    return Promise.resolve({
+      findings: [],
+      summary: "",
+      suggested_next_version: "0.2",
+      usage: null,
+      effort_used: "max",
+    });
+  }
+
+  revise(_input: ReviseInput): Promise<ReviseOutput> {
+    return Promise.resolve({
+      spec: "# SPEC\n\nrevised\n",
+      ready: true,
+      rationale: "[]",
+      usage: null,
+      effort_used: "max",
+    });
+  }
+
+  /**
+   * Prototype method that is NOT part of the Adapter interface — used
+   * as a probe for "did the wrapper drop my prototype methods?". A
+   * real adapter may add helpers like this (internal cache hooks,
+   * doctor() probes, etc.) and downstream callers that cast back to
+   * the concrete class must continue to see them after wrapping.
+   */
+  customProtoHelper(): string {
+    return `custom:${this.vendor}`;
+  }
+}
+
+const NOOP_PROGRESS: ProgressReporter = {
+  roundStart: () => undefined,
+  beginReviewer: () => ({
+    complete: () => undefined,
+    abort: () => undefined,
+  }),
+  beginLead: () => ({
+    complete: () => undefined,
+    abort: () => undefined,
+  }),
+  shutdown: () => undefined,
+};
+
+function seedState(): State {
+  return {
+    slug: "refunds",
+    phase: "review_loop",
+    round_index: 0,
+    version: "0.1.0",
+    persona: { skill: "refunds", accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: "2026-04-19T12:00:00Z",
+    updated_at: "2026-04-19T12:00:00Z",
+  };
+}
+
+describe("wrapAdaptersForProgress — preserves class prototype (#101)", () => {
+  test("wrapped adapters still satisfy instanceof of the original class", () => {
+    const lead = new FakeClassAdapter("claude");
+    const revA = new FakeClassAdapter("codex");
+    const revB = new FakeClassAdapter("claude");
+
+    const wrapped = wrapAdaptersForProgress(
+      { lead, reviewerA: revA, reviewerB: revB },
+      seedState(),
+      NOOP_PROGRESS,
+    );
+
+    expect(wrapped.lead).toBeInstanceOf(FakeClassAdapter);
+    expect(wrapped.reviewerA).toBeInstanceOf(FakeClassAdapter);
+    expect(wrapped.reviewerB).toBeInstanceOf(FakeClassAdapter);
+  });
+
+  test("wrapped adapters retain prototype methods (detect / models / ask)", async () => {
+    const lead = new FakeClassAdapter("claude");
+    const revA = new FakeClassAdapter("codex");
+    const revB = new FakeClassAdapter("claude");
+
+    const wrapped = wrapAdaptersForProgress(
+      { lead, reviewerA: revA, reviewerB: revB },
+      seedState(),
+      NOOP_PROGRESS,
+    );
+
+    // Prototype methods must be callable on the wrapped value. The
+    // object-spread implementation silently drops these because
+    // prototype methods are non-enumerable own properties of the
+    // prototype, not of the instance.
+    expect(await wrapped.lead.detect()).toEqual({
+      installed: true,
+      version: "x",
+      path: "/x",
+    });
+    expect(await wrapped.reviewerA.models()).toEqual([
+      { id: "codex-max", family: "codex" },
+    ]);
+    expect(wrapped.reviewerB.supports_structured_output()).toBe(true);
+
+    // Custom prototype methods must survive too so downstream code
+    // that casts wrapped back to the concrete class keeps working.
+    expect(
+      (wrapped.lead as unknown as FakeClassAdapter).customProtoHelper(),
+    ).toBe("custom:claude");
+  });
+
+  test("wrapped adapters still intercept critique/revise with progress hooks", async () => {
+    const lead = new FakeClassAdapter("claude");
+    const revA = new FakeClassAdapter("codex");
+    const revB = new FakeClassAdapter("claude");
+
+    const callLog: string[] = [];
+    const progress: ProgressReporter = {
+      roundStart: () => undefined,
+      beginReviewer: (seat) => {
+        callLog.push(`begin:${seat}`);
+        return {
+          complete: () => callLog.push(`complete:${seat}`),
+          abort: () => callLog.push(`abort:${seat}`),
+        };
+      },
+      beginLead: () => {
+        callLog.push("begin:lead");
+        return {
+          complete: () => callLog.push("complete:lead"),
+          abort: () => callLog.push("abort:lead"),
+        };
+      },
+      shutdown: () => undefined,
+    };
+
+    const wrapped = wrapAdaptersForProgress(
+      { lead, reviewerA: revA, reviewerB: revB },
+      seedState(),
+      progress,
+    );
+
+    const critiqueInput: CritiqueInput = {
+      spec: "# SPEC\n\nseed\n",
+      guidelines: "",
+      opts: { effort: "max", timeout: 1_000 },
+    };
+    const reviseInput: ReviseInput = {
+      spec: "# SPEC\n\nseed\n",
+      reviews: [],
+      decisions_history: [],
+      opts: { effort: "max", timeout: 1_000 },
+    };
+
+    await wrapped.reviewerA.critique(critiqueInput);
+    await wrapped.reviewerB.critique(critiqueInput);
+    await wrapped.lead.revise(reviseInput);
+
+    expect(callLog).toEqual([
+      "begin:reviewer_a",
+      "complete:reviewer_a",
+      "begin:reviewer_b",
+      "complete:reviewer_b",
+      "begin:lead",
+      "complete:lead",
+    ]);
+  });
+});

--- a/tests/cli/iterate-progress.test.ts
+++ b/tests/cli/iterate-progress.test.ts
@@ -241,9 +241,7 @@ function slowAdapter(
   reviseOut: ReviseOutput,
   steps: StubScheduler,
 ): Adapter {
-  const waitUntil = (
-    startMs: number,
-  ): Promise<void> =>
+  const waitUntil = (startMs: number): Promise<void> =>
     new Promise((resolve) => {
       const poll = (): void => {
         if (clock.now() - startMs >= delayMs) {

--- a/tests/cli/iterate-progress.test.ts
+++ b/tests/cli/iterate-progress.test.ts
@@ -1,0 +1,454 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Issue #101 — `samospec iterate` must emit per-phase progress and a
+ * heartbeat to stderr while a round is running so operators can tell
+ * "working" from "hung". Stdout keeps its existing final-summary lines
+ * untouched (scripts parsing stdout must not break).
+ *
+ * The tests drive runIterate with a slow, deterministic stub clock + a
+ * stub scheduler that lets us manually "tick" time forward. No real
+ * wall-clock dependency.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type {
+  Adapter,
+  CritiqueInput,
+  CritiqueOutput,
+  ReviseInput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { runIterate, type IterateResolvers } from "../../src/cli/iterate.ts";
+import { writeState } from "../../src/state/store.ts";
+import type { State } from "../../src/state/types.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-iterate-progress-"));
+  initRepo(tmp);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function initRepo(cwd: string): void {
+  spawnSync("git", ["init", "-q"], { cwd });
+  spawnSync("git", ["config", "user.email", "test@example.com"], { cwd });
+  spawnSync("git", ["config", "user.name", "Test"], { cwd });
+  spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd });
+  spawnSync("git", ["checkout", "-q", "-b", "samospec/refunds"], { cwd });
+  writeFileSync(path.join(cwd, "README.md"), "seed\n", "utf8");
+  spawnSync("git", ["add", "README.md"], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "seed"], { cwd });
+}
+
+function seedSpec(cwd: string, slug: string): State {
+  const slugDir = path.join(cwd, ".samo", "spec", slug);
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(
+    path.join(slugDir, "SPEC.md"),
+    "# SPEC\n\ncontent v0.1\n",
+    "utf8",
+  );
+  writeFileSync(path.join(slugDir, "TLDR.md"), "# TLDR\n\n- old\n", "utf8");
+  writeFileSync(
+    path.join(slugDir, "decisions.md"),
+    "# decisions\n\n- No review-loop decisions yet.\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "changelog.md"),
+    "# changelog\n\n## v0.1 — seed\n\n- initial\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "interview.json"),
+    JSON.stringify({
+      slug,
+      persona: 'Veteran "refunds" expert',
+      generated_at: "2026-04-19T12:00:00Z",
+      questions: [],
+      answers: [],
+    }),
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "context.json"),
+    JSON.stringify({
+      phase: "draft",
+      files: [],
+      risk_flags: [],
+      budget: { phase: "draft", tokens_used: 0, tokens_budget: 0 },
+    }),
+    "utf8",
+  );
+  const state: State = {
+    slug,
+    phase: "review_loop",
+    round_index: 0,
+    version: "0.1.0",
+    persona: { skill: "refunds", accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: "2026-04-19T12:00:00Z",
+    updated_at: "2026-04-19T12:00:00Z",
+  };
+  writeState(path.join(slugDir, "state.json"), state);
+  spawnSync("git", ["add", "."], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "spec(refunds): draft v0.1"], {
+    cwd,
+  });
+  return state;
+}
+
+const ACCEPT_RESOLVERS: IterateResolvers = {
+  onManualEdit: () => Promise.resolve("incorporate"),
+  onDegraded: () => Promise.resolve("accept"),
+  onReviewerExhausted: () => Promise.resolve("abort"),
+};
+
+const DEFAULT_TIME_INPUTS = {
+  sessionStartedAtMs: 0,
+  nowMs: 0,
+  maxWallClockMs: 60 * 60 * 1000,
+};
+
+const SAMPLE_CRITIQUE: CritiqueOutput = {
+  findings: [
+    { category: "ambiguity", text: "ambiguous", severity: "minor" },
+    {
+      category: "missing-requirement",
+      text: "missing something",
+      severity: "major",
+    },
+  ],
+  summary: "two findings",
+  suggested_next_version: "0.2",
+  usage: null,
+  effort_used: "max",
+};
+
+const SAMPLE_REVISE: ReviseOutput = {
+  spec: "# SPEC\n\ncontent v0.2 revised\n",
+  ready: true,
+  rationale: "[]",
+  usage: null,
+  effort_used: "max",
+};
+
+/**
+ * Deterministic clock + scheduler pair so the runIterate progress test
+ * can drive "heartbeat fires after 30s" without real sleeps.
+ */
+interface StubClock {
+  now(): number;
+  advance(ms: number): void;
+}
+
+interface StubScheduler {
+  /**
+   * Start an interval. The implementation must call `cb` each time
+   * `clock.advance()` moves past the next multiple of `intervalMs`.
+   * Returns a cancel handle.
+   */
+  schedule(cb: () => void, intervalMs: number): { cancel: () => void };
+  tick(): void;
+}
+
+function makeStubClockAndScheduler(): {
+  clock: StubClock;
+  scheduler: StubScheduler;
+} {
+  let nowMs = 0;
+  interface Entry {
+    cb: () => void;
+    intervalMs: number;
+    nextFireAt: number;
+    cancelled: boolean;
+  }
+  const entries: Entry[] = [];
+  const clock: StubClock = {
+    now: () => nowMs,
+    advance: (ms: number) => {
+      const target = nowMs + ms;
+      // Fire each scheduled callback for every interval boundary we cross.
+      // Loop until the active entries are all past the target.
+      while (true) {
+        const live = entries.filter((e) => !e.cancelled);
+        if (live.length === 0) break;
+        const next = live
+          .map((e) => e.nextFireAt)
+          .reduce((a, b) => (a < b ? a : b));
+        if (next > target) break;
+        nowMs = next;
+        for (const e of entries) {
+          if (!e.cancelled && e.nextFireAt === next) {
+            e.cb();
+            e.nextFireAt += e.intervalMs;
+          }
+        }
+      }
+      nowMs = target;
+    },
+  };
+  const scheduler: StubScheduler = {
+    schedule(cb, intervalMs) {
+      const entry: Entry = {
+        cb,
+        intervalMs,
+        nextFireAt: nowMs + intervalMs,
+        cancelled: false,
+      };
+      entries.push(entry);
+      return {
+        cancel: () => {
+          entry.cancelled = true;
+        },
+      };
+    },
+    tick() {
+      // Convenience helper — advance by zero, flush anything pending.
+      clock.advance(0);
+    },
+  };
+  return { clock, scheduler };
+}
+
+/**
+ * Build a slow adapter whose `critique` / `revise` resolve only after
+ * the stub clock advances past `delayMs`. We do this with a polling
+ * setTimeout on the microtask queue so the scheduler's heartbeat can
+ * fire during the wait.
+ */
+function slowAdapter(
+  vendor: string,
+  delayMs: number,
+  clock: StubClock,
+  critiqueOut: CritiqueOutput,
+  reviseOut: ReviseOutput,
+  steps: StubScheduler,
+): Adapter {
+  const waitUntil = (
+    startMs: number,
+  ): Promise<void> =>
+    new Promise((resolve) => {
+      const poll = (): void => {
+        if (clock.now() - startMs >= delayMs) {
+          resolve();
+          return;
+        }
+        // Yield to the test so it can advance the clock.
+        setImmediate(poll);
+      };
+      poll();
+    });
+  return {
+    vendor,
+    detect: () =>
+      Promise.resolve({ installed: true, version: "x", path: "/x" }),
+    auth_status: () => Promise.resolve({ authenticated: true }),
+    supports_structured_output: () => true,
+    supports_effort: () => true,
+    models: () => Promise.resolve([{ id: `${vendor}-max`, family: vendor }]),
+    ask: () => Promise.reject(new Error("unused")),
+    critique: async (_input: CritiqueInput) => {
+      const startedAt = clock.now();
+      await waitUntil(startedAt);
+      steps.tick();
+      return critiqueOut;
+    },
+    revise: async (_input: ReviseInput) => {
+      const startedAt = clock.now();
+      await waitUntil(startedAt);
+      steps.tick();
+      return reviseOut;
+    },
+  };
+}
+
+/**
+ * Drive the stub clock forward while `runIterate` is awaiting adapter
+ * calls. Runs concurrently with the runIterate promise so the test
+ * can advance simulated time without blocking on real wall-clock.
+ */
+async function driveClock(
+  clock: StubClock,
+  scheduler: StubScheduler,
+  totalMs: number,
+  stepMs: number,
+): Promise<void> {
+  let advanced = 0;
+  while (advanced < totalMs) {
+    // Let any outstanding microtasks run so the slow-adapter poll can
+    // check the clock between advances.
+    await new Promise((r) => setImmediate(r));
+    clock.advance(stepMs);
+    scheduler.tick();
+    advanced += stepMs;
+  }
+}
+
+describe("cli/iterate — progress + heartbeat (#101)", () => {
+  test("emits round-start, per-phase, heartbeat on stderr; stdout unchanged", async () => {
+    const slug = "refunds";
+    seedSpec(tmp, slug);
+
+    const { clock, scheduler } = makeStubClockAndScheduler();
+
+    // Each phase takes 90s of fake time. Heartbeat = 30s. So each phase
+    // should trigger at least 2 heartbeat firings.
+    const PHASE_MS = 90_000;
+    const lead = slowAdapter(
+      "claude",
+      PHASE_MS,
+      clock,
+      SAMPLE_CRITIQUE,
+      SAMPLE_REVISE,
+      scheduler,
+    );
+    const revA = slowAdapter(
+      "codex",
+      PHASE_MS,
+      clock,
+      SAMPLE_CRITIQUE,
+      SAMPLE_REVISE,
+      scheduler,
+    );
+    const revB = slowAdapter(
+      "claude",
+      PHASE_MS,
+      clock,
+      SAMPLE_CRITIQUE,
+      SAMPLE_REVISE,
+      scheduler,
+    );
+
+    const iteratePromise = runIterate({
+      cwd: tmp,
+      slug,
+      now: "2026-04-19T12:00:00Z",
+      resolvers: ACCEPT_RESOLVERS,
+      adapters: { lead, reviewerA: revA, reviewerB: revB },
+      maxRounds: 1,
+      ...DEFAULT_TIME_INPUTS,
+      progress: {
+        clock: { now: () => clock.now() },
+        heartbeatIntervalMs: 30_000,
+        schedule: (cb, ms) => scheduler.schedule(cb, ms),
+      },
+    });
+
+    // Drive 600s of fake time in 1s steps — enough for both phases.
+    await driveClock(clock, scheduler, 600_000, 1_000);
+    const res = await iteratePromise;
+
+    expect(res.exitCode).toBe(0);
+
+    // --- stderr assertions ---
+    const err = res.stderr;
+
+    // (a) Round-start line.
+    expect(err).toContain("round 1 starting");
+
+    // (b) Per-phase start/complete lines with identity + duration.
+    // Reviewers A + B run in parallel.
+    expect(err).toMatch(/reviewer A \(codex\) starting/);
+    expect(err).toMatch(/reviewer A complete \(\d+s, \d+ findings\)/);
+    expect(err).toMatch(/reviewer B \(claude\) starting/);
+    expect(err).toMatch(/reviewer B complete \(\d+s, \d+ findings\)/);
+    expect(err).toMatch(/lead revise starting/);
+    expect(err).toMatch(/lead revise complete \(\d+s\)/);
+
+    // (c) At least one heartbeat line. Format: "<child> (<model>) — <N>s"
+    // The heartbeat must identify the active child.
+    expect(err).toMatch(/— \d+s$/m);
+
+    // (d) Stdout still carries the existing final-summary lines.
+    expect(res.stdout).toContain("committed spec(refunds)");
+    expect(res.stdout).toContain("next:");
+
+    // (e) Stdout NOT polluted with progress or heartbeat.
+    expect(res.stdout).not.toContain("round 1 starting");
+    expect(res.stdout).not.toMatch(/— \d+s/);
+    expect(res.stdout).not.toContain("reviewer A starting");
+    expect(res.stdout).not.toContain("lead revise starting");
+  });
+
+  test("--quiet suppresses progress + heartbeat; final summary still on stdout", async () => {
+    const slug = "refunds";
+    seedSpec(tmp, slug);
+
+    const { clock, scheduler } = makeStubClockAndScheduler();
+    const PHASE_MS = 90_000;
+    const lead = slowAdapter(
+      "claude",
+      PHASE_MS,
+      clock,
+      SAMPLE_CRITIQUE,
+      SAMPLE_REVISE,
+      scheduler,
+    );
+    const revA = slowAdapter(
+      "codex",
+      PHASE_MS,
+      clock,
+      SAMPLE_CRITIQUE,
+      SAMPLE_REVISE,
+      scheduler,
+    );
+    const revB = slowAdapter(
+      "claude",
+      PHASE_MS,
+      clock,
+      SAMPLE_CRITIQUE,
+      SAMPLE_REVISE,
+      scheduler,
+    );
+
+    const iteratePromise = runIterate({
+      cwd: tmp,
+      slug,
+      now: "2026-04-19T12:00:00Z",
+      resolvers: ACCEPT_RESOLVERS,
+      adapters: { lead, reviewerA: revA, reviewerB: revB },
+      maxRounds: 1,
+      quiet: true,
+      ...DEFAULT_TIME_INPUTS,
+      progress: {
+        clock: { now: () => clock.now() },
+        heartbeatIntervalMs: 30_000,
+        schedule: (cb, ms) => scheduler.schedule(cb, ms),
+      },
+    });
+
+    await driveClock(clock, scheduler, 600_000, 1_000);
+    const res = await iteratePromise;
+
+    expect(res.exitCode).toBe(0);
+
+    // No progress or heartbeat lines on either stream.
+    expect(res.stderr).not.toContain("round 1 starting");
+    expect(res.stderr).not.toContain("reviewer A (codex) starting");
+    expect(res.stderr).not.toContain("lead revise starting");
+    expect(res.stderr).not.toMatch(/— \d+s/);
+    expect(res.stdout).not.toContain("round 1 starting");
+    expect(res.stdout).not.toMatch(/— \d+s/);
+
+    // Final summary still on stdout.
+    expect(res.stdout).toContain("committed spec(refunds)");
+    expect(res.stdout).toContain("next:");
+  });
+});

--- a/tests/cli/iterate-progress.test.ts
+++ b/tests/cli/iterate-progress.test.ts
@@ -374,8 +374,18 @@ describe("cli/iterate — progress + heartbeat (#101)", () => {
     // The heartbeat must identify the active child.
     expect(err).toMatch(/— \d+s$/m);
 
-    // (d) Stdout still carries the existing final-summary lines.
+    // (d) Stdout still carries ALL three existing final-summary lines:
+    //     - `committed spec(...)` (refine commit notice)
+    //     - the stop-reason line (max-rounds here because
+    //       `maxRounds: 1` trips condition 1 before lead-ready)
+    //     - `next: ...` (next-action hint)
+    // Reviewer flagged that the middle line was previously unchecked so
+    // a regression emitting it to stderr would have slipped through
+    // the stdout-invariance guard.
     expect(res.stdout).toContain("committed spec(refunds)");
+    expect(res.stdout).toContain(
+      "samospec: max rounds reached. Review loop exited cleanly.",
+    );
     expect(res.stdout).toContain("next:");
 
     // (e) Stdout NOT polluted with progress or heartbeat.


### PR DESCRIPTION
Closes #101. Refs #93 item 6.

## Summary

- `samospec iterate` now emits a human-readable progress stream on **stderr** for every round: round-start, per-phase start/complete lines with adapter identity + duration, and a heartbeat line every ~30s of silent work that identifies the active child (e.g. `lead (claude-opus-4-7) — 180s`).
- Stdout is unchanged — the three existing final-summary lines (`committed spec(...)` / stop-reason / `next: ...`) stay intact so scripts parsing stdout don't break.
- New `--quiet` flag suppresses progress + heartbeat (final summary still lands on stdout).

## Why

The bug: a single `claude --print` call could block for 12+ minutes and the user had no way to tell `working` from `hung` without `ps`-ing child PIDs. Issue #101 asked for a visible progress + heartbeat on stderr so stdout parsers keep working.

## Implementation

- New `src/cli/iterate-progress.ts` defines `ProgressReporter` with:
  - Injectable **clock** (`now()`) and **scheduler** (`schedule(cb, ms)`) so the heartbeat is unit-testable without real wall-clock sleeps. Production wiring uses `performance.now()` and `setInterval` (unref'd, so a stray timer never holds the process alive past `iterate` exit).
  - `beginReviewer` / `beginLead` phase brackets: each returns a `{complete, abort}` handle so callers cleanly emit the completion line + leave the heartbeat tracker.
  - `quiet: true` short-circuits to a no-op reporter (zero timers scheduled).
- `runIterate` builds per-round adapter proxies that forward critique/revise transparently but emit start/complete + join the heartbeat tracker. `runRound`'s retry / partial-failure paths are untouched — proxies preserve error propagation.
- `--quiet` added to `samospec iterate` CLI parser + USAGE.

## Testability note

Red-first TDD (see commit `2060938`): the new test in `tests/cli/iterate-progress.test.ts` drives a stub clock + stub scheduler + slow adapter (each phase takes 90s of fake time). Test manually advances fake time in 1s steps and asserts:

- round-start on stderr
- per-phase start/complete with identity + duration
- at least one heartbeat line (>=30s granularity)
- stdout retains the final-summary lines
- stdout NOT polluted with progress or heartbeat
- `--quiet` suppresses progress + heartbeat while final summary still prints on stdout

No real wall-clock dependency — tests run in 0.23s.

## Stderr vs stdout contract

Progress + heartbeat: **stderr only.**
Final summary (`committed …`, stop-reason, `next: …`): **stdout, unchanged.**

This means `samospec iterate <slug> | jq` (when / if JSON stdout is added) keeps working. Operators can mute progress with `samospec iterate <slug> --quiet` or `samospec iterate <slug> 2>/dev/null`.

## Test plan

- [x] Red test fails before implementation (commit `2060938` — captured output: `Expected to contain: "round 1 starting" / Received: ""`).
- [x] Green test passes after implementation (2 pass, 24 expect() calls).
- [x] Full suite: `bun test` — 1359 pass / 0 fail.
- [x] `bunx tsc --noEmit` — clean.
- [x] `bun run lint` — clean.
- [x] `bun run format:check` — clean.
- [ ] Manual run on a non-trivial spec (requires a real `claude`/`codex` session, out of scope for this agent).

## Non-goals

- No changes to `state.json` schema.
- No changes to round commit contents.
- No change to existing stdout lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)