### PR TITLE
ci: add npm publish workflow (on GitHub Release)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,111 @@
+# Copyright 2026 Nikolay Samokhvalov.
+
+name: publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v0.4.2). Must already exist."
+        required: true
+
+permissions:
+  contents: read
+  id-token: write # reserved for future OIDC migration
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify version matches tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Check package.json version == tag
+        id: check
+        run: |
+          set -Eeuo pipefail
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          PKG=$(node -p "require('./package.json').version")
+          EXPECTED="${TAG#v}"
+          if [[ "${PKG}" != "${EXPECTED}" ]]; then
+            echo "::error::package.json version (${PKG}) != release tag (${EXPECTED})"
+            exit 1
+          fi
+          echo "version=${PKG}" >> "${GITHUB_OUTPUT}"
+          echo "Verified: tag=${TAG} → package.json=${PKG}"
+
+  test:
+    name: Test / lint / typecheck
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Format check
+        run: bun run format:check
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+  publish:
+    name: Publish to npm
+    needs: [verify, test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/samospec/v/${{ needs.verify.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Node (for npm CLI)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,13 @@ This updates `package.json` and scaffolds a CHANGELOG entry. Then:
 1. Fill in the CHANGELOG entry (Added / Fixed / Changed).
 2. Update any `vX.Y.Z` references in `README.md`.
 3. Commit: `chore: bump version to X.Y.Z`. Tag on `main` after the PR merges.
+4. Cut the GitHub Release — this triggers `.github/workflows/publish.yml`:
+
+   ```bash
+   gh release create vX.Y.Z --title "vX.Y.Z" --notes-file /tmp/release-notes.md
+   ```
+
+   The workflow verifies `package.json` version == tag, runs lint/format/typecheck/tests, and publishes to npm with provenance (`npm publish --access public --provenance`). `NPM_TOKEN` lives in GitHub Actions secrets.
 
 ## Copyright
 


### PR DESCRIPTION
## Summary

- Adds \`.github/workflows/publish.yml\`: on \`release.published\` (or manual \`workflow_dispatch\` with an explicit tag), verifies \`package.json\` version matches the tag, re-runs the CI gate (lint/format/typecheck/tests), then \`npm publish --access public --provenance\`.
- Auth: \`NPM_TOKEN\` (automation token) already stored in GitHub Actions secrets.
- Documents the release flow in \`CLAUDE.md\`: bump-version → fill CHANGELOG → merge → tag → \`gh release create\` → workflow publishes.

## Test plan

- [ ] CI green (lint/format/typecheck/tests) on this PR.
- [ ] After merge, rotate the NPM token we used to set up the secret (it was shared in chat).
- [ ] Cut a test release (e.g. re-run v0.4.1 via \`gh release create v0.4.1 --generate-notes\` if the release doesn't yet exist, or patch to v0.4.2) and watch the workflow on https://github.com/NikolayS/samospec/actions.
- [ ] Verify \`npm view samospec@<version>\` resolves and the package has provenance metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)