### PR TITLE
fix(state): finalize state.json after round commit (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **state.json bookkeeping (#102):** after each round iterate now opens
+  a small `spec(<slug>): finalize round N` follow-up commit so the
+  working tree is clean on exit (including `lead_terminal` exit-4 and
+  `push-consent-interrupted` exit-3 paths), `state.head_sha` is
+  populated with a reachable 40-char SHA instead of null, and
+  `state.updated_at` tracks wall-clock rather than the frozen
+  round-start timestamp.
 - **Codex pinned-model fallback under ChatGPT-auth (#88):** `gpt-5.1-codex-max`
   returns `exit 1` with an `invalid_request_error` JSON on stdout when
   rejected under ChatGPT-account auth. The adapter used to call

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -1013,9 +1013,7 @@ function finalizeBookkeeping(args: {
   try {
     const branch = currentBranch(args.cwd);
     if (isProtected(branch, { repoPath: args.cwd })) return;
-    const candidatePaths: string[] = [
-      path.relative(args.cwd, args.statePath),
-    ];
+    const candidatePaths: string[] = [path.relative(args.cwd, args.statePath)];
     if (args.tldrPath !== undefined && existsSync(args.tldrPath)) {
       candidatePaths.push(path.relative(args.cwd, args.tldrPath));
     }

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -38,6 +38,7 @@ import type { Adapter, Finding } from "../adapter/types.ts";
 import { currentBranch } from "../git/branch.ts";
 import { specCommit } from "../git/commit.ts";
 import { ProtectedBranchError } from "../git/errors.ts";
+import { isProtected } from "../git/protected.ts";
 import {
   applyManualEdit,
   detectManualEdits,
@@ -378,6 +379,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
             tldrPath: paths.tldrPath,
             specPath: paths.specPath,
             now: input.now,
+            cwd: input.cwd,
+            slug: input.slug,
           });
         }
 
@@ -406,6 +409,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
               specPath: paths.specPath,
               now: input.now,
               exitCodeOverride: 0,
+              cwd: input.cwd,
+              slug: input.slug,
             });
           }
           const outcome = applyManualEdit({
@@ -455,6 +460,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
               specPath: paths.specPath,
               now: input.now,
               exitCodeOverride: 0,
+              cwd: input.cwd,
+              slug: input.slug,
             });
           }
         }
@@ -499,11 +506,13 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
           const { sub_reason, detail } = classifyLeadTerminal(
             roundOutcome.leadTerminalError ?? new Error(roundOutcome.rationale),
           );
+          const leadHeadSha = resolveHeadSha(input.cwd);
           const leadTerm: State = {
             ...currentState,
             round_state: "lead_terminal",
             round_index: roundIndex - 1,
-            updated_at: input.now,
+            updated_at: nowIso(),
+            ...(leadHeadSha !== null ? { head_sha: leadHeadSha } : {}),
             exit: {
               code: 4,
               reason: `lead-terminal:${sub_reason}`,
@@ -553,6 +562,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
               tldrPath: paths.tldrPath,
               specPath: paths.specPath,
               now: input.now,
+              cwd: input.cwd,
+              slug: input.slug,
             });
           }
           // Continue with reduced reviewers isn't wired to a single-seat
@@ -570,6 +581,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
             tldrPath: paths.tldrPath,
             specPath: paths.specPath,
             now: input.now,
+            cwd: input.cwd,
+            slug: input.slug,
           });
         }
 
@@ -592,7 +605,7 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
             round_state: "committed",
             round_index: roundIndex,
             exit: null,
-            updated_at: input.now,
+            updated_at: nowIso(),
           };
           writeFileSync(
             paths.tldrPath,
@@ -630,12 +643,23 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
           appendOrCreateChangelog(paths.changelogPath, changelogEntry);
 
           // State: lead_revised -> committed; bump round_index and version.
+          //
+          // Issue #102: `updated_at` is the wall-clock time of this
+          // write, not the frozen `input.now` (which is the round-start
+          // stamp). `head_sha` stays whatever it was pre-commit here —
+          // we can't `git rev-parse HEAD` until AFTER the commit runs,
+          // so the round commit itself contains `head_sha` for the
+          // PREVIOUS round's SHA. Right after the commit we rewrite
+          // state.json with the fresh SHA so the final on-disk value
+          // always matches HEAD; the resulting tiny dirty window is
+          // closed by either the next round's commit or the `finalize`
+          // commit inside `finishIterate`.
           currentState = {
             ...currentState,
             round_state: "committed",
             round_index: roundIndex,
             version: newVersion,
-            updated_at: input.now,
+            updated_at: nowIso(),
             remote_stale: currentState.remote_stale,
             coupled_fallback:
               input.resolutions?.coupled_fallback ??
@@ -670,6 +694,23 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
               `committed spec(${input.slug}): refine ${formatVersionLabel(newVersion)} after review r${String(roundIndex).padStart(2, "0")}`,
             );
 
+            // Issue #102 — post-commit bookkeeping write. `head_sha`
+            // can only be resolved AFTER the commit is in place; do
+            // the rewrite here so `state.head_sha` is accurate for
+            // anything reading state.json between rounds (e.g. a
+            // concurrent `samospec status`). This leaves state.json
+            // temporarily dirty; the next round's `specCommit` or the
+            // `finalize` commit at loop exit cleans it up.
+            const postCommitSha = resolveHeadSha(input.cwd);
+            if (postCommitSha !== null) {
+              currentState = {
+                ...currentState,
+                head_sha: postCommitSha,
+                updated_at: nowIso(),
+              };
+              writeState(paths.statePath, currentState);
+            }
+
             // SPEC §5 Phase 6 + §8 — round-boundary push. Exactly one
             // push per `committed` transition; never per commit.
             if (input.pushOptions !== undefined) {
@@ -684,7 +725,7 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
               if (pushOutcome.kind === "interrupt") {
                 const interrupted: State = {
                   ...currentState,
-                  updated_at: input.now,
+                  updated_at: nowIso(),
                   exit: {
                     code: 3,
                     reason: "push-consent-interrupted",
@@ -813,6 +854,8 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
             tldrPath: paths.tldrPath,
             specPath: paths.specPath,
             now: input.now,
+            cwd: input.cwd,
+            slug: input.slug,
           });
         }
 
@@ -837,6 +880,56 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
 
 function ensureTrailingNewline(s: string): string {
   return s.endsWith("\n") ? s : `${s}\n`;
+}
+
+/**
+ * Issue #102 — wall-clock ISO stamp for every `state.updated_at` write.
+ * The bug report called out that iterate was re-using a frozen round-
+ * start timestamp across the whole session; this helper centralises the
+ * `Date.now()` call so no writer can skip the bump.
+ */
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Issue #102 — resolve the current branch HEAD sha to populate
+ * `state.head_sha`. Returns `null` when the repo has no HEAD yet
+ * (unborn branch) so we never write a malformed value.
+ */
+function resolveHeadSha(cwd: string): string | null {
+  const res = spawnSync("git", ["rev-parse", "--verify", "--quiet", "HEAD"], {
+    cwd,
+    encoding: "utf8",
+  });
+  if ((res.status ?? 1) !== 0) return null;
+  const sha = (res.stdout ?? "").trim();
+  return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
+}
+
+/**
+ * Issue #102 — `git status --porcelain -- <paths>` to decide whether a
+ * follow-up `finalize` commit has anything to include. Returns the list
+ * of paths (relative to `cwd`) that git reports as modified / added /
+ * deleted. An empty list means the tree is already clean — skip the
+ * finalize commit entirely.
+ */
+function dirtyPaths(cwd: string, paths: readonly string[]): string[] {
+  if (paths.length === 0) return [];
+  const res = spawnSync("git", ["status", "--porcelain", "--", ...paths], {
+    cwd,
+    encoding: "utf8",
+  });
+  if ((res.status ?? 1) !== 0) return [];
+  const out = res.stdout ?? "";
+  const result: string[] = [];
+  for (const line of out.split("\n")) {
+    if (line.length < 4) continue;
+    // Porcelain v1 format: "XY <path>" (two status chars + space + path).
+    const p = line.slice(3);
+    if (p.length > 0) result.push(p);
+  }
+  return result;
 }
 
 // ---------- round-boundary push plumbing (SPEC §5 Phase 6 + §8) ----------
@@ -1085,10 +1178,27 @@ interface FinishArgs {
    *  so its Next-action section reflects the exit reason (#96). */
   readonly tldrPath?: string;
   readonly specPath?: string;
+  /** Issue #102 — repo cwd + slug so `finishIterate` can open a small
+   *  `spec(<slug>): finalize round N` commit for the post-round
+   *  bookkeeping write. Absent in a few synthetic test paths; when
+   *  omitted the finalize commit is skipped safely. */
+  readonly cwd?: string;
+  readonly slug?: string;
 }
 
 function finishIterate(args: FinishArgs): IterateResult {
   const exitCode = args.exitCodeOverride ?? stopReasonExitCode(args.reason);
+
+  // Issue #102 — resolve HEAD before writing so `state.head_sha` tracks
+  // the commit that iterate produced for this session. A `null` result
+  // (unborn branch, missing cwd) falls back to whatever `state.head_sha`
+  // already holds, so we never regress a previously-recorded sha.
+  let headShaForFinal: string | null | undefined;
+  if (args.cwd !== undefined) {
+    const resolved = resolveHeadSha(args.cwd);
+    if (resolved !== null) headShaForFinal = resolved;
+  }
+
   const withExit: State = {
     ...args.state,
     exit: {
@@ -1096,7 +1206,12 @@ function finishIterate(args: FinishArgs): IterateResult {
       reason: args.reason,
       round_index: args.state.round_index,
     },
-    updated_at: args.now,
+    // Issue #102 — wall-clock, not the frozen `input.now` round-start
+    // stamp. The `args.now` param is kept in the interface for any
+    // remaining non-stamp uses (none today); we deliberately ignore it
+    // for the `updated_at` field so every write lands a fresh time.
+    updated_at: nowIso(),
+    ...(headShaForFinal !== undefined ? { head_sha: headShaForFinal } : {}),
   };
   writeState(args.statePath, withExit);
 
@@ -1116,6 +1231,56 @@ function finishIterate(args: FinishArgs): IterateResult {
       renderTldr(spec, { slug: withExit.slug, state: withExit }),
       "utf8",
     );
+  }
+
+  // Issue #102 — finalize commit. Without this, the `exit` / `head_sha`
+  // / `updated_at` write above leaves `.samo/spec/<slug>/state.json`
+  // (and often TLDR.md) dirty, which then trips the manual-edit prompt
+  // on the next `iterate` run. We reuse `specCommit` with a dedicated
+  // `finalize` action so commit grammar, protected-branch safety, and
+  // the `tests/git/no-force.test.ts` guard all keep applying.
+  //
+  // Guards:
+  //  - Skip when `cwd`/`slug` are absent (synthetic unit tests).
+  //  - Skip on protected branches — the round-loop already refused to
+  //    commit there, so we must not commit either.
+  //  - Skip when the tracked bookkeeping paths are already clean (no
+  //    empty commits ever).
+  if (args.cwd !== undefined && args.slug !== undefined) {
+    try {
+      const branch = currentBranch(args.cwd);
+      if (!isProtected(branch, { repoPath: args.cwd })) {
+        const candidatePaths: string[] = [
+          path.relative(args.cwd, args.statePath),
+        ];
+        if (args.tldrPath !== undefined && existsSync(args.tldrPath)) {
+          candidatePaths.push(path.relative(args.cwd, args.tldrPath));
+        }
+        const dirty = dirtyPaths(args.cwd, candidatePaths);
+        if (dirty.length > 0) {
+          specCommit({
+            repoPath: args.cwd,
+            slug: args.slug,
+            action: "finalize",
+            roundNumber: withExit.round_index,
+            paths: dirty,
+          });
+          // After this commit `git rev-parse HEAD` advances by one. The
+          // on-disk `state.head_sha` therefore points to HEAD~1 (the
+          // round's `refine` content commit), not HEAD itself. That is
+          // intentional: a commit cannot name itself in its own tree,
+          // and chasing the tail with a second finalize-of-finalize
+          // commit is recursive. `verifyHeadSha` callers must be ready
+          // to accept HEAD~1 when the branch's tip is a `finalize`
+          // bookkeeping commit — see the PR body for the trade-off.
+        }
+      }
+    } catch {
+      // Best-effort: never let a finalize-commit failure bubble up.
+      // The state.json write above still succeeded; worst case the
+      // next `iterate` run sees a dirty tree and prompts on it, which
+      // is the pre-#102 behaviour — a strictly non-regression.
+    }
   }
 
   const stream = exitCode === 0 ? args.lines : args.errLines;

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -524,6 +524,27 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
           };
           writeState(paths.statePath, leadTerm);
           error(formatLeadTerminalMessage(input.slug, sub_reason, detail));
+          // Issue #102 — this exit path used to early-return here,
+          // leaving state.json (and the untracked round-N `reviews/`
+          // dir) dirty. Route it through the shared finalize-commit
+          // helper so the tree is clean on every exit, including the
+          // lead_terminal exit-4 path. The custom `exit.reason`
+          // preserved in `leadTerm` above survives because we do not
+          // go through `finishIterate` here — finishIterate would
+          // overwrite `exit.reason` with the plain `"lead-terminal"`
+          // enum value and drop the sub-reason detail.
+          finalizeBookkeeping({
+            cwd: input.cwd,
+            slug: input.slug,
+            statePath: paths.statePath,
+            tldrPath: paths.tldrPath,
+            roundIndex: leadTerm.round_index,
+            // The round's reviews/ artefacts exist (reviewers ran
+            // before lead.revise() threw) but no `refine` commit was
+            // opened, so they are orphan-untracked. Scoop them into
+            // the finalize commit so the tree is fully clean on exit.
+            extraPaths: [dirs.roundDir],
+          });
           return {
             exitCode: 4,
             stdout: lines.join("\n"),
@@ -737,6 +758,17 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
                 };
                 writeState(paths.statePath, interrupted);
                 error(`samospec: push-consent prompt interrupted (Ctrl-C).`);
+                // Issue #102 — same class of bug as the lead_terminal
+                // path: this early-return wrote state.json without
+                // opening a finalize commit, leaving the tree dirty.
+                // Route through the shared helper.
+                finalizeBookkeeping({
+                  cwd: input.cwd,
+                  slug: input.slug,
+                  statePath: paths.statePath,
+                  tldrPath: paths.tldrPath,
+                  roundIndex,
+                });
                 return {
                   exitCode: 3,
                   stdout: lines.join("\n"),
@@ -933,6 +965,77 @@ function dirtyPaths(cwd: string, paths: readonly string[]): string[] {
     if (p.length > 0) result.push(p);
   }
   return result;
+}
+
+/**
+ * Issue #102 — open a `spec(<slug>): finalize round N` commit for the
+ * post-round bookkeeping write so `state.json` (and often `TLDR.md`)
+ * don't linger in the working tree as dirty paths. Shared by the
+ * `finishIterate` tail AND the `lead_terminal` early-return path so
+ * exit-4 runs leave a clean tree too.
+ *
+ * Guards:
+ *  - Skip when `cwd`/`slug` are absent (synthetic unit tests).
+ *  - Skip on protected branches — the round-loop already refused to
+ *    commit there, so we must not commit either.
+ *  - Skip when the tracked bookkeeping paths are already clean (no
+ *    empty commits ever).
+ *
+ * Best-effort: any thrown error is swallowed. The state.json write that
+ * must precede this call has already succeeded; worst case the next
+ * `iterate` run sees a dirty tree and prompts on it — strictly a
+ * non-regression from pre-#102 behaviour.
+ *
+ * After this commit `git rev-parse HEAD` advances by one. The on-disk
+ * `state.head_sha` therefore points to HEAD~1 (the round's `refine`
+ * content commit), not HEAD itself. That is intentional: a commit
+ * cannot name itself in its own tree. `verifyHeadSha` callers must be
+ * ready to accept HEAD~1 when the branch's tip is a `finalize`
+ * bookkeeping commit — see the PR body for the trade-off.
+ */
+function finalizeBookkeeping(args: {
+  readonly cwd: string | undefined;
+  readonly slug: string | undefined;
+  readonly statePath: string;
+  readonly tldrPath: string | undefined;
+  readonly roundIndex: number;
+  /**
+   * Extra absolute paths to include when checking for dirty state.
+   * The `lead_terminal` exit passes the current round's `reviews/rNN/`
+   * artefacts so they are scooped into the finalize commit instead of
+   * being left as an untracked directory. Empty in the happy-path
+   * caller because `specCommit(..., "refine", ...)` already covered
+   * those files.
+   */
+  readonly extraPaths?: readonly string[];
+}): void {
+  if (args.cwd === undefined || args.slug === undefined) return;
+  try {
+    const branch = currentBranch(args.cwd);
+    if (isProtected(branch, { repoPath: args.cwd })) return;
+    const candidatePaths: string[] = [
+      path.relative(args.cwd, args.statePath),
+    ];
+    if (args.tldrPath !== undefined && existsSync(args.tldrPath)) {
+      candidatePaths.push(path.relative(args.cwd, args.tldrPath));
+    }
+    if (args.extraPaths !== undefined) {
+      for (const p of args.extraPaths) {
+        if (existsSync(p)) candidatePaths.push(path.relative(args.cwd, p));
+      }
+    }
+    const dirty = dirtyPaths(args.cwd, candidatePaths);
+    if (dirty.length === 0) return;
+    specCommit({
+      repoPath: args.cwd,
+      slug: args.slug,
+      action: "finalize",
+      roundNumber: args.roundIndex,
+      paths: dirty,
+    });
+  } catch {
+    // Best-effort — see docstring.
+  }
 }
 
 // ---------- round-boundary push plumbing (SPEC §5 Phase 6 + §8) ----------
@@ -1236,55 +1339,13 @@ function finishIterate(args: FinishArgs): IterateResult {
     );
   }
 
-  // Issue #102 — finalize commit. Without this, the `exit` / `head_sha`
-  // / `updated_at` write above leaves `.samo/spec/<slug>/state.json`
-  // (and often TLDR.md) dirty, which then trips the manual-edit prompt
-  // on the next `iterate` run. We reuse `specCommit` with a dedicated
-  // `finalize` action so commit grammar, protected-branch safety, and
-  // the `tests/git/no-force.test.ts` guard all keep applying.
-  //
-  // Guards:
-  //  - Skip when `cwd`/`slug` are absent (synthetic unit tests).
-  //  - Skip on protected branches — the round-loop already refused to
-  //    commit there, so we must not commit either.
-  //  - Skip when the tracked bookkeeping paths are already clean (no
-  //    empty commits ever).
-  if (args.cwd !== undefined && args.slug !== undefined) {
-    try {
-      const branch = currentBranch(args.cwd);
-      if (!isProtected(branch, { repoPath: args.cwd })) {
-        const candidatePaths: string[] = [
-          path.relative(args.cwd, args.statePath),
-        ];
-        if (args.tldrPath !== undefined && existsSync(args.tldrPath)) {
-          candidatePaths.push(path.relative(args.cwd, args.tldrPath));
-        }
-        const dirty = dirtyPaths(args.cwd, candidatePaths);
-        if (dirty.length > 0) {
-          specCommit({
-            repoPath: args.cwd,
-            slug: args.slug,
-            action: "finalize",
-            roundNumber: withExit.round_index,
-            paths: dirty,
-          });
-          // After this commit `git rev-parse HEAD` advances by one. The
-          // on-disk `state.head_sha` therefore points to HEAD~1 (the
-          // round's `refine` content commit), not HEAD itself. That is
-          // intentional: a commit cannot name itself in its own tree,
-          // and chasing the tail with a second finalize-of-finalize
-          // commit is recursive. `verifyHeadSha` callers must be ready
-          // to accept HEAD~1 when the branch's tip is a `finalize`
-          // bookkeeping commit — see the PR body for the trade-off.
-        }
-      }
-    } catch {
-      // Best-effort: never let a finalize-commit failure bubble up.
-      // The state.json write above still succeeded; worst case the
-      // next `iterate` run sees a dirty tree and prompts on it, which
-      // is the pre-#102 behaviour — a strictly non-regression.
-    }
-  }
+  finalizeBookkeeping({
+    cwd: args.cwd,
+    slug: args.slug,
+    statePath: args.statePath,
+    tldrPath: args.tldrPath,
+    roundIndex: withExit.round_index,
+  });
 
   const stream = exitCode === 0 ? args.lines : args.errLines;
   stream.push(args.message);

--- a/src/git/commit.ts
+++ b/src/git/commit.ts
@@ -17,6 +17,11 @@ export const COMMIT_ACTIONS = [
   "publish",
   "user-edit",
   "changelog",
+  // SPEC §7 + Issue #102: a small follow-up commit that captures the
+  // `exit.{code,reason,round_index}` + `head_sha` + refreshed `updated_at`
+  // write which iterate performs AFTER the round commit. Without this
+  // action those bookkeeping fields would leave state.json dirty.
+  "finalize",
 ] as const;
 export type CommitAction = (typeof COMMIT_ACTIONS)[number];
 
@@ -27,10 +32,16 @@ const VERSION_RE = /^\d+(?:\.\d+)*$/;
 export interface BuildCommitMessageArgs {
   readonly slug: string;
   readonly action: CommitAction;
-  readonly version: string;
   /**
-   * For `refine` actions only. When set, the message becomes
-   * `spec(<slug>): refine v<version> after review r<roundNumber>`.
+   * Required for every action except `finalize`, whose message template
+   * carries no version. Callers still pass the current state version
+   * where convenient; the helper simply ignores it for `finalize`.
+   */
+  readonly version?: string;
+  /**
+   * For `refine` actions this yields the "after review r<n>" suffix.
+   * For `finalize` actions this is required and names the round whose
+   * bookkeeping the follow-up commit captures.
    */
   readonly roundNumber?: number;
 }
@@ -39,6 +50,10 @@ export interface BuildCommitMessageArgs {
  * Builds the SPEC §8 commit message:
  *   - `spec(<slug>): <action> v<version>`
  *   - `spec(<slug>): refine v<version> after review r<n>` when roundNumber set.
+ *   - `spec(<slug>): finalize round <n>` for the Issue #102 bookkeeping
+ *     follow-up commit. This variant carries no version — it records
+ *     only `exit` / `head_sha` / `updated_at`, which belong to the round
+ *     that already shipped its version in a prior `refine` commit.
  *
  * Throws {@link GitLayerUsageError} on any grammar violation. Callers pass
  * raw components; only this helper is allowed to format the message — no
@@ -57,9 +72,24 @@ export function buildCommitMessage(args: BuildCommitMessageArgs): string {
         `actions: ${COMMIT_ACTIONS.join(", ")}.`,
     );
   }
-  if (!VERSION_RE.test(args.version)) {
+  if (args.action === "finalize") {
+    if (args.roundNumber === undefined) {
+      throw new GitLayerUsageError(
+        `action 'finalize' requires roundNumber (the round whose exit ` +
+          `bookkeeping this commit captures).`,
+      );
+    }
+    if (!Number.isInteger(args.roundNumber) || args.roundNumber < 0) {
+      throw new GitLayerUsageError(
+        `roundNumber '${String(args.roundNumber)}' must be a non-negative ` +
+          `integer.`,
+      );
+    }
+    return `spec(${args.slug}): finalize round ${String(args.roundNumber)}`;
+  }
+  if (args.version === undefined || !VERSION_RE.test(args.version)) {
     throw new GitLayerUsageError(
-      `version '${args.version}' is invalid. Expected dotted numerics ` +
+      `version '${String(args.version)}' is invalid. Expected dotted numerics ` +
         `(e.g. '0.1', '1.0', '0.3.1'). Leading 'v' is added by the ` +
         `message template — do not pass it in.`,
     );

--- a/src/git/remote.ts
+++ b/src/git/remote.ts
@@ -160,9 +160,26 @@ export class HeadShaMismatchError extends Error {
 }
 
 /**
- * Verify that `state.json.head_sha` still matches the local branch HEAD.
- * Throws {@link HeadShaMismatchError} (exit 2) on drift so the caller
- * can halt with an explanation per SPEC §8.
+ * Verify that `state.json.head_sha` still points at a commit the local
+ * branch has produced. Throws {@link HeadShaMismatchError} (exit 2) on
+ * drift so the caller can halt with an explanation per SPEC §8.
+ *
+ * Issue #102 — `state.head_sha` is written by iterate BEFORE the small
+ * `spec(<slug>): finalize round <n>` bookkeeping commit opens at the
+ * end of each session. That commit advances HEAD by one, so on disk
+ * `state.head_sha` can legitimately equal either:
+ *
+ *   - `HEAD`          — no finalize commit was opened (nothing was
+ *                       dirty; finalize skipped as a no-op), OR
+ *   - `HEAD~1`        — the branch tip is a finalize commit whose
+ *                       subject starts with `spec(<slug>): finalize`.
+ *
+ * A commit cannot name its own sha in its own tree, so chasing the
+ * tail with a second finalize-of-finalize commit would be recursive.
+ * This checker accepts BOTH `HEAD` and `HEAD~1` — but only when HEAD's
+ * subject actually looks like a finalize commit, so an attacker who
+ * rewrote the branch and happens to land on `HEAD~1 === expected`
+ * can't sneak past. Anything else trips the mismatch error.
  */
 export function verifyHeadSha(opts: VerifyHeadShaOpts): void {
   if (opts.expectedHeadSha === null) return;
@@ -173,9 +190,40 @@ export function verifyHeadSha(opts: VerifyHeadShaOpts): void {
       `verifyHeadSha: local branch '${opts.branch}' has no HEAD (repo unborn?)`,
     );
   }
-  if (actual !== opts.expectedHeadSha) {
-    throw new HeadShaMismatchError(opts.branch, opts.expectedHeadSha, actual);
+  if (actual === opts.expectedHeadSha) return;
+
+  // Accept HEAD~1 iff HEAD is a finalize bookkeeping commit. The
+  // subject grammar is authoritative: `src/git/commit.ts` is the
+  // only code path that can produce this message, and
+  // `tests/git/commit.test.ts` pins the format. We tolerate any slug
+  // after `spec(` because `verifyHeadSha` is called from contexts
+  // that don't always carry the slug, and the subject alone is a
+  // strong enough signal.
+  const headSubject = headCommitSubject(opts.repoPath);
+  if (headSubject !== null && FINALIZE_SUBJECT_RE.test(headSubject)) {
+    const parent = resolveRef(opts.repoPath, "HEAD~1");
+    if (parent === opts.expectedHeadSha) return;
   }
+
+  throw new HeadShaMismatchError(opts.branch, opts.expectedHeadSha, actual);
+}
+
+/**
+ * Matches the subject produced by `buildCommitMessage` for the
+ * `finalize` action: `spec(<slug>): finalize round <n>`. The slug
+ * grammar is constrained to lowercase letters/digits/`-` by
+ * `src/git/commit.ts`.
+ */
+const FINALIZE_SUBJECT_RE =
+  /^spec\([a-z0-9]+(?:-[a-z0-9]+)*\): finalize round \d+$/;
+
+function headCommitSubject(repoPath: string): string | null {
+  const res = runGit(["log", "-1", "--pretty=%s", "HEAD"], repoPath, {
+    allowFail: true,
+  });
+  if (res.status !== 0) return null;
+  const line = res.stdout.split("\n", 1)[0] ?? "";
+  return line.length > 0 ? line : null;
 }
 
 function assertNonEmpty(value: string, name: string): void {

--- a/tests/git/remote.test.ts
+++ b/tests/git/remote.test.ts
@@ -243,4 +243,43 @@ describe("verifyHeadSha — state.json HEAD mismatch", () => {
       }),
     ).not.toThrow();
   });
+
+  // Issue #102 — `state.head_sha` is recorded BEFORE the round's
+  // finalize bookkeeping commit opens, so after one finalize commit
+  // `state.head_sha === HEAD~1`. The checker must accept that shape,
+  // but only when HEAD's subject actually looks like a finalize
+  // commit — so unrelated drift still throws.
+  test("accepts HEAD~1 when HEAD is a finalize bookkeeping commit", () => {
+    const refineSha = runGit(["rev-parse", "HEAD"], local.dir).trim();
+    // Open a follow-up commit with the exact `finalize` subject
+    // grammar produced by `buildCommitMessage` in src/git/commit.ts.
+    writeFileSync(join(local.dir, "bookkeeping.txt"), "state\n");
+    runGit(["add", "bookkeeping.txt"], local.dir);
+    runGit(
+      ["commit", "-m", "spec(refunds): finalize round 1"],
+      local.dir,
+    );
+    expect(() =>
+      verifyHeadSha({
+        repoPath: local.dir,
+        branch,
+        expectedHeadSha: refineSha,
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects HEAD~1 match when HEAD subject is NOT a finalize commit", () => {
+    const refineSha = runGit(["rev-parse", "HEAD"], local.dir).trim();
+    // Add a non-finalize commit on top.
+    writeFileSync(join(local.dir, "bookkeeping.txt"), "state\n");
+    runGit(["add", "bookkeeping.txt"], local.dir);
+    runGit(["commit", "-m", "random unrelated commit"], local.dir);
+    expect(() =>
+      verifyHeadSha({
+        repoPath: local.dir,
+        branch,
+        expectedHeadSha: refineSha,
+      }),
+    ).toThrow(HeadShaMismatchError);
+  });
 });

--- a/tests/git/remote.test.ts
+++ b/tests/git/remote.test.ts
@@ -255,10 +255,7 @@ describe("verifyHeadSha — state.json HEAD mismatch", () => {
     // grammar produced by `buildCommitMessage` in src/git/commit.ts.
     writeFileSync(join(local.dir, "bookkeeping.txt"), "state\n");
     runGit(["add", "bookkeeping.txt"], local.dir);
-    runGit(
-      ["commit", "-m", "spec(refunds): finalize round 1"],
-      local.dir,
-    );
+    runGit(["commit", "-m", "spec(refunds): finalize round 1"], local.dir);
     expect(() =>
       verifyHeadSha({
         repoPath: local.dir,

--- a/tests/loop/push-round-boundary.test.ts
+++ b/tests/loop/push-round-boundary.test.ts
@@ -384,6 +384,18 @@ describe("iterate — round-boundary push integration", () => {
     });
 
     expect(res.exitCode).toBe(3);
+
+    // Issue #102 — the push-consent-interrupted early-return wrote
+    // state.json with `exit.code=3` + fresh `updated_at` and then
+    // bailed without opening a finalize commit. Now that it routes
+    // through the shared `finalizeBookkeeping` helper the tree must
+    // be clean on exit.
+    const status = spawnSync("git", ["status", "--porcelain"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    expect(status.status).toBe(0);
+    expect(status.stdout).toBe("");
   });
 
   test("no pushOptions provided → local-only (no push attempts, no prompt)", async () => {

--- a/tests/loop/push-round-boundary.test.ts
+++ b/tests/loop/push-round-boundary.test.ts
@@ -390,12 +390,46 @@ describe("iterate — round-boundary push integration", () => {
     // bailed without opening a finalize commit. Now that it routes
     // through the shared `finalizeBookkeeping` helper the tree must
     // be clean on exit.
+    //
+    // Observation A: tree-clean.
     const status = spawnSync("git", ["status", "--porcelain"], {
       cwd: tmp,
       encoding: "utf8",
     });
     expect(status.status).toBe(0);
     expect(status.stdout).toBe("");
+
+    // Observation B: state.head_sha is a reachable 40-char SHA (not
+    // null). Same as the lead_terminal block, the recorded sha is
+    // either HEAD (no finalize bookkeeping commit opened) or HEAD~1
+    // (finalize commit is the tip, cannot name itself).
+    const statePath = path.join(tmp, ".samo", "spec", "refunds", "state.json");
+    const state: State = JSON.parse(readFileSync(statePath, "utf8")) as State;
+    expect(state.head_sha).not.toBeNull();
+    expect(state.head_sha).toMatch(/^[0-9a-f]{40}$/);
+    const rev = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    const headSha = (rev.stdout ?? "").trim();
+    const parent = spawnSync("git", ["rev-parse", "HEAD~1"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    const parentSha = (parent.stdout ?? "").trim();
+    const recorded = state.head_sha ?? "";
+    expect([headSha, parentSha]).toContain(recorded);
+
+    // Observation C: state.updated_at > state.created_at. Pre-fix the
+    // early-return wrote updated_at = now at the start of the exit
+    // path, but the seed state.json was already written with the same
+    // round-start timestamp, so any regression that re-routes through
+    // the pre-fix early-return would leave these equal. Assert a
+    // strict inequality (at least a few ms of wall-clock progress
+    // between seedSpec and exit).
+    const createdMs = Date.parse(state.created_at);
+    const updatedMs = Date.parse(state.updated_at);
+    expect(updatedMs).toBeGreaterThan(createdMs);
   });
 
   test("no pushOptions provided → local-only (no push attempts, no prompt)", async () => {

--- a/tests/loop/state-finalize.test.ts
+++ b/tests/loop/state-finalize.test.ts
@@ -195,7 +195,7 @@ describe("loop/state-finalize — iterate bookkeeping (#102)", () => {
     expect(status.stdout).toBe("");
   });
 
-  test("B: state.head_sha matches rev-parse HEAD after exit", async () => {
+  test("B: state.head_sha is a reachable 40-char SHA after exit", async () => {
     const slug = "refunds";
     seedSpec(tmp, slug, "2026-04-19T12:00:00Z");
     await runOneRoundConverged({
@@ -206,15 +206,30 @@ describe("loop/state-finalize — iterate bookkeeping (#102)", () => {
 
     const statePath = path.join(tmp, ".samo", "spec", slug, "state.json");
     const state: State = JSON.parse(readFileSync(statePath, "utf8"));
+
+    expect(state.head_sha).not.toBeNull();
+    expect(state.head_sha).toMatch(/^[0-9a-f]{40}$/);
+
+    // The finalize bookkeeping commit IS HEAD and cannot name itself in
+    // its own state.json payload, so `state.head_sha` points to the
+    // refine content commit (HEAD~1). Verify that: (1) the recorded
+    // sha is reachable from HEAD, and (2) the current HEAD is either
+    // that sha itself (no finalize commit path) or its direct child.
     const rev = spawnSync("git", ["rev-parse", "HEAD"], {
       cwd: tmp,
       encoding: "utf8",
     });
     const headSha = (rev.stdout ?? "").trim();
-
-    expect(state.head_sha).not.toBeNull();
-    expect(state.head_sha).toMatch(/^[0-9a-f]{40}$/);
-    expect(state.head_sha).toBe(headSha);
+    const parent = spawnSync("git", ["rev-parse", "HEAD~1"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    const parentSha = (parent.stdout ?? "").trim();
+    // Narrow: the preceding assertions guarantee `head_sha` is a non-
+    // null 40-char hex string at this point; the optional-chain above
+    // is only there because the Zod schema makes the field nullable.
+    const recorded = state.head_sha ?? "";
+    expect([headSha, parentSha]).toContain(recorded);
   });
 
   test("C: state.updated_at advances past created_at and tracks wall-clock", async () => {

--- a/tests/loop/state-finalize.test.ts
+++ b/tests/loop/state-finalize.test.ts
@@ -1,0 +1,246 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * Issue #102 — iterate must leave the tree clean, populate `head_sha`, and
+ * keep `updated_at` current across every state.json write.
+ *
+ * Red-first: three targeted assertions around a single converged run.
+ *   A) `git status --porcelain` empty under `.samo/spec/<slug>/` after exit.
+ *   B) `state.head_sha` is a 40-char SHA matching `git rev-parse HEAD`.
+ *   C) `state.updated_at > state.created_at` and within 10s of wall-clock now.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type { Adapter, CritiqueOutput } from "../../src/adapter/types.ts";
+import { runIterate, type IterateResolvers } from "../../src/cli/iterate.ts";
+import { writeState } from "../../src/state/store.ts";
+import type { State } from "../../src/state/types.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-state-finalize-"));
+  initRepo(tmp);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function initRepo(cwd: string): void {
+  spawnSync("git", ["init", "-q"], { cwd });
+  spawnSync("git", ["config", "user.email", "test@example.com"], { cwd });
+  spawnSync("git", ["config", "user.name", "Test"], { cwd });
+  spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd });
+  spawnSync("git", ["checkout", "-q", "-b", "samospec/refunds"], { cwd });
+  writeFileSync(path.join(cwd, "README.md"), "seed\n", "utf8");
+  spawnSync("git", ["add", "README.md"], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "seed"], { cwd });
+}
+
+/** Seed matches the `tests/loop/e2e.test.ts` shape; kept local to stay
+ *  decoupled from that test's exports. */
+function seedSpec(cwd: string, slug: string, createdAt: string): void {
+  const slugDir = path.join(cwd, ".samo", "spec", slug);
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(
+    path.join(slugDir, "SPEC.md"),
+    "# SPEC\n\nv0.1 body\n- initial requirement\n",
+    "utf8",
+  );
+  writeFileSync(path.join(slugDir, "TLDR.md"), "# TLDR\n\n- stub\n", "utf8");
+  writeFileSync(
+    path.join(slugDir, "decisions.md"),
+    "# decisions\n\n- No review-loop decisions yet.\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "changelog.md"),
+    "# changelog\n\n## v0.1 — seed\n\n- initial\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "interview.json"),
+    JSON.stringify({
+      slug,
+      persona: 'Veteran "refunds" expert',
+      generated_at: createdAt,
+      questions: [],
+      answers: [],
+    }),
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "context.json"),
+    JSON.stringify({
+      phase: "draft",
+      files: [],
+      risk_flags: [],
+      budget: { phase: "draft", tokens_used: 0, tokens_budget: 0 },
+    }),
+    "utf8",
+  );
+  const state: State = {
+    slug,
+    phase: "review_loop",
+    round_index: 0,
+    version: "0.1.0",
+    persona: { skill: "refunds", accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+  writeState(path.join(slugDir, "state.json"), state);
+  spawnSync("git", ["add", "."], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "spec(refunds): draft v0.1"], {
+    cwd,
+  });
+}
+
+const ACCEPT_RESOLVERS: IterateResolvers = {
+  onManualEdit: () => Promise.resolve("incorporate"),
+  onDegraded: () => Promise.resolve("accept"),
+  onReviewerExhausted: () => Promise.resolve("abort"),
+};
+const DEFAULT_TIME_INPUTS = {
+  sessionStartedAtMs: 0,
+  nowMs: 0,
+  maxWallClockMs: 60 * 60 * 1000,
+};
+
+function buildCritique(suffix: number): CritiqueOutput {
+  return {
+    findings: [
+      {
+        category: "ambiguity",
+        text: `finding #${String(suffix)} in spec body`,
+        severity: "minor",
+      },
+    ],
+    summary: `round ${String(suffix)} summary`,
+    suggested_next_version: `0.${String(suffix + 1)}`,
+    usage: null,
+    effort_used: "max",
+  };
+}
+
+/** Converges in one round via `ready=true`. */
+async function runOneRoundConverged(args: {
+  readonly cwd: string;
+  readonly slug: string;
+  readonly now: string;
+}): Promise<void> {
+  const lead: Adapter = createFakeAdapter({
+    revise: {
+      spec: "# SPEC\n\nrevised body\n- item\n",
+      ready: true,
+      rationale: "[]",
+      usage: null,
+      effort_used: "max",
+    },
+  });
+  const critiqueAdapter = createFakeAdapter({ critique: buildCritique(1) });
+
+  const res = await runIterate({
+    cwd: args.cwd,
+    slug: args.slug,
+    now: args.now,
+    resolvers: ACCEPT_RESOLVERS,
+    adapters: {
+      lead,
+      reviewerA: critiqueAdapter,
+      reviewerB: critiqueAdapter,
+    },
+    maxRounds: 3,
+    ...DEFAULT_TIME_INPUTS,
+  });
+  expect(res.exitCode).toBe(0);
+  expect(res.stopReason).toBe("ready");
+}
+
+describe("loop/state-finalize — iterate bookkeeping (#102)", () => {
+  test("A: working tree is clean after a converged run", async () => {
+    const slug = "refunds";
+    seedSpec(tmp, slug, "2026-04-19T12:00:00Z");
+    await runOneRoundConverged({
+      cwd: tmp,
+      slug,
+      now: "2026-04-19T12:00:00Z",
+    });
+
+    const status = spawnSync("git", ["status", "--porcelain"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    expect(status.status).toBe(0);
+    // The spec tree must be clean — no `M .samo/spec/<slug>/state.json`.
+    expect(status.stdout).toBe("");
+  });
+
+  test("B: state.head_sha matches rev-parse HEAD after exit", async () => {
+    const slug = "refunds";
+    seedSpec(tmp, slug, "2026-04-19T12:00:00Z");
+    await runOneRoundConverged({
+      cwd: tmp,
+      slug,
+      now: "2026-04-19T12:00:00Z",
+    });
+
+    const statePath = path.join(tmp, ".samo", "spec", slug, "state.json");
+    const state: State = JSON.parse(readFileSync(statePath, "utf8"));
+    const rev = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    const headSha = (rev.stdout ?? "").trim();
+
+    expect(state.head_sha).not.toBeNull();
+    expect(state.head_sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(state.head_sha).toBe(headSha);
+  });
+
+  test("C: state.updated_at advances past created_at and tracks wall-clock", async () => {
+    const slug = "refunds";
+    const createdAt = "2026-04-19T12:00:00Z";
+    seedSpec(tmp, slug, createdAt);
+
+    // Pass the SAME round-start timestamp as `input.now`. Today the
+    // iterate loop threads this value straight into every state.json
+    // write, which is exactly the bug observation C calls out: the
+    // stamp is "frozen at round start", never tracks wall-clock.
+    //
+    // After the fix, `updated_at` must be re-bumped to the current
+    // wall-clock on the final write, so it will be newer than the
+    // round-start stamp and within a few seconds of `Date.now()`.
+    await runOneRoundConverged({ cwd: tmp, slug, now: createdAt });
+
+    const statePath = path.join(tmp, ".samo", "spec", slug, "state.json");
+    const state: State = JSON.parse(readFileSync(statePath, "utf8"));
+
+    const createdMs = Date.parse(state.created_at);
+    const updatedMs = Date.parse(state.updated_at);
+    expect(updatedMs).toBeGreaterThan(createdMs);
+
+    // Within 10s of wall-clock now — tolerates slow CI.
+    const nowMs = Date.now();
+    expect(Math.abs(nowMs - updatedMs)).toBeLessThan(10_000);
+  });
+});

--- a/tests/loop/state-finalize.test.ts
+++ b/tests/loop/state-finalize.test.ts
@@ -192,8 +192,7 @@ async function runOneRoundLeadTerminal(args: {
     // Throw a plain Error so the SPEC §7 sub-reason classifier falls
     // back to `adapter_error` — the exact bucket is not load-bearing
     // for this test, only that the lead_terminal path is taken.
-    revise: () =>
-      Promise.reject(new Error("synthetic lead failure for test")),
+    revise: () => Promise.reject(new Error("synthetic lead failure for test")),
   };
   const critiqueAdapter = createFakeAdapter({ critique: buildCritique(1) });
 

--- a/tests/loop/state-finalize.test.ts
+++ b/tests/loop/state-finalize.test.ts
@@ -176,6 +176,43 @@ async function runOneRoundConverged(args: {
   expect(res.stopReason).toBe("ready");
 }
 
+/**
+ * Drives iterate to a `lead_terminal` exit (exit 4) by replacing the lead
+ * adapter's `revise()` with a reject. The rest of the round is otherwise
+ * a normal one-round loop; both reviewers succeed.
+ */
+async function runOneRoundLeadTerminal(args: {
+  readonly cwd: string;
+  readonly slug: string;
+  readonly now: string;
+}): Promise<void> {
+  const base = createFakeAdapter({});
+  const lead: Adapter = {
+    ...base,
+    // Throw a plain Error so the SPEC §7 sub-reason classifier falls
+    // back to `adapter_error` — the exact bucket is not load-bearing
+    // for this test, only that the lead_terminal path is taken.
+    revise: () =>
+      Promise.reject(new Error("synthetic lead failure for test")),
+  };
+  const critiqueAdapter = createFakeAdapter({ critique: buildCritique(1) });
+
+  const res = await runIterate({
+    cwd: args.cwd,
+    slug: args.slug,
+    now: args.now,
+    resolvers: ACCEPT_RESOLVERS,
+    adapters: {
+      lead,
+      reviewerA: critiqueAdapter,
+      reviewerB: critiqueAdapter,
+    },
+    maxRounds: 3,
+    ...DEFAULT_TIME_INPUTS,
+  });
+  expect(res.exitCode).toBe(4);
+}
+
 describe("loop/state-finalize — iterate bookkeeping (#102)", () => {
   test("A: working tree is clean after a converged run", async () => {
     const slug = "refunds";
@@ -255,6 +292,76 @@ describe("loop/state-finalize — iterate bookkeeping (#102)", () => {
     expect(updatedMs).toBeGreaterThan(createdMs);
 
     // Within 10s of wall-clock now — tolerates slow CI.
+    const nowMs = Date.now();
+    expect(Math.abs(nowMs - updatedMs)).toBeLessThan(10_000);
+  });
+
+  // Issue #102 — the `ready=true` happy-path test above covered the main
+  // finalize seam. This block re-asserts the same three invariants for
+  // the `lead_terminal` exit (exit code 4), which pre-fix bypassed
+  // `finishIterate` via an early return and left state.json dirty.
+  test("A (lead_terminal): working tree is clean after exit 4", async () => {
+    const slug = "refunds";
+    seedSpec(tmp, slug, "2026-04-19T12:00:00Z");
+    await runOneRoundLeadTerminal({
+      cwd: tmp,
+      slug,
+      now: "2026-04-19T12:00:00Z",
+    });
+
+    const status = spawnSync("git", ["status", "--porcelain"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    expect(status.status).toBe(0);
+    expect(status.stdout).toBe("");
+  });
+
+  test("B (lead_terminal): state.head_sha is a 40-char SHA after exit 4", async () => {
+    const slug = "refunds";
+    seedSpec(tmp, slug, "2026-04-19T12:00:00Z");
+    await runOneRoundLeadTerminal({
+      cwd: tmp,
+      slug,
+      now: "2026-04-19T12:00:00Z",
+    });
+
+    const statePath = path.join(tmp, ".samo", "spec", slug, "state.json");
+    const state: State = JSON.parse(readFileSync(statePath, "utf8"));
+
+    expect(state.head_sha).not.toBeNull();
+    expect(state.head_sha).toMatch(/^[0-9a-f]{40}$/);
+
+    // The finalize bookkeeping commit is HEAD and cannot name itself in
+    // its own payload, so the recorded sha is either HEAD (no finalize
+    // commit — nothing to finalize) or HEAD~1 (finalize commit present).
+    const rev = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    const headSha = (rev.stdout ?? "").trim();
+    const parent = spawnSync("git", ["rev-parse", "HEAD~1"], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    const parentSha = (parent.stdout ?? "").trim();
+    const recorded = state.head_sha ?? "";
+    expect([headSha, parentSha]).toContain(recorded);
+  });
+
+  test("C (lead_terminal): state.updated_at advances past created_at", async () => {
+    const slug = "refunds";
+    const createdAt = "2026-04-19T12:00:00Z";
+    seedSpec(tmp, slug, createdAt);
+    await runOneRoundLeadTerminal({ cwd: tmp, slug, now: createdAt });
+
+    const statePath = path.join(tmp, ".samo", "spec", slug, "state.json");
+    const state: State = JSON.parse(readFileSync(statePath, "utf8"));
+
+    const createdMs = Date.parse(state.created_at);
+    const updatedMs = Date.parse(state.updated_at);
+    expect(updatedMs).toBeGreaterThan(createdMs);
+
     const nowMs = Date.now();
     expect(Math.abs(nowMs - updatedMs)).toBeLessThan(10_000);
   });


### PR DESCRIPTION
Closes #102

## Summary

- `iterate` now captures the final `exit` / `head_sha` / `updated_at` write
  in a follow-up `spec(<slug>): finalize round N` commit, so the tree is
  empty under `.samo/spec/<slug>/` after any converged run.
- `state.head_sha` is resolved from `git rev-parse HEAD` after the round
  commit and populated on disk (previously always `null`).
- `state.updated_at` now tracks wall-clock on every `state.json` write —
  the old code threaded the frozen `input.now` round-start stamp into
  every field.

## Design

- Chose the **two-commit** option from the issue's design matrix:
  `spec(<slug>): refine v<version> after review r<N>` (content) followed
  by `spec(<slug>): finalize round <N>` (bookkeeping only). The follow-up
  commit is skipped when nothing is dirty (no empty commits ever) and
  re-uses `specCommit` so protected-branch / no-force / no-amend
  guarantees remain enforced by the existing regression tests.
- **Trade-off on B:** `state.head_sha` ends up pointing to the `refine`
  content commit (HEAD~1 after iterate exits). A commit cannot name its
  own SHA in its own tree, so the only way to keep `state.head_sha == HEAD`
  literally is to leave state.json dirty (which then fails A). The refine
  sha is a stable, reachable pointer; `verifyHeadSha` callers should
  accept HEAD or HEAD~1 when iterate's tip is a `finalize` commit.
- Zod schema unchanged — `head_sha` was already `nullable().optional()`.

## Test plan

- [x] Red-first: three targeted tests in `tests/loop/state-finalize.test.ts`
      exercising A / B / C against a real `runIterate` in a temp git repo.
      Pre-fix output:

  ```
  (fail) loop/state-finalize — iterate bookkeeping (#102) > A: working tree is clean after a converged run
    received " M .samo/spec/refunds/TLDR.md\n M .samo/spec/refunds/state.json\n"
  (fail) loop/state-finalize — iterate bookkeeping (#102) > B: state.head_sha is a reachable 40-char SHA after exit
    received null
  (fail) loop/state-finalize — iterate bookkeeping (#102) > C: state.updated_at advances past created_at and tracks wall-clock
    Expected: > 1776600000000, Received: 1776600000000
   0 pass / 3 fail
  ```
- [x] Green: all three pass post-fix (`3 pass / 0 fail`).
- [x] Full suite: `1360 pass / 0 fail` (`bun test`, ~52s).
- [x] `bun run lint`, `bun run typecheck`, `bun run format:check` all clean.