### PR TITLE
docs: add Apache-2.0 LICENSE + refresh README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,67 +1,122 @@
 # Changelog
 
-## [0.4.1] - 2026-04-21
-
-### Added
-
-- (describe additions)
-
-### Fixed
-
-- (describe fixes)
-
-### Changed
-
-- (describe changes)
-
-## [0.4.0] - 2026-04-21
-
-### Added
-
-- (describe additions)
-
-### Fixed
-
-- (describe fixes)
-
-### Changed
-
-- (describe changes)
-
-## [0.3.1] - 2026-04-21
-
-### Added
-
-- (describe additions)
-
-### Fixed
-
-- (describe fixes)
-
-### Changed
-
-- (describe changes)
-
-## [0.3.0] - 2026-04-21
-
-### Added
-
-- (describe additions)
-
-### Fixed
-
-- (describe fixes)
-
-### Changed
-
-- (describe changes)
-
 All notable changes to SamoSpec are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
 ## [Unreleased]
+
+---
+
+## [0.4.1] - 2026-04-21
+
+### Fixed
+
+- **Codex pinned-model fallback under ChatGPT-auth (#88):** `gpt-5.1-codex-max`
+  returns `exit 1` with an `invalid_request_error` JSON on stdout when
+  rejected under ChatGPT-account auth. The adapter used to call
+  `classifyExit(exitCode, stderr)` first and the empty stderr yielded
+  "other", so the account-default fallback chain never fired. Fix scans
+  stdout AND stderr for the error signature before classifying exit —
+  stdout-carried error JSON wins regardless of exit code. Also adds
+  `"not supported"` to the unavailable-phrase list.
+- **Codex agentic-wrapper output parser (#88):** codex v0.120+ emits an
+  agentic banner followed by `codex\n<JSON>\ntokens used…`. The legacy
+  extractor matched the literal `codex\n` prefix anywhere and produced a
+  partial JSON fragment, failing with `schema_violation`. Now requires the
+  next non-blank line after `codex\n` to start with `{`, guarded against
+  stray `codex` tokens inside the wrapped content.
+
+---
+
+## [0.4.0] - 2026-04-21
+
+### Added
+
+- **Idea precedence over slug cues (#85):** lead and reviewer prompts now
+  include an AUTHORITATIVE idea framing block ahead of any slug-derived
+  hint. Fixes a failure mode where e.g. a slug `todo-stream` made Claude
+  draft a CRUD todo app despite an explicit "NOT a CRUD app" clarifier in
+  `--idea`.
+- **Reviewer B contradiction detection (#85):** when an idea is present,
+  Reviewer B's critique prompt receives a contradiction-detection directive
+  that flags any section of the revised spec that deviates from the
+  original idea.
+
+---
+
+## [0.3.1] - 2026-04-21
+
+### Fixed
+
+- **Bun spawn hang on SIGKILL (#81):** `new Response(stream).text()` blocks
+  waiting for EOF even after `SIGKILL`, so `spawnCli` never resolved on
+  timeout (observed live: a 22+ minute hang). Fix uses an `AbortController`
+  with a manual `ReadableStream` reader and `Promise.race` so the stream
+  read unblocks within `timeoutMs` of the kill signal.
+- **Per-call timeout + session wall-clock in `runNew` (#83):** the session
+  wall-clock budget is now honored on every `ask`/`revise` call — each is
+  wrapped in `withDeadline()` against the session deadline, so a hung
+  adapter can no longer pin the full session. On cap, `runNew` exits 4
+  with `session-wall-clock` in stderr.
+
+---
+
+## [0.3.0] - 2026-04-21
+
+### Added
+
+- **Auto-init git + empty commit (#72 / #65):** first `samospec init` in
+  a non-git or empty-HEAD directory either prompts or (`--yes`)
+  auto-creates `.git/` plus an initial empty commit.
+- **Next-step hints everywhere (#71):** `samospec resume <slug>` prints
+  `next: samospec iterate <slug>` or `next: samospec publish <slug>`
+  depending on phase. `samospec iterate` prints
+  `next: samospec publish <slug>` on success stops and recovery
+  guidance on failure stops.
+- **`--force` archive naming matches SPEC §10 (#69):**
+  `.samo/spec/<slug>.archived-YYYY-MM-DDThhmmssZ/` (ISO 8601 UTC, no
+  colons so it's Windows-portable, with `-1` / `-2` collision suffix on
+  same-second runs). Was `.bak.<ts>` in v0.2.0.
+- **`scripts/bump-version.ts` (#57):** release-prep script that bumps
+  `package.json` and scaffolds a CHANGELOG entry. Prevents the tag /
+  `package.json` drift that caused v0.1.0 / v0.1.1 mismatches.
+
+### Fixed
+
+- **Reviewer-failure convergence guard (#64):** when both reviewers fail
+  in a round, the lead's `ready=true` is no longer silently accepted.
+  `reviewers-exhausted` is now the dominant stopping reason over `ready`
+  / `semantic-convergence`. Prevents shipping an un-reviewed v0.N spec.
+- **Codex preflight label under OAuth (#70 / #80):** under ChatGPT OAuth
+  (no `OPENAI_API_KEY`), reviewer_a preflight cost now reads
+  `unknown — OAuth (no per-token cost visibility)` instead of a
+  misleading dollar figure. Wired end-to-end through `runPreflight`.
+- **`--force` on existing slug dir (#63 / #68):** `samospec new --force`
+  was silently ignored when the slug dir already existed. Now archives
+  the existing dir and proceeds.
+- **`samospec publish` base-branch push (#67):** `gh pr create` failed
+  when local `main` had not been pushed to the remote. Now pushes the
+  base branch first.
+- **`samospec init --yes` on non-git dirs (#79):** `runInitCommand` was
+  discarding `--yes`, so auto-git-init never fired from the CLI path.
+
+---
+
+## [0.1.1] - 2026-04-20
+
+### Fixed
+
+- **Codex under ChatGPT-account auth (#54 / #55):** the pinned models
+  `gpt-5.1-codex-max` / `gpt-5.1-codex` are not available on ChatGPT
+  subscription accounts, so v0.1.0 exhausted the fallback chain and left
+  Reviewer A failing every round. v0.1.1 adds an implicit account-default
+  tier after the explicit pins (one more call with `--model` omitted),
+  correctly classifies codex's exit-0 `invalid_request_error` stdout JSON
+  as `model_unavailable` instead of `schema_violation`, and lists every
+  attempted tier in the terminal error message. New opt-out:
+  `codex.accountDefaultFallback: false`.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may accept and charge a
+      fee for acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on Your own behalf and
+      on Your sole responsibility, not on behalf of any other Contributor,
+      and only if You agree to indemnify, defend, and hold each Contributor
+      harmless for any liability incurred by, or claims asserted against,
+      such Contributor by reason of your accepting any such warranty or
+      additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Nikolay Samokhvalov
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing permissions
+   and limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -137,8 +138,8 @@
 
    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
    7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
@@ -163,15 +164,15 @@
       has been advised of the possibility of such damages.
 
    9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may accept and charge a
-      fee for acceptance of support, warranty, indemnity, or other liability
-      obligations and/or rights consistent with this License. However, in
-      accepting such obligations, You may act only on Your own behalf and
-      on Your sole responsibility, not on behalf of any other Contributor,
-      and only if You agree to indemnify, defend, and hold each Contributor
-      harmless for any liability incurred by, or claims asserted against,
-      such Contributor by reason of your accepting any such warranty or
-      additional liability.
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
 
@@ -196,6 +197,6 @@
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied. See the License for the specific language governing permissions
-   and limitations under the License.
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # SamoSpec
 
+[![CI](https://github.com/NikolayS/samospec/actions/workflows/ci.yml/badge.svg)](https://github.com/NikolayS/samospec/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/samospec.svg)](https://www.npmjs.com/package/samospec)
+[![license](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![Bun](https://img.shields.io/badge/Bun-%E2%89%A5_1.2-000?logo=bun)](https://bun.sh)
+
 > Turn a rough idea into a **reviewed, versioned spec** — with every round captured in git, not chat scrollback.
 
 `samospec` is a git-native CLI that runs a small panel of top AI models against your idea: a **lead** drafts, two **reviewers** critique with different personas, the lead revises, and the loop repeats until convergence. The result is `SPEC.md` with real commit history — `v0.1 → v0.2 → … → v1.0` — that you can diff, blame, and publish.
@@ -18,7 +23,7 @@ SamoSpec treats spec authoring like code review:
 
 - **Panel, not monologue.** One lead drafts; two reviewers with deliberately different personas critique in parallel. Disagreement is surfaced, not averaged away.
 - **Every round is a commit.** Each revision lives on a `samospec/<slug>` branch. `git log` tells the story. `decisions.md` records what was accepted, rejected, or deferred — and why.
-- **Convergence is defined, not vibes.** Eight explicit stopping conditions (semantic convergence, repeat-findings halt via trigram Jaccard, wall-clock cap, budget cap, max rounds, …) mean the loop _ends_ on its own.
+- **Convergence is defined, not vibes.** Eight explicit stopping conditions — lead-ready, semantic convergence, repeat-findings halt via trigram Jaccard, wall-clock cap, budget cap, max rounds, reviewers-exhausted, user SIGINT — mean the loop _ends_ on its own.
 - **Strongest model, max effort, by default.** No silent downshifting. The thesis is that great specs come from the top of each vendor's ladder running hard, not from the cheapest model running often.
 
 ---
@@ -59,7 +64,7 @@ At every step: `samospec status <slug>` prints phase, current version, next-step
 
 ## How it works
 
-```
+```text
                  ┌────────────────────┐
    idea  ──►     │  LEAD  (Claude)    │  ──►   SPEC.md v0.N
                  │  draft / revise    │
@@ -84,7 +89,7 @@ At every step: `samospec status <slug>` prints phase, current version, next-step
 
 - **Lead** = `claude` CLI, pinned `claude-opus-4-7`, effort `max`.
 - **Reviewer A** = `codex` CLI with a **security/ops** persona: missing risks, weak implementation, unnecessary scope.
-- **Reviewer B** = second `claude` session with a **QA/pedant** persona: ambiguity, contradiction, weak testing. Also verifies the spec stays faithful to your original idea.
+- **Reviewer B** = second `claude` session with a **QA / testability** persona: ambiguity, contradiction, weak-testing. Also checks the spec's mandatory baseline sections and verifies it stays faithful to your original idea.
 - Adapters share a coupled-fallback rule (lead and Reviewer B use the same vendor, so a Claude outage fails them together rather than running an uneven panel).
 
 Every generated `SPEC.md` gets nine mandatory sections by default (goal & why, user stories, architecture, implementation details, tests plan with red/green TDD, team of veteran experts, sprint plan, embedded changelog, version header). Pass `--skip` to opt out.
@@ -96,7 +101,7 @@ Every generated `SPEC.md` gets nine mandatory sections by default (goal & why, u
 The CLI shells out to the vendor CLIs you already use. OAuth-based sessions are the **primary** auth mode — API keys are an alternative:
 
 - **Claude Code** — `claude /login` once in a terminal; samospec inherits the session for `claude --print` calls. Or `export ANTHROPIC_API_KEY=sk-ant-...`.
-- **Codex** — `codex login` (ChatGPT subscription account works); samospec handles the pinned-model fallback when your account default differs. Or `export OPENAI_API_KEY=sk-...`.
+- **Codex** — `codex auth` (ChatGPT subscription account works); samospec handles the pinned-model fallback when your account default differs. Or `export OPENAI_API_KEY=sk-...`.
 
 ```bash
 samospec doctor   # verifies CLI availability, auth, git, lockfile, config, entropy, push consent
@@ -125,7 +130,6 @@ samospec doctor   # verifies CLI availability, auth, git, lockfile, config, entr
 | `samospec iterate <slug>`        | Runs review rounds (lead + two reviewers in parallel) until a stopping condition fires.                                                      |
 | `samospec resume <slug>`         | Idempotent resume from any crash/kill. Works at every round state boundary.                                                                  |
 | `samospec status <slug>`         | Phase, version, round index, last-round summary, next-step hint.                                                                             |
-| `samospec tldr <slug>`           | One-paragraph TL;DR for stakeholders.                                                                                                        |
 | `samospec publish <slug>`        | Promotes spec to `.samo/blueprints/`, commits, pushes, opens PR via `gh` / `glab`.                                                           |
 
 Useful flags:

--- a/README.md
+++ b/README.md
@@ -1,82 +1,176 @@
 # SamoSpec
 
-SamoSpec (`samospec`) is a git-native CLI that turns a rough idea into a
-strong, versioned specification document through a structured dialogue between
-the user, one lead AI expert, and a small panel of AI review experts — with
-every material step automatically captured in git. It is part of the
-[samo](https://github.com/NikolayS/samospec) project ecosystem and ships as
-an npm package under the `samospec` name. The tool runs locally, orchestrates
-Claude Code, Codex, and (post-v1) additional vendors behind one opinionated
-workflow, and requires no external state beyond a git repository.
+> Turn a rough idea into a **reviewed, versioned spec** — with every round captured in git, not chat scrollback.
+
+`samospec` is a git-native CLI that runs a small panel of top AI models against your idea: a **lead** drafts, two **reviewers** critique with different personas, the lead revises, and the loop repeats until convergence. The result is `SPEC.md` with real commit history — `v0.1 → v0.2 → … → v1.0` — that you can diff, blame, and publish.
+
+**Live demo** — a real spec produced end-to-end over ChatGPT-account OAuth:
+→ https://github.com/NikolayS/todo-stream/tree/samospec/todo-stream
+(browse the `.samo/spec/todo-stream/` tree; 7 review rounds, both reviewers writing real critiques)
+
+---
+
+## Why
+
+Most "AI writes my spec" tools give you one shot from one model. You get a monologue in a chat window, lose the context the moment the tab closes, and have no record of what was considered and rejected.
+
+SamoSpec treats spec authoring like code review:
+
+- **Panel, not monologue.** One lead drafts; two reviewers with deliberately different personas critique in parallel. Disagreement is surfaced, not averaged away.
+- **Every round is a commit.** Each revision lives on a `samospec/<slug>` branch. `git log` tells the story. `decisions.md` records what was accepted, rejected, or deferred — and why.
+- **Convergence is defined, not vibes.** Eight explicit stopping conditions (semantic convergence, repeat-findings halt via trigram Jaccard, wall-clock cap, budget cap, max rounds, …) mean the loop _ends_ on its own.
+- **Strongest model, max effort, by default.** No silent downshifting. The thesis is that great specs come from the top of each vendor's ladder running hard, not from the cheapest model running often.
+
+---
 
 ## Install
 
-Requires [Bun](https://bun.sh) >= 1.2.0.
-
-```bash
-bunx samospec
-```
-
-or install globally:
+Requires [Bun](https://bun.sh) ≥ 1.2.0.
 
 ```bash
 bun install -g samospec
-samospec --version
+samospec --version   # 0.4.1
 ```
 
-Note: `npx` is NOT supported in v0.1.0. Use `bunx` or a global Bun install.
+Or one-shot:
+
+```bash
+bunx samospec doctor
+```
+
+`npx` is not supported — use `bunx` or a global Bun install.
+
+---
 
 ## Quickstart
 
-These three commands take an idea to a reviewed, version-controlled spec.
+Three commands, from idea to reviewed spec:
 
 ```bash
-samospec init
-samospec new my-feature --idea "Describe the feature here"
-samospec iterate
+samospec init                                       # scaffolds .samo/ in the current git repo
+samospec new linkrot --idea "Detect dead links in Markdown files"
+samospec iterate linkrot                            # lead drafts → 2 reviewers critique → lead revises → repeat
+samospec publish linkrot                            # promote, commit, push, open PR via gh
 ```
 
-**Prerequisites:**
+At every step: `samospec status <slug>` prints phase, current version, next-step hint, and last-round summary.
 
-samospec requires authenticated `claude` and `codex` CLIs on PATH.
-The primary auth mode is OAuth — run `claude /login` (or equivalent
-for Codex) interactively once; samospec inherits that session for
-non-interactive work calls. Alternatively, export
-`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`.
+---
 
-- [Claude Code](https://claude.ai/download) — OAuth via `claude /login`,
-  or `export ANTHROPIC_API_KEY=sk-ant-...`
-- [Codex](https://platform.openai.com/docs/guides/codex) — OAuth via
-  `codex auth`, or `export OPENAI_API_KEY=sk-...`
+## How it works
 
-`samospec doctor` checks everything before you start.
+```
+                 ┌────────────────────┐
+   idea  ──►     │  LEAD  (Claude)    │  ──►   SPEC.md v0.N
+                 │  draft / revise    │
+                 └────┬───────────────┘
+                      │  (parallel)
+       ┌──────────────┴──────────────┐
+       ▼                             ▼
+ ┌──────────────┐             ┌──────────────┐
+ │ Reviewer A   │             │ Reviewer B   │
+ │ (Codex)      │             │ (Claude #2)  │
+ │ security/ops │             │ QA/pedant    │
+ └──────┬───────┘             └───────┬──────┘
+        │                             │
+        └───────┐             ┌───────┘
+                ▼             ▼
+             ┌──────────────────────┐
+             │  round.json          │  ─► commit ─► repeat
+             │  claude.md, codex.md │
+             │  decisions.md update │
+             └──────────────────────┘
+```
 
-- `samospec init` — initialise `.samo/` in the current git repo (idempotent).
-- `samospec new <slug> --idea "..."` — start a new spec; leads you through
-  persona selection, a five-question strategic interview, and writes v0.1.
-- `samospec iterate` — run review rounds (lead + two reviewers in parallel)
-  until converged, at the iteration cap, or on your request.
-- `samospec publish <slug>` — promote the final spec to `blueprints/`, commit,
-  push (if consented), and open a PR via `gh` or `glab`.
-- `samospec doctor` — check CLI availability, auth, config sanity, calibration,
-  push consent, and global-config contamination before running anything.
+- **Lead** = `claude` CLI, pinned `claude-opus-4-7`, effort `max`.
+- **Reviewer A** = `codex` CLI with a **security/ops** persona: missing risks, weak implementation, unnecessary scope.
+- **Reviewer B** = second `claude` session with a **QA/pedant** persona: ambiguity, contradiction, weak testing. Also verifies the spec stays faithful to your original idea.
+- Adapters share a coupled-fallback rule (lead and Reviewer B use the same vendor, so a Claude outage fails them together rather than running an uneven panel).
 
-## Full specification
+Every generated `SPEC.md` gets nine mandatory sections by default (goal & why, user stories, architecture, implementation details, tests plan with red/green TDD, team of veteran experts, sprint plan, embedded changelog, version header). Pass `--skip` to opt out.
 
-See [`.samo/blueprints/SPEC.md`](.samo/blueprints/SPEC.md) for the complete
-product spec (architecture, state machines, adapter contract, publish lint,
-dogfood scorecard, threat model, and implementation plan).
+---
 
-## Not in v0.1.0
+## Auth — OAuth is the happy path
 
-The following are explicitly deferred and are NOT in this release:
+The CLI shells out to the vendor CLIs you already use. OAuth-based sessions are the **primary** auth mode — API keys are an alternative:
 
-- Homebrew, apt, or standalone binary distribution — use `bunx` or `bun install -g`.
-- Gemini and OpenCode adapters — Claude Code + Codex only in v0.1.0.
-- Non-software persona packs (marketing, ops playbooks, research specs).
-- `samospec compare`, `samospec diff`, `samospec export`.
-- `samospec experts set` — edit `.samo/config.json` manually until v0.2.
+- **Claude Code** — `claude /login` once in a terminal; samospec inherits the session for `claude --print` calls. Or `export ANTHROPIC_API_KEY=sk-ant-...`.
+- **Codex** — `codex login` (ChatGPT subscription account works); samospec handles the pinned-model fallback when your account default differs. Or `export OPENAI_API_KEY=sk-...`.
+
+```bash
+samospec doctor   # verifies CLI availability, auth, git, lockfile, config, entropy, push consent
+```
+
+---
+
+## Safety model
+
+- **Never commits to protected branches.** The publish PR targets `main` from a `samospec/<slug>` branch.
+- **First-push consent.** `samospec iterate` asks once per remote before pushing; decision persists in `.samo/config.json`.
+- **Prompt-injection envelope.** Untrusted content (repo files, review bodies) is wrapped in a content-unique `<repo_content_<sha8> trusted="false">…</repo_content_<sha8>>` frame with a recency-bias suffix reminder, so a hostile README can't hijack the lead.
+- **Hard-coded no-read list** for credential files (`.env*`, `~/.aws/credentials`, `~/.ssh/id_*`, …) cannot be overridden.
+- **Transcripts not committed by default.** When opted in, they pass a gitleaks/truffleHog-derived redaction pass first.
+- **Minimal-env spawn.** Subprocesses see only `HOME`, `PATH`, `TMPDIR`, `USER`, `LOGNAME` plus caller-declared auth vars — no ambient environment bleed.
+
+---
+
+## Commands
+
+| Command                          | What it does                                                                                                                                 |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `samospec init`                  | Scaffolds `.samo/` in the current git repo. Idempotent.                                                                                      |
+| `samospec doctor`                | Checks CLI availability, auth, git, lockfile, config, entropy, calibration, push consent, global-vendor-config contamination, PR-capability. |
+| `samospec new <slug> --idea "…"` | Starts a new spec: persona selection → five-question strategic interview → drafts v0.1.                                                      |
+| `samospec iterate <slug>`        | Runs review rounds (lead + two reviewers in parallel) until a stopping condition fires.                                                      |
+| `samospec resume <slug>`         | Idempotent resume from any crash/kill. Works at every round state boundary.                                                                  |
+| `samospec status <slug>`         | Phase, version, round index, last-round summary, next-step hint.                                                                             |
+| `samospec tldr <slug>`           | One-paragraph TL;DR for stakeholders.                                                                                                        |
+| `samospec publish <slug>`        | Promotes spec to `.samo/blueprints/`, commits, pushes, opens PR via `gh` / `glab`.                                                           |
+
+Useful flags:
+
+- `samospec new --skip user-stories,sprint-plan,…` — opt out of baseline sections.
+- `samospec new --max-session-wall-clock-ms 1800000` — 30-min session cap.
+- `samospec new --force` — archive any existing `<slug>` dir as `.archived-YYYY-MM-DDThhmmssZ/` before starting.
+- `samospec iterate --rounds 5` — cap rounds for this invocation.
+- `samospec iterate --no-push` — stay local this run.
+
+---
+
+## Stack
+
+- **Language:** TypeScript on Bun
+- **Distribution:** npm (Homebrew / apt / standalone binaries — v1.1+)
+- **Subprocess:** `Bun.spawn` (minimal env; AbortController-backed stream reader so SIGKILL actually unblocks)
+- **Schema validation:** Zod for every structured-output contract
+- **Tests:** Bun's built-in runner; `fast-check` for property-based tests on the phase + round state machines
+
+---
+
+## Not in this release (deferred)
+
+- Homebrew, apt, or standalone compiled binaries — planned for v1.1+.
+- Gemini and OpenCode adapters — planned for v1.1+. Claude + Codex only today.
+- `samospec compare`, `samospec diff`, `samospec export pdf|html` — v1.5+.
+- Non-software persona packs (marketing, ops playbooks, research specs) — v1.5+.
+- `samospec experts set` — edit `.samo/config.json` manually until v1.1.
+
+See [`.samo/blueprints/SPEC.md`](.samo/blueprints/SPEC.md) for the full product spec (architecture, state machines, adapter contract, publish lint, dogfood scorecard, threat model, implementation plan).
+
+---
+
+## Contributing
+
+- PRs welcome; target `main` from a feature branch.
+- Red-green TDD for new code — failing test → minimum green → refactor. Property-based tests for anything touching the phase machine, round state machine, or adapter contract.
+- Conventional Commits, 50-char subjects, present tense. Never amend, never force-push without confirmation.
+- See [`CLAUDE.md`](CLAUDE.md) for full engineering standards.
+
+Found a bug? https://github.com/NikolayS/samospec/issues
+
+---
 
 ## License
 
-UNLICENSED. Copyright 2026 Nikolay Samokhvalov.
+Apache-2.0. See [`LICENSE`](LICENSE). Copyright 2026 Nikolay Samokhvalov.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "docs",
     "package.json",
     "README.md",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "LICENSE"
   ],
   "scripts": {
     "samospec": "bun run src/main.ts",
@@ -26,7 +27,7 @@
   "engines": {
     "bun": ">=1.2.0"
   },
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "author": "Nikolay Samokhvalov",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Adds the `LICENSE` file (standard Apache-2.0 text, © 2026 Nikolay Samokhvalov). Closes the gap between `CLAUDE.md` / release notes (already say Apache-2.0) and the actual repo (had no LICENSE).
- Flips `package.json` `license` from `UNLICENSED` to `Apache-2.0` and ships the `LICENSE` in the npm tarball via `files`.
- Rewrites `README.md` — the prior one was v0.1.0-era and read flat:
  - Tagline + \"why\" section (panel vs monologue, every round a commit, convergence is defined, top-of-ladder by default)
  - **Live demo** link to https://github.com/NikolayS/todo-stream/tree/samospec/todo-stream (7 review rounds under ChatGPT-OAuth)
  - ASCII architecture diagram (lead + 2 reviewers in parallel)
  - Safety-model section (prompt-injection envelope, no-read list, minimal-env spawn, first-push consent)
  - Full command table
  - Deferred items rescoped for v1.1+ instead of v0.1.0

## Test plan

- [ ] CI green (docs-only change — no code).
- [ ] Render README on GitHub: code fences language-hinted, table aligned, list markers `- `.
- [ ] `samospec --version` still prints 0.4.1 (no code change).
- [ ] `npm pkg get license` → `\"Apache-2.0\"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)