### PR TITLE
feat: architecture schema + ASCII diagram (#107)

### DIFF
--- a/.samo/blueprints/SPEC.md
+++ b/.samo/blueprints/SPEC.md
@@ -174,6 +174,14 @@ touching surrounding prose.
   if the lead regenerates SPEC.md prose, the diagram stays in lockstep
   with the schema.
 
+**v0.1 scope:** the lead adapter does not yet emit architecture
+content, so every spec currently ships a zero-node `architecture.json`
+rendered as `(architecture not yet specified)`. Enriching the lead
+prompt to author architecture data is deferred to a later release. The
+schema, renderer, and sentinel block are live and stable — when the
+lead prompt lands, existing specs begin to populate architecture on
+the next `iterate` round without migration.
+
 ### Model roles
 
 - **Lead** (default `claude` CLI, `claude-opus-4-7`, effort `max`).

--- a/.samo/blueprints/SPEC.md
+++ b/.samo/blueprints/SPEC.md
@@ -147,9 +147,32 @@ Before any paid lead call, run the **preflight cost estimate** (§11). Uses scaf
 | `loop` | round scheduling, convergence + repeat-findings halt, cost summary emission |
 | `adapter` | uniform interface over `claude`, `codex`; schema validation; JSON code-fence stripping; retry/repair |
 | `policy` | budget guard: iteration/reviewer caps, token/$ budgets, wall-clock, preflight estimate |
-| `render` | TL;DR, status, changelog formatting |
+| `render` | TL;DR, status, changelog formatting, architecture ASCII diagram (#107) |
 | `publish` | promote to `blueprints/`, open PR, publish lint |
 | `doctor` | CLI availability, auth, subscription-auth flag, git/remote health, config sanity, entropy warning, global-config detection |
+
+### Architecture schema + ASCII diagram (#107)
+
+Every spec ships a machine-readable `architecture.json` alongside
+SPEC.md; the ASCII rendering of it is embedded in SPEC.md between
+`<!-- architecture:begin -->` / `<!-- architecture:end -->` sentinel
+comments so the renderer can replace the block each round without
+touching surrounding prose.
+
+- **Source of truth**: JSON + Zod at `.samo/spec/<slug>/architecture.json`.
+  Shape: `{ version: "1", nodes, edges, groups?, notes? }`. Node kinds:
+  `external | component | datastore | boundary`. Edge kinds:
+  `call | data | control`. IDs unique; every edge endpoint must resolve
+  to a node or a group.
+- **ASCII rendering**: 80 cols hard, ~40 lines soft. When the soft cap
+  trips, sibling groups collapse to a single `[N <label>]` pill.
+  Oversized labels truncated with `…`; the full label lives in the JSON.
+- **Zero-node placeholder**: `(architecture not yet specified)` (single
+  line) when no nodes have been contributed yet.
+- **Round-trip**: the ASCII block is a pure function of
+  `architecture.json`. `iterate` re-renders it on every round so even
+  if the lead regenerates SPEC.md prose, the diagram stays in lockstep
+  with the schema.
 
 ### Model roles
 
@@ -422,6 +445,7 @@ Stale removal is logged; the new process writes its own lockfile.
     context.json                 # discovery/ranking/provenance + risk_flags
     decisions.md                 # append-only; includes user-edit entries
     changelog.md
+    architecture.json            # machine-readable schema (#107)
     reviews/r01/
       codex.md                   # structured critique (security/ops persona)
       claude.md                  # structured critique (QA/pedant persona)
@@ -438,7 +462,7 @@ blueprints/
 
 **Rules:**
 
-- **Committed by default:** `SPEC.md`, `TLDR.md`, `state.json`, `interview.json`, `context.json`, `decisions.md`, `changelog.md`, `reviews/` (incl. `round.json`).
+- **Committed by default:** `SPEC.md`, `TLDR.md`, `state.json`, `interview.json`, `context.json`, `decisions.md`, `changelog.md`, `architecture.json`, `reviews/` (incl. `round.json`).
 - **Not committed by default:** `transcripts/`, `cache/`, `.lock`. Opt-in retention for transcripts via `samospec config set storage.retain_transcripts true`; trimmed + redacted either way.
 - **Secrets redaction.** Regex corpus drawn from the gitleaks and truffleHog rule sets. Tightened patterns:
   - AWS: `AKIA[0-9A-Z]{16}`, `ASIA[0-9A-Z]{16}`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `resume` all maintain architecture.json and re-render the SPEC.md
   block from it each round.
 
+### Known limitations
+
+- Architecture schema + ASCII diagram shipped (#107); the lead adapter
+  does not yet populate `architecture.json`, so all specs produced by
+  this release render the `(architecture not yet specified)`
+  placeholder. Lead-prompt enrichment tracked as a follow-up.
+
 ---
 
 ## [0.4.1] - 2026-04-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Architecture schema + ASCII diagram (#107):** every spec now ships a
+  machine-readable `.samo/spec/<slug>/architecture.json` (Zod-validated;
+  `version: "1"`, nodes/edges/groups/notes) alongside SPEC.md, and an
+  auto-rendered ASCII diagram embedded between
+  `<!-- architecture:begin -->` / `<!-- architecture:end -->` sentinels
+  inside SPEC.md. The renderer is deterministic, capped at 80 columns
+  hard and ~40 lines soft (sibling groups collapse to `[N label]` when
+  the soft cap trips), and zero-node schemas render a
+  `(architecture not yet specified)` placeholder. `new`, `iterate`, and
+  `resume` all maintain architecture.json and re-render the SPEC.md
+  block from it each round.
+
 ---
 
 ## [0.4.1] - 2026-04-21

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ At every step: `samospec status <slug>` prints phase, current version, next-step
 
 Every generated `SPEC.md` gets nine mandatory sections by default (goal & why, user stories, architecture, implementation details, tests plan with red/green TDD, team of veteran experts, sprint plan, embedded changelog, version header). Pass `--skip` to opt out.
 
+Every spec also ships a machine-readable `.samo/spec/<slug>/architecture.json` (Zod-validated; nodes/edges/groups/notes) and an auto-rendered 80-column ASCII diagram embedded in SPEC.md between `<!-- architecture:begin -->` / `<!-- architecture:end -->` sentinels. `iterate` re-renders the block from `architecture.json` on every round, so the diagram stays in lockstep with the schema.
+
 ---
 
 ## Auth — OAuth is the happy path

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -55,7 +55,9 @@ import {
   shouldStartNextRound,
   type CallTimeoutsMs,
 } from "../policy/wallclock.ts";
+import { injectArchitectureBlock } from "../render/architecture-spec.ts";
 import { renderTldr } from "../render/tldr.ts";
+import { readArchitectureOrEmpty } from "../state/architecture-store.ts";
 import {
   acquireLock,
   releaseLock,
@@ -654,7 +656,17 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
 
         // Write spec + TLDR + decisions + changelog, bump version, commit.
         if (roundOutcome.revisedSpec !== undefined) {
-          const newSpec = ensureTrailingNewline(roundOutcome.revisedSpec);
+          // #107: re-render the architecture block from architecture.json
+          // on every round. The JSON is the source of truth; even if the
+          // lead rewrote SPEC.md prose this round, the ASCII block stays
+          // a deterministic function of the schema.
+          const architecture = readArchitectureOrEmpty(paths.architecturePath);
+          const newSpec = ensureTrailingNewline(
+            injectArchitectureBlock(
+              ensureTrailingNewline(roundOutcome.revisedSpec),
+              architecture,
+            ),
+          );
           writeFileSync(paths.specPath, newSpec, "utf8");
           // TLDR is re-rendered in finishIterate once `exit` is set so
           // the Next-action section reflects convergence. Render here
@@ -743,6 +755,13 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
                 path.relative(input.cwd, paths.decisionsPath),
                 path.relative(input.cwd, paths.changelogPath),
                 path.relative(input.cwd, dirs.roundJson),
+                // #107: include architecture.json whenever it exists,
+                // so iterate rounds track schema changes in git alongside
+                // SPEC.md. Older specs that predate this feature simply
+                // skip this path.
+                ...(existsSync(paths.architecturePath)
+                  ? [path.relative(input.cwd, paths.architecturePath)]
+                  : []),
                 ...(existsSync(dirs.codexPath)
                   ? [path.relative(input.cwd, dirs.codexPath)]
                   : []),

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -54,7 +54,13 @@ import {
   preflightConfigFromParsed,
   type PreflightAdapter,
 } from "../policy/preflight.ts";
+import { injectArchitectureBlock } from "../render/architecture-spec.ts";
 import { renderTldr } from "../render/tldr.ts";
+import {
+  readArchitectureOrEmpty,
+  writeArchitecture,
+} from "../state/architecture-store.ts";
+import { emptyArchitecture } from "../state/architecture.ts";
 import {
   LockContendedError,
   acquireLock,
@@ -724,9 +730,22 @@ export async function runNew(
     const tldrPath = path.join(slugDir, "TLDR.md");
     const decisionsPath = path.join(slugDir, "decisions.md");
     const changelogPath = path.join(slugDir, "changelog.md");
+    const architecturePath = path.join(slugDir, "architecture.json");
 
-    // SPEC.md: lead's draft verbatim.
-    writeFileSync(specPath, ensureTrailingNewline(draft.spec), "utf8");
+    // #107: initial architecture.json is the empty placeholder. The
+    // lead adapter doesn't author architecture for v0.1 of this feature
+    // — the JSON is the source of truth, and the ASCII renderer
+    // substitutes `(architecture not yet specified)` on render. Later
+    // versions will extend the lead prompt to emit a richer schema.
+    writeArchitecture(architecturePath, emptyArchitecture());
+
+    // SPEC.md: lead's draft with the sentinel-delimited architecture
+    // block injected (or appended when no Architecture heading exists).
+    const specWithArchitecture = injectArchitectureBlock(
+      ensureTrailingNewline(draft.spec),
+      readArchitectureOrEmpty(architecturePath),
+    );
+    writeFileSync(specPath, ensureTrailingNewline(specWithArchitecture), "utf8");
 
     // TLDR.md: heuristic render. Pass state so the Next-action section
     // is derived from state via computeNextAction (#96).
@@ -803,6 +822,9 @@ export async function runNew(
             path.relative(input.cwd, path.join(slugDir, "context.json")),
             path.relative(input.cwd, path.join(slugDir, "decisions.md")),
             path.relative(input.cwd, path.join(slugDir, "changelog.md")),
+            // #107: architecture.json joins the per-round committed
+            // artifacts so git tracks every schema change across iterate.
+            path.relative(input.cwd, architecturePath),
           ],
         });
         notice(
@@ -1110,6 +1132,8 @@ export interface SpecPaths {
   readonly contextPath: string;
   readonly decisionsPath: string;
   readonly changelogPath: string;
+  /** #107 — machine-readable architecture schema alongside SPEC.md. */
+  readonly architecturePath: string;
 }
 
 export function specPaths(cwd: string, slug: string): SpecPaths {
@@ -1124,6 +1148,7 @@ export function specPaths(cwd: string, slug: string): SpecPaths {
     contextPath: path.join(slugDir, "context.json"),
     decisionsPath: path.join(slugDir, "decisions.md"),
     changelogPath: path.join(slugDir, "changelog.md"),
+    architecturePath: path.join(slugDir, "architecture.json"),
   };
 }
 

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -745,7 +745,11 @@ export async function runNew(
       ensureTrailingNewline(draft.spec),
       readArchitectureOrEmpty(architecturePath),
     );
-    writeFileSync(specPath, ensureTrailingNewline(specWithArchitecture), "utf8");
+    writeFileSync(
+      specPath,
+      ensureTrailingNewline(specWithArchitecture),
+      "utf8",
+    );
 
     // TLDR.md: heuristic render. Pass state so the Next-action section
     // is derived from state via computeNextAction (#96).

--- a/src/cli/resume.ts
+++ b/src/cli/resume.ts
@@ -29,7 +29,13 @@ import { contextJsonPath, writeContextJson } from "../context/provenance.ts";
 import { specCommit } from "../git/commit.ts";
 import { ProtectedBranchError } from "../git/errors.ts";
 import { writeCalibrationSample } from "../policy/calibration.ts";
+import { injectArchitectureBlock } from "../render/architecture-spec.ts";
 import { renderTldr } from "../render/tldr.ts";
+import {
+  readArchitectureOrEmpty,
+  writeArchitecture,
+} from "../state/architecture-store.ts";
+import { emptyArchitecture } from "../state/architecture.ts";
 import {
   LockContendedError,
   acquireLock,
@@ -340,7 +346,25 @@ export async function runResume(
         throw err;
       }
 
-      writeFileSync(paths.specPath, ensureTrailingNewline(draft.spec), "utf8");
+      // #107: seed architecture.json (empty placeholder) the same way
+      // runNew does on its happy path so resumed drafts ship the same
+      // file set. Idempotent — if a prior partial run already wrote
+      // architecture.json we keep whatever's on disk.
+      if (!existsSync(paths.architecturePath)) {
+        writeArchitecture(paths.architecturePath, emptyArchitecture());
+      }
+      const architectureForDraft = readArchitectureOrEmpty(
+        paths.architecturePath,
+      );
+      const specWithArchitecture = injectArchitectureBlock(
+        ensureTrailingNewline(draft.spec),
+        architectureForDraft,
+      );
+      writeFileSync(
+        paths.specPath,
+        ensureTrailingNewline(specWithArchitecture),
+        "utf8",
+      );
       writeFileSync(
         paths.tldrPath,
         renderTldr(draft.spec, { slug: input.slug, state: nextState }),
@@ -398,6 +422,10 @@ export async function runResume(
               relative(input.cwd, paths.contextPath),
               relative(input.cwd, paths.decisionsPath),
               relative(input.cwd, paths.changelogPath),
+              // #107: architecture.json is a committed artifact alongside
+              // SPEC.md. Added to the commit set here so resume leaves a
+              // file set identical to runNew's happy path (SPEC §13.5).
+              relative(input.cwd, paths.architecturePath),
             ],
           });
           notice(`committed spec(${input.slug}): draft v0.1`);

--- a/src/render/architecture-ascii.ts
+++ b/src/render/architecture-ascii.ts
@@ -108,7 +108,9 @@ function renderBody(doc: Architecture, opts: RenderOpts): string {
     lines.push("");
     lines.push("groups:");
     for (const g of doc.groups) {
-      lines.push(truncateLine(`- ${g.id} (${g.label}): ${g.members.join(", ")}`));
+      lines.push(
+        truncateLine(`- ${g.id} (${g.label}): ${g.members.join(", ")}`),
+      );
     }
   }
 

--- a/src/render/architecture-ascii.ts
+++ b/src/render/architecture-ascii.ts
@@ -1,0 +1,215 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §3 + Issue #107 — deterministic ASCII renderer for an
+ * architecture schema. Pure function of the input; no clocks, no
+ * randomness.
+ *
+ * Contract (locked in the #107 scope comment):
+ *   - Hard cap: every line <= 80 columns.
+ *   - Soft cap: ~40 lines. When exceeded, sibling groups collapse
+ *     to a single `[N <label>]` pill so the diagram still fits one
+ *     terminal screen.
+ *   - Labels exceeding the visible-label budget are truncated with
+ *     `…`; the full label stays in architecture.json.
+ *   - Zero-node schemas render as the literal placeholder
+ *     `(architecture not yet specified)` (single line).
+ *
+ * Layout (v0.1): top-down by schema order, one box per node, arrows
+ * listed in an Edges section below. Intentionally NOT a general graph
+ * layout — see non-goals in #107.
+ */
+
+import type { Architecture, ArchitectureNode } from "../state/architecture.ts";
+
+// ---------- constants ----------
+
+/** Hard column cap per SPEC.md terminal-viewer guidance. */
+const MAX_COLS = 80;
+/** Soft line cap before group-collapse kicks in. */
+const SOFT_LINES = 40;
+/** Leading indent for inter-node connector rows. */
+const CONNECTOR_INDENT = "  ";
+/** Inner-box horizontal padding (one column each side). */
+const BOX_PAD = 2;
+/** The ellipsis character used for label truncation. */
+const ELLIPSIS = "…";
+
+// ---------- public API ----------
+
+export function renderArchitectureAscii(doc: Architecture): string {
+  if (doc.nodes.length === 0) {
+    return "(architecture not yet specified)";
+  }
+
+  // First attempt: full render with group members expanded inline.
+  const full = renderBody(doc, { collapseGroups: false });
+  if (countLines(full) <= SOFT_LINES) {
+    return full;
+  }
+  // Soft cap exceeded — collapse groups to counts.
+  return renderBody(doc, { collapseGroups: true });
+}
+
+// ---------- internal render ----------
+
+interface RenderOpts {
+  readonly collapseGroups: boolean;
+}
+
+/**
+ * Assemble the full diagram body as a newline-joined string. Both the
+ * uncollapsed and collapsed passes share this so behavior stays
+ * symmetric except for how group members are expanded.
+ */
+function renderBody(doc: Architecture, opts: RenderOpts): string {
+  const lines: string[] = [];
+  const groupIds = new Set((doc.groups ?? []).map((g) => g.id));
+  const nodesById = new Map<string, ArchitectureNode>(
+    doc.nodes.map((n) => [n.id, n]),
+  );
+
+  // Which node ids belong to a collapsed group? Those nodes are
+  // rendered once via the group pill, never as a standalone box.
+  const collapsedMemberIds = new Set<string>();
+  if (opts.collapseGroups && doc.groups !== undefined) {
+    for (const g of doc.groups) {
+      for (const m of g.members) collapsedMemberIds.add(m);
+    }
+  }
+
+  // --- nodes section ---
+  const renderedPills = new Set<string>();
+
+  for (const node of doc.nodes) {
+    if (collapsedMemberIds.has(node.id)) {
+      // Render the owning group's pill on first encounter; skip on
+      // subsequent member iterations so members collapse into a single
+      // pill in their original schema position.
+      if (opts.collapseGroups && doc.groups !== undefined) {
+        const owner = doc.groups.find((g) => g.members.includes(node.id));
+        if (owner !== undefined && !renderedPills.has(owner.id)) {
+          renderedPills.add(owner.id);
+          const pill = `[${owner.members.length.toString()} ${owner.label}]`;
+          lines.push(...renderBox(pill, "group"));
+        }
+      }
+      continue;
+    }
+    lines.push(...renderBox(formatNodeLabel(node), node.kind));
+  }
+
+  // --- expanded groups section (only when groups aren't collapsed) ---
+  if (
+    !opts.collapseGroups &&
+    doc.groups !== undefined &&
+    doc.groups.length > 0
+  ) {
+    lines.push("");
+    lines.push("groups:");
+    for (const g of doc.groups) {
+      lines.push(truncateLine(`- ${g.id} (${g.label}): ${g.members.join(", ")}`));
+    }
+  }
+
+  // --- edges section ---
+  if (doc.edges.length > 0) {
+    lines.push("");
+    lines.push("edges:");
+    for (const e of doc.edges) {
+      const kindMark = e.kind === "call" ? "→" : e.kind === "data" ? "⇢" : "⇒";
+      // Sanity: if either endpoint's node is collapsed, show the owning
+      // group id instead. This keeps the collapsed diagram consistent.
+      const from = remapCollapsed(e.from, doc, opts, groupIds, nodesById);
+      const to = remapCollapsed(e.to, doc, opts, groupIds, nodesById);
+      const label = e.label === undefined ? "" : ` [${e.label}]`;
+      lines.push(truncateLine(`- ${from} ${kindMark} ${to}${label}`));
+    }
+  }
+
+  // --- notes section ---
+  if (doc.notes !== undefined && doc.notes.length > 0) {
+    lines.push("");
+    lines.push("notes:");
+    for (const n of doc.notes) {
+      lines.push(truncateLine(`- ${n}`));
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// ---------- box rendering ----------
+
+/**
+ * Render a 3-line box for a node label + its kind, e.g.:
+ *
+ *   ┌──────────────────┐
+ *   │ User (external)  │
+ *   └──────────────────┘
+ *
+ * The label is pre-truncated if it would make the box exceed 80 cols.
+ */
+function renderBox(innerLabel: string, kind: string): string[] {
+  const label = `${innerLabel}${kind === "group" ? "" : ` (${kind})`}`;
+  // Budget: MAX_COLS − indent − 2 box bars − BOX_PAD padding columns.
+  const maxInner = MAX_COLS - CONNECTOR_INDENT.length - 2 - BOX_PAD;
+  const shown = truncate(label, maxInner);
+  const width = shown.length + BOX_PAD;
+  const top = `${CONNECTOR_INDENT}┌${"─".repeat(width)}┐`;
+  const mid = `${CONNECTOR_INDENT}│ ${shown}${" ".repeat(width - shown.length - 1)}│`;
+  const bot = `${CONNECTOR_INDENT}└${"─".repeat(width)}┘`;
+  return [top, mid, bot];
+}
+
+function formatNodeLabel(n: ArchitectureNode): string {
+  return n.label;
+}
+
+// ---------- label / line truncation ----------
+
+/**
+ * Cap `s` at `max` visual columns. When the raw string is already
+ * within the limit, return as-is; otherwise reserve one column for `…`.
+ */
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  if (max <= 1) return ELLIPSIS;
+  return `${s.slice(0, max - 1)}${ELLIPSIS}`;
+}
+
+/**
+ * Per-line guard used for edge / group / note lines. Keeps the hard
+ * 80-col invariant without tying width to any particular box-drawing
+ * shape.
+ */
+function truncateLine(s: string): string {
+  return truncate(s, MAX_COLS);
+}
+
+function countLines(s: string): number {
+  // `split("\n")` always yields >= 1 element for a non-empty string.
+  return s.split("\n").length;
+}
+
+// ---------- edge endpoint remapping ----------
+
+function remapCollapsed(
+  id: string,
+  doc: Architecture,
+  opts: RenderOpts,
+  groupIds: Set<string>,
+  nodesById: Map<string, ArchitectureNode>,
+): string {
+  // Group ids always render as-is.
+  if (groupIds.has(id)) return id;
+  // Node ids stay as-is unless the group-collapse pass has folded them
+  // into a group pill — in which case we replace with the owning group's
+  // id so the edge terminates at the right visible element.
+  if (!opts.collapseGroups || doc.groups === undefined) return id;
+  if (!nodesById.has(id)) return id;
+  for (const g of doc.groups) {
+    if (g.members.includes(id)) return g.id;
+  }
+  return id;
+}

--- a/src/render/architecture-spec.ts
+++ b/src/render/architecture-spec.ts
@@ -46,11 +46,7 @@ export function injectArchitectureBlock(
   // Case 1: sentinels already exist — swap the body.
   const begin = spec.indexOf(ARCHITECTURE_BEGIN_SENTINEL);
   const end = spec.indexOf(ARCHITECTURE_END_SENTINEL);
-  if (
-    begin !== -1 &&
-    end !== -1 &&
-    end > begin
-  ) {
+  if (begin !== -1 && end !== -1 && end > begin) {
     const before = spec.slice(0, begin);
     const after = spec.slice(end + ARCHITECTURE_END_SENTINEL.length);
     return `${before}${block}${after}`;

--- a/src/render/architecture-spec.ts
+++ b/src/render/architecture-spec.ts
@@ -1,0 +1,96 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §3 + Issue #107 — SPEC.md integration for the architecture
+ * diagram. Given a SPEC.md string and an Architecture, emit a new
+ * SPEC.md with a sentinel-delimited ASCII block either replaced
+ * (when sentinels exist) or injected (when they don't).
+ *
+ * Design note: we chose post-processing over augmenting the lead
+ * adapter's prompt. Reasons:
+ *   - Determinism: the block is a pure function of architecture.json,
+ *     independent of however the lead phrased SPEC.md this round.
+ *   - Round-trip safety: iterate may regenerate SPEC.md text every
+ *     round; the block is always re-rendered from JSON so it can't
+ *     drift from the schema.
+ *   - Backward compatibility: specs without sentinels get them added
+ *     additively. No existing file gets its prose rearranged.
+ *
+ * Sentinel grammar: literal HTML comments so they survive Markdown
+ * rendering on GitHub / local viewers and are trivial to regex.
+ */
+
+import type { Architecture } from "../state/architecture.ts";
+import { renderArchitectureAscii } from "./architecture-ascii.ts";
+
+export const ARCHITECTURE_BEGIN_SENTINEL = "<!-- architecture:begin -->";
+export const ARCHITECTURE_END_SENTINEL = "<!-- architecture:end -->";
+
+// Matches an optional one-line Markdown heading containing the word
+// "Architecture" (case-insensitive). Used to find an insertion point
+// when sentinels are absent. Whitespace-lenient on purpose — specs in
+// the wild use `## Architecture`, `## 3. Architecture`, `### System
+// architecture`, etc.
+const ARCHITECTURE_HEADING_RE = /^(#{2,6})\s+.*architecture\b.*$/im;
+
+/**
+ * Replace or inject the architecture block in `spec`. Returns a new
+ * string; never mutates. Pure function of its inputs.
+ */
+export function injectArchitectureBlock(
+  spec: string,
+  doc: Architecture,
+): string {
+  const block = renderBlock(doc);
+
+  // Case 1: sentinels already exist — swap the body.
+  const begin = spec.indexOf(ARCHITECTURE_BEGIN_SENTINEL);
+  const end = spec.indexOf(ARCHITECTURE_END_SENTINEL);
+  if (
+    begin !== -1 &&
+    end !== -1 &&
+    end > begin
+  ) {
+    const before = spec.slice(0, begin);
+    const after = spec.slice(end + ARCHITECTURE_END_SENTINEL.length);
+    return `${before}${block}${after}`;
+  }
+
+  // Case 2: an Architecture heading exists — insert the block right
+  // after the heading's blank line so existing prose stays below it.
+  const headingMatch = ARCHITECTURE_HEADING_RE.exec(spec);
+  if (headingMatch !== null) {
+    const headingEnd = (headingMatch.index ?? 0) + headingMatch[0].length;
+    const before = spec.slice(0, headingEnd);
+    const after = spec.slice(headingEnd);
+    const joiner = spec.startsWith("\n", headingEnd) ? "\n\n" : "\n\n";
+    return `${before}${joiner}${block}${after.startsWith("\n") ? "" : "\n"}${after}`;
+  }
+
+  // Case 3: no heading either — append a new `## Architecture` section
+  // at the end of the document. Additive: existing text is preserved
+  // verbatim.
+  const trailingNewline = spec.endsWith("\n") ? "" : "\n";
+  const section = `## Architecture\n\n${block}\n`;
+  return `${spec}${trailingNewline}\n${section}`;
+}
+
+/**
+ * Produce the sentinel-delimited block body (including both sentinels
+ * and a fenced `text` code block for the diagram). The fence tags the
+ * content as `text` so Markdown renderers do not try to interpret the
+ * box-drawing characters; viewers still show the ASCII as intended.
+ */
+function renderBlock(doc: Architecture): string {
+  const ascii = renderArchitectureAscii(doc);
+  const lines: string[] = [
+    ARCHITECTURE_BEGIN_SENTINEL,
+    "",
+    "```text",
+    ascii,
+    "```",
+    "",
+    ARCHITECTURE_END_SENTINEL,
+  ];
+  return lines.join("\n");
+}

--- a/src/state/architecture-store.ts
+++ b/src/state/architecture-store.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §3 + Issue #107 — atomic read/write for architecture.json.
+ * Mirrors the state/store.ts atomicity pattern (temp file + fsync +
+ * rename) so a crash mid-write leaves either the old file or nothing.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import path from "node:path";
+
+import {
+  architectureSchema,
+  emptyArchitecture,
+  type Architecture,
+} from "./architecture.ts";
+
+/**
+ * Read architecture.json from disk. Returns `null` when the file is
+ * absent. Throws on I/O or schema errors so the CLI surfaces the
+ * problem as an exit-1 "state is malformed" rather than silently
+ * falling back to the empty document.
+ */
+export function readArchitecture(file: string): Architecture | null {
+  if (!existsSync(file)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch (err) {
+    throw new Error(
+      `architecture.json at ${file} could not be read: ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `architecture.json at ${file} is not valid JSON: ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+  const result = architectureSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `architecture.json at ${file} failed schema validation: ${result.error.message}`,
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Read architecture.json, falling back to `emptyArchitecture()` when
+ * the file is absent. Used by render/iterate paths that always want a
+ * document to pass to the ASCII renderer.
+ */
+export function readArchitectureOrEmpty(file: string): Architecture {
+  return readArchitecture(file) ?? emptyArchitecture();
+}
+
+/**
+ * Atomic write: validate → write to `.tmp.<pid>` sibling → fsync →
+ * rename over the target → fsync the parent dir. Refuses to write an
+ * invalid document.
+ */
+export function writeArchitecture(file: string, doc: Architecture): void {
+  const parsed = architectureSchema.safeParse(doc);
+  if (!parsed.success) {
+    throw new Error(
+      `refusing to write invalid architecture to ${file}: ${parsed.error.message}`,
+    );
+  }
+  const dir = path.dirname(file);
+  mkdirSync(dir, { recursive: true });
+  const tmp = path.join(dir, `.${path.basename(file)}.tmp.${process.pid}`);
+  const payload = `${JSON.stringify(parsed.data, null, 2)}\n`;
+  const fd = openSync(tmp, "w", 0o644);
+  try {
+    writeSync(fd, payload, 0, "utf8");
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  try {
+    renameSync(tmp, file);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+  try {
+    const dfd = openSync(dir, "r");
+    try {
+      fsyncSync(dfd);
+    } finally {
+      closeSync(dfd);
+    }
+  } catch {
+    // Windows + some filesystems disallow directory fsync; rename
+    // remains atomic.
+  }
+}

--- a/src/state/architecture.ts
+++ b/src/state/architecture.ts
@@ -1,0 +1,174 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+/**
+ * SPEC §3 + Issue #107 — structured architecture schema.
+ *
+ * Canonical machine-readable representation of a spec's architecture:
+ * a small graph of nodes + edges, with optional groups for sibling
+ * collapse in the ASCII renderer and free-form notes.
+ *
+ * This module only validates + parses. The ASCII renderer lives in
+ * `src/render/architecture-ascii.ts`; the SPEC.md injection helpers
+ * live in `src/render/architecture-spec.ts`. Keeping those concerns
+ * separate so the schema is the sole source of truth — renderers are
+ * pure functions of the schema.
+ *
+ * Scope decisions (locked in issue #107 scope comment):
+ *   - `version: "1"` only. No migration path yet.
+ *   - Node kinds: external | component | datastore | boundary.
+ *   - Edge kinds: call | data | control.
+ *   - IDs must be unique across nodes + groups.
+ *   - Every edge endpoint must resolve to a node id OR a group id.
+ *   - Every group member must resolve to a node id.
+ *   - Zero-node schemas are valid (rendered as a placeholder).
+ */
+
+import { z } from "zod";
+
+export const ARCHITECTURE_NODE_KINDS = [
+  "external",
+  "component",
+  "datastore",
+  "boundary",
+] as const;
+export type ArchitectureNodeKind = (typeof ARCHITECTURE_NODE_KINDS)[number];
+
+export const ARCHITECTURE_EDGE_KINDS = ["call", "data", "control"] as const;
+export type ArchitectureEdgeKind = (typeof ARCHITECTURE_EDGE_KINDS)[number];
+
+/** ID grammar: lowercase letters, digits, hyphen/underscore. 1..64 chars. */
+const idSchema = z
+  .string()
+  .regex(
+    /^[a-z0-9][a-z0-9_-]{0,63}$/,
+    "id must be lowercase alphanumeric with '-' or '_' (1-64 chars)",
+  );
+
+/** Labels are free-form user prose but must be single-line + bounded. */
+const labelSchema = z
+  .string()
+  .min(1, "label must be non-empty")
+  .max(256, "label must be <= 256 chars")
+  .refine((s) => !/[\r\n]/.test(s), "label must be single-line");
+
+export const architectureNodeSchema = z
+  .object({
+    id: idSchema,
+    label: labelSchema,
+    kind: z.enum(ARCHITECTURE_NODE_KINDS),
+  })
+  .strict();
+export type ArchitectureNode = z.infer<typeof architectureNodeSchema>;
+
+export const architectureEdgeSchema = z
+  .object({
+    from: idSchema,
+    to: idSchema,
+    label: labelSchema.optional(),
+    kind: z.enum(ARCHITECTURE_EDGE_KINDS),
+  })
+  .strict();
+export type ArchitectureEdge = z.infer<typeof architectureEdgeSchema>;
+
+export const architectureGroupSchema = z
+  .object({
+    id: idSchema,
+    label: labelSchema,
+    members: z.array(idSchema).min(1, "group must have >= 1 member"),
+  })
+  .strict();
+export type ArchitectureGroup = z.infer<typeof architectureGroupSchema>;
+
+/**
+ * Core architecture document. The `superRefine` pass enforces cross-
+ * field invariants that plain Zod shape can't (unique ids, edge
+ * endpoint resolution, group membership resolution).
+ */
+export const architectureSchema = z
+  .object({
+    version: z.literal("1"),
+    nodes: z.array(architectureNodeSchema),
+    edges: z.array(architectureEdgeSchema),
+    groups: z.array(architectureGroupSchema).optional(),
+    notes: z.array(z.string().min(1).max(512)).optional(),
+  })
+  .strict()
+  .superRefine((doc, ctx) => {
+    const nodeIds = new Set<string>();
+    for (const [i, n] of doc.nodes.entries()) {
+      if (nodeIds.has(n.id)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["nodes", i, "id"],
+          message: `duplicate node id '${n.id}'`,
+        });
+      }
+      nodeIds.add(n.id);
+    }
+    const groupIds = new Set<string>();
+    const groupMemberIds = new Set<string>();
+    if (doc.groups !== undefined) {
+      for (const [i, g] of doc.groups.entries()) {
+        if (groupIds.has(g.id) || nodeIds.has(g.id)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["groups", i, "id"],
+            message: `duplicate id '${g.id}' (clashes with a node or group)`,
+          });
+        }
+        groupIds.add(g.id);
+        for (const [j, m] of g.members.entries()) {
+          if (!nodeIds.has(m)) {
+            ctx.addIssue({
+              code: "custom",
+              path: ["groups", i, "members", j],
+              message: `group '${g.id}' member '${m}' does not resolve to a node`,
+            });
+          }
+          groupMemberIds.add(m);
+        }
+      }
+    }
+    const resolvable = new Set<string>([...nodeIds, ...groupIds]);
+    for (const [i, e] of doc.edges.entries()) {
+      if (!resolvable.has(e.from)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["edges", i, "from"],
+          message: `edge.from '${e.from}' does not resolve to a node or group`,
+        });
+      }
+      if (!resolvable.has(e.to)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["edges", i, "to"],
+          message: `edge.to '${e.to}' does not resolve to a node or group`,
+        });
+      }
+    }
+  });
+
+export type Architecture = z.infer<typeof architectureSchema>;
+
+/**
+ * Parse-or-throw: used by callers that have already confirmed the
+ * caller is in an error-path (CLI fails hard on a malformed JSON).
+ */
+export function parseArchitecture(raw: unknown): Architecture {
+  const result = architectureSchema.safeParse(raw);
+  if (!result.success) {
+    throw new Error(
+      `architecture.json failed schema validation: ${result.error.message}`,
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Empty placeholder document: version-1, no nodes. Produced by `new`
+ * when the lead adapter didn't emit an architecture (the ASCII
+ * renderer substitutes a `(architecture not yet specified)` block).
+ */
+export function emptyArchitecture(): Architecture {
+  return { version: "1", nodes: [], edges: [] };
+}

--- a/tests/cli/architecture-integration.test.ts
+++ b/tests/cli/architecture-integration.test.ts
@@ -4,130 +4,191 @@
 // new` emits an architecture.json and a sentinel-delimited ASCII block
 // in SPEC.md, and that iterate re-renders the block from architecture
 // .json on each round.
-//
-// Red-first: the hooks assert artifacts the current new/iterate don't
-// yet produce.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
-  rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
-import type { Adapter, AskInput, AskOutput } from "../../src/adapter/types.ts";
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  ReviseInput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { runIterate } from "../../src/cli/iterate.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { runInit } from "../../src/cli/init.ts";
+import { writeArchitecture } from "../../src/state/architecture-store.ts";
 import { parseArchitecture } from "../../src/state/architecture.ts";
+import { writeState } from "../../src/state/store.ts";
+import { createTempRepo, type TempRepo } from "../git/helpers/tempRepo.ts";
 
 function askOut(answer: string): AskOutput {
   return { answer, usage: null, effort_used: "max" };
 }
 
+function personaJson(): string {
+  return JSON.stringify({
+    persona: 'Veteran "architecture diagram" expert',
+    rationale: "matches the idea",
+  });
+}
+
+function questionsJson(): string {
+  return JSON.stringify({
+    questions: [
+      { id: "q1", text: "framework?", options: ["a", "b"] },
+      { id: "q2", text: "auth?", options: ["a", "b"] },
+    ],
+  });
+}
+
+const SAMPLE_SPEC =
+  "# arch-demo\n\n" +
+  "## Goal\n\nEmit diagrams alongside specs.\n\n" +
+  "## 3. Architecture\n\nInitial prose.\n\n" +
+  "## 4. Other\n\n- bullet\n";
+
 function makeLeadAdapter(): Adapter {
   const base = createFakeAdapter();
-  let call = 0;
-  const canned = [
-    // persona
-    JSON.stringify({
-      persona: 'Veteran "CLI tooling" expert',
-      rationale: "Matches the idea.",
-    }),
-    // interview Q1..Q5
-    JSON.stringify({ id: "Q1", text: "q?", options: [{ id: "a", text: "a" }] }),
-    JSON.stringify({ id: "Q2", text: "q?", options: [{ id: "a", text: "a" }] }),
-    JSON.stringify({ id: "Q3", text: "q?", options: [{ id: "a", text: "a" }] }),
-    JSON.stringify({ id: "Q4", text: "q?", options: [{ id: "a", text: "a" }] }),
-    JSON.stringify({ id: "Q5", text: "q?", options: [{ id: "a", text: "a" }] }),
-  ];
-  const ask = (input: AskInput): Promise<AskOutput> => {
-    const out = canned[call] ?? "{}";
-    call += 1;
-    return Promise.resolve(askOut(out));
-  };
+  const answers = [personaJson(), questionsJson()];
+  let askCall = 0;
   return {
     ...base,
-    vendor: "fake-lead",
-    ask,
-    revise: () =>
+    ask: (_input: AskInput): Promise<AskOutput> => {
+      const a = answers[askCall] ?? answers[answers.length - 1] ?? "";
+      askCall += 1;
+      return Promise.resolve(askOut(a));
+    },
+    revise: (_input: ReviseInput): Promise<ReviseOutput> =>
       Promise.resolve({
-        spec:
-          "# arch-demo\n\n## 3. Architecture\n\nPlaceholder prose.\n\n" +
-          "## 4. Other\n\nMore text.\n",
+        spec: SAMPLE_SPEC,
         ready: false,
-        rationale: "first draft",
+        rationale: "v0.1 draft",
         usage: null,
         effort_used: "max",
       }),
   };
 }
 
-async function runNewWithArchitecture(cwd: string, slug: string) {
-  await runInit({
-    cwd,
-    force: true,
-    yes: true,
-    interactiveFn: (): Promise<boolean> => Promise.resolve(true),
-  });
-  const adapter = makeLeadAdapter();
-  const resolvers: ChoiceResolvers = {
+function acceptResolver(): ChoiceResolvers {
+  return {
     persona: () => Promise.resolve({ kind: "accept" }),
-    question: (_q) => Promise.resolve({ kind: "choice", choice: "a" }),
+    question: (_q) => Promise.resolve({ choice: "decide for me" }),
   };
-  return await runNew(
-    {
-      cwd,
-      slug,
-      idea: "a CLI that emits architecture diagrams",
-      explain: false,
-      resolvers,
-      now: "2026-04-21T00:00:00.000Z",
-      noPush: true,
-    },
-    adapter,
-  );
 }
 
-let tmpRoot: string;
+// ---------- fixtures ----------
+
+let repo: TempRepo;
+let tmp: string;
 
 beforeEach(() => {
-  tmpRoot = mkdtempSync(path.join(tmpdir(), "arch107-"));
-  // Initialize a git repo so `samospec new` can branch + commit.
-  spawnSync("git", ["init", "--initial-branch=main", tmpRoot], {
-    encoding: "utf8",
-  });
-  spawnSync("git", ["-C", tmpRoot, "config", "user.email", "a@b.c"]);
-  spawnSync("git", ["-C", tmpRoot, "config", "user.name", "Test"]);
-  // Seed a minimal commit so HEAD resolves.
-  writeFileSync(path.join(tmpRoot, "README.md"), "seed\n");
-  spawnSync("git", ["-C", tmpRoot, "add", "README.md"]);
-  spawnSync("git", ["-C", tmpRoot, "commit", "-m", "seed"]);
+  repo = createTempRepo({ initialBranch: "work" });
+  tmp = repo.dir;
+  runInit({ cwd: tmp });
+  repo.run(["add", ".samo"]);
+  repo.run(["commit", "-m", "chore: init .samo"]);
 });
 
 afterEach(() => {
-  if (tmpRoot !== undefined) rmSync(tmpRoot, { recursive: true, force: true });
+  repo.cleanup();
 });
+
+// ---------- new ----------
+
+describe("samospec new — architecture.json + SPEC.md block (#107)", () => {
+  test("writes .samo/spec/<slug>/architecture.json parseable by the schema", async () => {
+    const slug = "arch-demo";
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug,
+        idea: "a CLI that emits architecture diagrams",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-21T00:00:00Z",
+        noPush: true,
+      },
+      makeLeadAdapter(),
+    );
+    expect(result.exitCode).toBe(0);
+    const archPath = path.join(
+      tmp,
+      ".samo",
+      "spec",
+      slug,
+      "architecture.json",
+    );
+    expect(existsSync(archPath)).toBe(true);
+    const doc = parseArchitecture(
+      JSON.parse(readFileSync(archPath, "utf8")) as unknown,
+    );
+    expect(doc.version).toBe("1");
+  });
+
+  test("SPEC.md contains the sentinel-delimited architecture block", async () => {
+    const slug = "arch-demo";
+    await runNew(
+      {
+        cwd: tmp,
+        slug,
+        idea: "a CLI that emits architecture diagrams",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-21T00:00:00Z",
+        noPush: true,
+      },
+      makeLeadAdapter(),
+    );
+    const spec = readFileSync(
+      path.join(tmp, ".samo", "spec", slug, "SPEC.md"),
+      "utf8",
+    );
+    expect(spec).toContain("<!-- architecture:begin -->");
+    expect(spec).toContain("<!-- architecture:end -->");
+    // Empty architecture => placeholder inside the sentinels.
+    expect(spec).toContain("(architecture not yet specified)");
+  });
+
+  test("architecture.json is tracked in git on the first commit (#94)", async () => {
+    const slug = "arch-demo";
+    await runNew(
+      {
+        cwd: tmp,
+        slug,
+        idea: "a CLI that emits architecture diagrams",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: "2026-04-21T00:00:00Z",
+        noPush: true,
+      },
+      makeLeadAdapter(),
+    );
+    const lsFiles = repo.run([
+      "ls-files",
+      "--error-unmatch",
+      `.samo/spec/${slug}/architecture.json`,
+    ]);
+    expect(lsFiles.status).toBe(0);
+  });
+});
+
+// ---------- iterate ----------
 
 describe("samospec iterate — architecture block re-render (#107)", () => {
   test("re-renders the SPEC.md block from architecture.json each round", async () => {
-    // Lazily import iterate helpers to avoid a top-level circular build path.
-    const { runIterate } = await import("../../src/cli/iterate.ts");
-    const { writeState } = await import("../../src/state/store.ts");
-    const { writeArchitecture } = await import(
-      "../../src/state/architecture-store.ts"
-    );
     const slug = "arch-iter";
-    const slugDir = path.join(tmpRoot, ".samo", "spec", slug);
+    // Minimal spec on disk so iterate can load state + spec.
+    const slugDir = path.join(tmp, ".samo", "spec", slug);
     mkdirSync(slugDir, { recursive: true });
-    // Seed a SPEC.md with an empty architecture block so we can watch
-    // iterate replace it with the rendered version of architecture.json.
     const seededSpec = [
       "# SPEC",
       "",
@@ -168,8 +229,6 @@ describe("samospec iterate — architecture block re-render (#107)", () => {
         budget: { phase: "draft", tokens_used: 0, tokens_budget: 0 },
       }),
     );
-    // Seed a non-empty architecture.json so iterate re-renders a real
-    // box diagram, not the placeholder.
     writeArchitecture(path.join(slugDir, "architecture.json"), {
       version: "1",
       nodes: [
@@ -178,10 +237,6 @@ describe("samospec iterate — architecture block re-render (#107)", () => {
       ],
       edges: [{ from: "user", to: "app", kind: "call" }],
     });
-    // Switch to the spec branch so iterate can commit.
-    spawnSync("git", ["-C", tmpRoot, "checkout", "-b", `samospec/${slug}`]);
-    spawnSync("git", ["-C", tmpRoot, "add", ".samo"]);
-    spawnSync("git", ["-C", tmpRoot, "commit", "-m", `spec(${slug}): seed`]);
     writeState(path.join(slugDir, "state.json"), {
       slug,
       phase: "review_loop",
@@ -198,8 +253,9 @@ describe("samospec iterate — architecture block re-render (#107)", () => {
       created_at: "2026-04-21T00:00:00Z",
       updated_at: "2026-04-21T00:00:00Z",
     });
-    spawnSync("git", ["-C", tmpRoot, "add", ".samo"]);
-    spawnSync("git", ["-C", tmpRoot, "commit", "-m", `spec(${slug}): state`]);
+    repo.run(["checkout", "-b", `samospec/${slug}`]);
+    repo.run(["add", ".samo"]);
+    repo.run(["commit", "-m", `spec(${slug}): seed`]);
     const lead = {
       ...createFakeAdapter({
         revise: {
@@ -212,7 +268,7 @@ describe("samospec iterate — architecture block re-render (#107)", () => {
       }),
     };
     await runIterate({
-      cwd: tmpRoot,
+      cwd: tmp,
       slug,
       now: "2026-04-21T01:00:00Z",
       resolvers: {
@@ -235,59 +291,6 @@ describe("samospec iterate — architecture block re-render (#107)", () => {
     expect(spec).toContain("User");
     expect(spec).toContain("App");
     expect(spec).toContain("user → app");
-    // The placeholder has been replaced.
     expect(spec).not.toContain("(architecture not yet specified)");
-  });
-});
-
-describe("samospec new — architecture.json + SPEC.md block (#107)", () => {
-  test("writes .samo/spec/<slug>/architecture.json parseable by the schema", async () => {
-    const slug = "arch-demo";
-    const result = await runNewWithArchitecture(tmpRoot, slug);
-    expect(result.exitCode).toBe(0);
-    const archPath = path.join(
-      tmpRoot,
-      ".samo",
-      "spec",
-      slug,
-      "architecture.json",
-    );
-    expect(existsSync(archPath)).toBe(true);
-    const raw = JSON.parse(readFileSync(archPath, "utf8")) as unknown;
-    const doc = parseArchitecture(raw);
-    // v0.1 of this feature starts with an empty architecture unless
-    // the lead adapter contributes one. The renderer substitutes the
-    // placeholder at render time; both are valid states for the JSON.
-    expect(doc.version).toBe("1");
-  });
-
-  test("SPEC.md contains the sentinel-delimited architecture block", async () => {
-    const slug = "arch-demo";
-    await runNewWithArchitecture(tmpRoot, slug);
-    const spec = readFileSync(
-      path.join(tmpRoot, ".samo", "spec", slug, "SPEC.md"),
-      "utf8",
-    );
-    expect(spec).toContain("<!-- architecture:begin -->");
-    expect(spec).toContain("<!-- architecture:end -->");
-    // Placeholder for a zero-node architecture.
-    expect(spec).toContain("(architecture not yet specified)");
-  });
-
-  test("architecture.json is tracked in git on the first commit (#94)", async () => {
-    const slug = "arch-demo";
-    await runNewWithArchitecture(tmpRoot, slug);
-    const lsFiles = spawnSync(
-      "git",
-      [
-        "-C",
-        tmpRoot,
-        "ls-files",
-        "--error-unmatch",
-        `.samo/spec/${slug}/architecture.json`,
-      ],
-      { encoding: "utf8" },
-    );
-    expect(lsFiles.status).toBe(0);
   });
 });

--- a/tests/cli/architecture-integration.test.ts
+++ b/tests/cli/architecture-integration.test.ts
@@ -2,8 +2,9 @@
 
 // SPEC §3 + Issue #107 — integration tests asserting that `samospec
 // new` emits an architecture.json and a sentinel-delimited ASCII block
-// in SPEC.md, and that iterate re-renders the block from architecture
-// .json on each round.
+// in SPEC.md, that iterate re-renders the block from architecture.json
+// on each round, and that resume seeds/preserves architecture.json and
+// commits it alongside SPEC.md (the new + iterate + resume triad).
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -20,8 +21,15 @@ import type {
 import { runIterate } from "../../src/cli/iterate.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { runInit } from "../../src/cli/init.ts";
-import { writeArchitecture } from "../../src/state/architecture-store.ts";
-import { parseArchitecture } from "../../src/state/architecture.ts";
+import { runResume } from "../../src/cli/resume.ts";
+import {
+  readArchitectureOrEmpty,
+  writeArchitecture,
+} from "../../src/state/architecture-store.ts";
+import {
+  emptyArchitecture,
+  parseArchitecture,
+} from "../../src/state/architecture.ts";
 import { writeState } from "../../src/state/store.ts";
 import { createTempRepo, type TempRepo } from "../git/helpers/tempRepo.ts";
 
@@ -281,5 +289,183 @@ describe("samospec iterate — architecture block re-render (#107)", () => {
     expect(spec).toContain("App");
     expect(spec).toContain("user → app");
     expect(spec).not.toContain("(architecture not yet specified)");
+  });
+});
+
+// ---------- resume ----------
+//
+// These tests exercise runResume's "Case C" path (persona + interview
+// on disk, SPEC.md missing — resume re-runs the draft). They complete
+// the new + iterate + resume triad required by issue #107: coverage is
+// retroactive (the resume wiring in src/cli/resume.ts already seeds +
+// preserves + commits architecture.json, see lines 349-363 / 428), but
+// without these tests the idempotency note on resume.ts:352 and the
+// architecturePath entry in the specCommit paths array are unverified.
+
+// Adapter for the *resume* leg: persona is already on disk, so the
+// first ask is the interview's questions call, and revise() is the
+// draft call. Sequenced to match the single expected ask.
+function makeResumeAdapter(): Adapter {
+  const base = createFakeAdapter();
+  const answers = [questionsJson()];
+  let askCall = 0;
+  return {
+    ...base,
+    ask: (_input: AskInput): Promise<AskOutput> => {
+      const a = answers[askCall] ?? answers[answers.length - 1] ?? "";
+      askCall += 1;
+      return Promise.resolve(askOut(a));
+    },
+    revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+      Promise.resolve({
+        spec: SAMPLE_SPEC,
+        ready: false,
+        rationale: "v0.1 draft (resumed)",
+        usage: null,
+        effort_used: "max",
+      }),
+  };
+}
+
+describe("samospec resume — architecture.json + SPEC.md block (#107)", () => {
+  // Drives runNew to the point where state.json + persona are written
+  // but the interview rejects, so interview.json / SPEC.md / architecture
+  // .json are absent on disk — exactly the shape that resume's Case C
+  // expects.
+  async function seedDraftPhaseWithKilledInterview(
+    slug: string,
+  ): Promise<void> {
+    const killResolvers: ChoiceResolvers = {
+      persona: () => Promise.resolve({ kind: "accept" }),
+      question: (_q) => Promise.reject(new Error("simulated kill")),
+    };
+    const first = await runNew(
+      {
+        cwd: tmp,
+        slug,
+        idea: "a CLI that emits architecture diagrams",
+        explain: false,
+        resolvers: killResolvers,
+        now: "2026-04-21T00:00:00Z",
+        noPush: true,
+      },
+      makeLeadAdapter(),
+    );
+    // Non-zero (interview was killed). Persona survives on disk.
+    expect(first.exitCode).not.toBe(0);
+    const slugDir = path.join(tmp, ".samo", "spec", slug);
+    expect(existsSync(path.join(slugDir, "state.json"))).toBe(true);
+    expect(existsSync(path.join(slugDir, "interview.json"))).toBe(false);
+    expect(existsSync(path.join(slugDir, "SPEC.md"))).toBe(false);
+  }
+
+  test("seeds the empty-placeholder architecture.json when missing", async () => {
+    const slug = "arch-resume-seed";
+    await seedDraftPhaseWithKilledInterview(slug);
+    const slugDir = path.join(tmp, ".samo", "spec", slug);
+    const archPath = path.join(slugDir, "architecture.json");
+    // Pre-condition: resume has not run yet, architecture.json is absent.
+    expect(existsSync(archPath)).toBe(false);
+
+    const result = await runResume(
+      {
+        cwd: tmp,
+        slug,
+        now: "2026-04-21T01:00:00Z",
+        resolvers: acceptResolver(),
+      },
+      makeResumeAdapter(),
+    );
+    expect(result.exitCode).toBe(0);
+
+    expect(existsSync(archPath)).toBe(true);
+    const doc = parseArchitecture(
+      JSON.parse(readFileSync(archPath, "utf8")) as unknown,
+    );
+    // Shape matches emptyArchitecture() exactly (SPEC §7 zero-node
+    // placeholder).
+    expect(doc).toEqual(emptyArchitecture());
+  });
+
+  test("preserves an existing architecture.json (idempotency per resume.ts:352)", async () => {
+    const slug = "arch-resume-preserve";
+    await seedDraftPhaseWithKilledInterview(slug);
+    const slugDir = path.join(tmp, ".samo", "spec", slug);
+    const archPath = path.join(slugDir, "architecture.json");
+
+    // Seed a minimal but valid 2-node document the way a prior partial
+    // run might have.
+    const seeded = {
+      version: "1" as const,
+      nodes: [
+        { id: "user", label: "User", kind: "external" as const },
+        { id: "app", label: "App", kind: "component" as const },
+      ],
+      edges: [{ from: "user", to: "app", kind: "call" as const }],
+    };
+    writeArchitecture(archPath, seeded);
+    const before = readFileSync(archPath, "utf8");
+
+    const result = await runResume(
+      {
+        cwd: tmp,
+        slug,
+        now: "2026-04-21T01:00:00Z",
+        resolvers: acceptResolver(),
+      },
+      makeResumeAdapter(),
+    );
+    expect(result.exitCode).toBe(0);
+
+    // Bytes are identical — resume did not overwrite.
+    const after = readFileSync(archPath, "utf8");
+    expect(after).toBe(before);
+    // And the parsed content equals what we seeded.
+    const doc = readArchitectureOrEmpty(archPath);
+    expect(doc).toEqual(seeded);
+  });
+
+  test("SPEC.md contains both sentinels after resume", async () => {
+    const slug = "arch-resume-sentinels";
+    await seedDraftPhaseWithKilledInterview(slug);
+    const result = await runResume(
+      {
+        cwd: tmp,
+        slug,
+        now: "2026-04-21T01:00:00Z",
+        resolvers: acceptResolver(),
+      },
+      makeResumeAdapter(),
+    );
+    expect(result.exitCode).toBe(0);
+    const spec = readFileSync(
+      path.join(tmp, ".samo", "spec", slug, "SPEC.md"),
+      "utf8",
+    );
+    expect(spec).toContain("<!-- architecture:begin -->");
+    expect(spec).toContain("<!-- architecture:end -->");
+  });
+
+  test("architecture.json is tracked in git after resume (specCommit paths)", async () => {
+    const slug = "arch-resume-commit";
+    await seedDraftPhaseWithKilledInterview(slug);
+    const result = await runResume(
+      {
+        cwd: tmp,
+        slug,
+        now: "2026-04-21T01:00:00Z",
+        resolvers: acceptResolver(),
+      },
+      makeResumeAdapter(),
+    );
+    expect(result.exitCode).toBe(0);
+    // git ls-files --error-unmatch exits non-zero if the path is not
+    // tracked; exit 0 proves it's in the index.
+    const lsFiles = repo.run([
+      "ls-files",
+      "--error-unmatch",
+      `.samo/spec/${slug}/architecture.json`,
+    ]);
+    expect(lsFiles.status).toBe(0);
   });
 });

--- a/tests/cli/architecture-integration.test.ts
+++ b/tests/cli/architecture-integration.test.ts
@@ -1,0 +1,293 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §3 + Issue #107 — integration tests asserting that `samospec
+// new` emits an architecture.json and a sentinel-delimited ASCII block
+// in SPEC.md, and that iterate re-renders the block from architecture
+// .json on each round.
+//
+// Red-first: the hooks assert artifacts the current new/iterate don't
+// yet produce.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type { Adapter, AskInput, AskOutput } from "../../src/adapter/types.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+import { runInit } from "../../src/cli/init.ts";
+import { parseArchitecture } from "../../src/state/architecture.ts";
+
+function askOut(answer: string): AskOutput {
+  return { answer, usage: null, effort_used: "max" };
+}
+
+function makeLeadAdapter(): Adapter {
+  const base = createFakeAdapter();
+  let call = 0;
+  const canned = [
+    // persona
+    JSON.stringify({
+      persona: 'Veteran "CLI tooling" expert',
+      rationale: "Matches the idea.",
+    }),
+    // interview Q1..Q5
+    JSON.stringify({ id: "Q1", text: "q?", options: [{ id: "a", text: "a" }] }),
+    JSON.stringify({ id: "Q2", text: "q?", options: [{ id: "a", text: "a" }] }),
+    JSON.stringify({ id: "Q3", text: "q?", options: [{ id: "a", text: "a" }] }),
+    JSON.stringify({ id: "Q4", text: "q?", options: [{ id: "a", text: "a" }] }),
+    JSON.stringify({ id: "Q5", text: "q?", options: [{ id: "a", text: "a" }] }),
+  ];
+  const ask = (input: AskInput): Promise<AskOutput> => {
+    const out = canned[call] ?? "{}";
+    call += 1;
+    return Promise.resolve(askOut(out));
+  };
+  return {
+    ...base,
+    vendor: "fake-lead",
+    ask,
+    revise: () =>
+      Promise.resolve({
+        spec:
+          "# arch-demo\n\n## 3. Architecture\n\nPlaceholder prose.\n\n" +
+          "## 4. Other\n\nMore text.\n",
+        ready: false,
+        rationale: "first draft",
+        usage: null,
+        effort_used: "max",
+      }),
+  };
+}
+
+async function runNewWithArchitecture(cwd: string, slug: string) {
+  await runInit({
+    cwd,
+    force: true,
+    yes: true,
+    interactiveFn: (): Promise<boolean> => Promise.resolve(true),
+  });
+  const adapter = makeLeadAdapter();
+  const resolvers: ChoiceResolvers = {
+    persona: () => Promise.resolve({ kind: "accept" }),
+    question: (_q) => Promise.resolve({ kind: "choice", choice: "a" }),
+  };
+  return await runNew(
+    {
+      cwd,
+      slug,
+      idea: "a CLI that emits architecture diagrams",
+      explain: false,
+      resolvers,
+      now: "2026-04-21T00:00:00.000Z",
+      noPush: true,
+    },
+    adapter,
+  );
+}
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(path.join(tmpdir(), "arch107-"));
+  // Initialize a git repo so `samospec new` can branch + commit.
+  spawnSync("git", ["init", "--initial-branch=main", tmpRoot], {
+    encoding: "utf8",
+  });
+  spawnSync("git", ["-C", tmpRoot, "config", "user.email", "a@b.c"]);
+  spawnSync("git", ["-C", tmpRoot, "config", "user.name", "Test"]);
+  // Seed a minimal commit so HEAD resolves.
+  writeFileSync(path.join(tmpRoot, "README.md"), "seed\n");
+  spawnSync("git", ["-C", tmpRoot, "add", "README.md"]);
+  spawnSync("git", ["-C", tmpRoot, "commit", "-m", "seed"]);
+});
+
+afterEach(() => {
+  if (tmpRoot !== undefined) rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("samospec iterate — architecture block re-render (#107)", () => {
+  test("re-renders the SPEC.md block from architecture.json each round", async () => {
+    // Lazily import iterate helpers to avoid a top-level circular build path.
+    const { runIterate } = await import("../../src/cli/iterate.ts");
+    const { writeState } = await import("../../src/state/store.ts");
+    const { writeArchitecture } = await import(
+      "../../src/state/architecture-store.ts"
+    );
+    const slug = "arch-iter";
+    const slugDir = path.join(tmpRoot, ".samo", "spec", slug);
+    mkdirSync(slugDir, { recursive: true });
+    // Seed a SPEC.md with an empty architecture block so we can watch
+    // iterate replace it with the rendered version of architecture.json.
+    const seededSpec = [
+      "# SPEC",
+      "",
+      "## 3. Architecture",
+      "",
+      "<!-- architecture:begin -->",
+      "(architecture not yet specified)",
+      "<!-- architecture:end -->",
+      "",
+      "## 4. Other",
+      "",
+      "body",
+      "",
+    ].join("\n");
+    writeFileSync(path.join(slugDir, "SPEC.md"), seededSpec);
+    writeFileSync(path.join(slugDir, "TLDR.md"), "# TLDR\n\n- t\n");
+    writeFileSync(
+      path.join(slugDir, "decisions.md"),
+      "# decisions\n\n- none\n",
+    );
+    writeFileSync(path.join(slugDir, "changelog.md"), "# changelog\n\n- s\n");
+    writeFileSync(
+      path.join(slugDir, "interview.json"),
+      JSON.stringify({
+        slug,
+        persona: "x",
+        generated_at: "2026-04-21T00:00:00Z",
+        questions: [],
+        answers: [],
+      }),
+    );
+    writeFileSync(
+      path.join(slugDir, "context.json"),
+      JSON.stringify({
+        phase: "draft",
+        files: [],
+        risk_flags: [],
+        budget: { phase: "draft", tokens_used: 0, tokens_budget: 0 },
+      }),
+    );
+    // Seed a non-empty architecture.json so iterate re-renders a real
+    // box diagram, not the placeholder.
+    writeArchitecture(path.join(slugDir, "architecture.json"), {
+      version: "1",
+      nodes: [
+        { id: "user", label: "User", kind: "external" },
+        { id: "app", label: "App", kind: "component" },
+      ],
+      edges: [{ from: "user", to: "app", kind: "call" }],
+    });
+    // Switch to the spec branch so iterate can commit.
+    spawnSync("git", ["-C", tmpRoot, "checkout", "-b", `samospec/${slug}`]);
+    spawnSync("git", ["-C", tmpRoot, "add", ".samo"]);
+    spawnSync("git", ["-C", tmpRoot, "commit", "-m", `spec(${slug}): seed`]);
+    writeState(path.join(slugDir, "state.json"), {
+      slug,
+      phase: "review_loop",
+      round_index: 0,
+      version: "0.1.0",
+      persona: { skill: "x", accepted: true },
+      push_consent: null,
+      calibration: null,
+      remote_stale: false,
+      coupled_fallback: false,
+      head_sha: null,
+      round_state: "committed",
+      exit: null,
+      created_at: "2026-04-21T00:00:00Z",
+      updated_at: "2026-04-21T00:00:00Z",
+    });
+    spawnSync("git", ["-C", tmpRoot, "add", ".samo"]);
+    spawnSync("git", ["-C", tmpRoot, "commit", "-m", `spec(${slug}): state`]);
+    const lead = {
+      ...createFakeAdapter({
+        revise: {
+          spec: "# SPEC\n\n## 3. Architecture\n\nRevised prose.\n",
+          ready: true,
+          rationale: "ok",
+          usage: null,
+          effort_used: "max",
+        },
+      }),
+    };
+    await runIterate({
+      cwd: tmpRoot,
+      slug,
+      now: "2026-04-21T01:00:00Z",
+      resolvers: {
+        onManualEdit: () => Promise.resolve("incorporate"),
+        onDegraded: () => Promise.resolve("accept"),
+        onReviewerExhausted: () => Promise.resolve("abort"),
+      },
+      adapters: {
+        lead,
+        reviewerA: createFakeAdapter({}),
+        reviewerB: createFakeAdapter({}),
+      },
+      maxRounds: 1,
+      sessionStartedAtMs: 0,
+      nowMs: 0,
+      maxWallClockMs: 60 * 60 * 1000,
+    });
+    const spec = readFileSync(path.join(slugDir, "SPEC.md"), "utf8");
+    expect(spec).toContain("<!-- architecture:begin -->");
+    expect(spec).toContain("User");
+    expect(spec).toContain("App");
+    expect(spec).toContain("user → app");
+    // The placeholder has been replaced.
+    expect(spec).not.toContain("(architecture not yet specified)");
+  });
+});
+
+describe("samospec new — architecture.json + SPEC.md block (#107)", () => {
+  test("writes .samo/spec/<slug>/architecture.json parseable by the schema", async () => {
+    const slug = "arch-demo";
+    const result = await runNewWithArchitecture(tmpRoot, slug);
+    expect(result.exitCode).toBe(0);
+    const archPath = path.join(
+      tmpRoot,
+      ".samo",
+      "spec",
+      slug,
+      "architecture.json",
+    );
+    expect(existsSync(archPath)).toBe(true);
+    const raw = JSON.parse(readFileSync(archPath, "utf8")) as unknown;
+    const doc = parseArchitecture(raw);
+    // v0.1 of this feature starts with an empty architecture unless
+    // the lead adapter contributes one. The renderer substitutes the
+    // placeholder at render time; both are valid states for the JSON.
+    expect(doc.version).toBe("1");
+  });
+
+  test("SPEC.md contains the sentinel-delimited architecture block", async () => {
+    const slug = "arch-demo";
+    await runNewWithArchitecture(tmpRoot, slug);
+    const spec = readFileSync(
+      path.join(tmpRoot, ".samo", "spec", slug, "SPEC.md"),
+      "utf8",
+    );
+    expect(spec).toContain("<!-- architecture:begin -->");
+    expect(spec).toContain("<!-- architecture:end -->");
+    // Placeholder for a zero-node architecture.
+    expect(spec).toContain("(architecture not yet specified)");
+  });
+
+  test("architecture.json is tracked in git on the first commit (#94)", async () => {
+    const slug = "arch-demo";
+    await runNewWithArchitecture(tmpRoot, slug);
+    const lsFiles = spawnSync(
+      "git",
+      [
+        "-C",
+        tmpRoot,
+        "ls-files",
+        "--error-unmatch",
+        `.samo/spec/${slug}/architecture.json`,
+      ],
+      { encoding: "utf8" },
+    );
+    expect(lsFiles.status).toBe(0);
+  });
+});

--- a/tests/cli/architecture-integration.test.ts
+++ b/tests/cli/architecture-integration.test.ts
@@ -6,12 +6,7 @@
 // .json on each round.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
@@ -120,13 +115,7 @@ describe("samospec new — architecture.json + SPEC.md block (#107)", () => {
       makeLeadAdapter(),
     );
     expect(result.exitCode).toBe(0);
-    const archPath = path.join(
-      tmp,
-      ".samo",
-      "spec",
-      slug,
-      "architecture.json",
-    );
+    const archPath = path.join(tmp, ".samo", "spec", slug, "architecture.json");
     expect(existsSync(archPath)).toBe(true);
     const doc = parseArchitecture(
       JSON.parse(readFileSync(archPath, "utf8")) as unknown,

--- a/tests/fixtures/architecture/grouped.json
+++ b/tests/fixtures/architecture/grouped.json
@@ -1,0 +1,23 @@
+{
+  "version": "1",
+  "nodes": [
+    { "id": "user", "label": "User", "kind": "external" },
+    { "id": "lead", "label": "Lead adapter", "kind": "component" },
+    { "id": "claude", "label": "Claude adapter", "kind": "component" },
+    { "id": "codex", "label": "Codex adapter", "kind": "component" },
+    { "id": "gemini", "label": "Gemini adapter", "kind": "component" },
+    { "id": "state", "label": "state.json", "kind": "datastore" }
+  ],
+  "edges": [
+    { "from": "user", "to": "lead", "kind": "call" },
+    { "from": "lead", "to": "adapters", "kind": "call" },
+    { "from": "lead", "to": "state", "kind": "data" }
+  ],
+  "groups": [
+    {
+      "id": "adapters",
+      "label": "adapters",
+      "members": ["claude", "codex", "gemini"]
+    }
+  ]
+}

--- a/tests/fixtures/architecture/oversized.json
+++ b/tests/fixtures/architecture/oversized.json
@@ -1,0 +1,55 @@
+{
+  "version": "1",
+  "nodes": [
+    { "id": "user", "label": "User", "kind": "external" },
+    { "id": "cli", "label": "samospec CLI", "kind": "component" },
+    { "id": "a01", "label": "adapter 01", "kind": "component" },
+    { "id": "a02", "label": "adapter 02", "kind": "component" },
+    { "id": "a03", "label": "adapter 03", "kind": "component" },
+    { "id": "a04", "label": "adapter 04", "kind": "component" },
+    { "id": "a05", "label": "adapter 05", "kind": "component" },
+    { "id": "a06", "label": "adapter 06", "kind": "component" },
+    { "id": "a07", "label": "adapter 07", "kind": "component" },
+    { "id": "a08", "label": "adapter 08", "kind": "component" },
+    { "id": "a09", "label": "adapter 09", "kind": "component" },
+    { "id": "a10", "label": "adapter 10", "kind": "component" },
+    { "id": "a11", "label": "adapter 11", "kind": "component" },
+    { "id": "a12", "label": "adapter 12", "kind": "component" },
+    { "id": "s01", "label": "datastore 01", "kind": "datastore" },
+    { "id": "s02", "label": "datastore 02", "kind": "datastore" },
+    { "id": "s03", "label": "datastore 03", "kind": "datastore" },
+    { "id": "s04", "label": "datastore 04", "kind": "datastore" },
+    { "id": "s05", "label": "datastore 05", "kind": "datastore" },
+    { "id": "s06", "label": "datastore 06", "kind": "datastore" }
+  ],
+  "edges": [
+    { "from": "user", "to": "cli", "kind": "call" },
+    { "from": "cli", "to": "adapters", "kind": "call" },
+    { "from": "cli", "to": "datastores", "kind": "data" }
+  ],
+  "groups": [
+    {
+      "id": "adapters",
+      "label": "adapters",
+      "members": [
+        "a01",
+        "a02",
+        "a03",
+        "a04",
+        "a05",
+        "a06",
+        "a07",
+        "a08",
+        "a09",
+        "a10",
+        "a11",
+        "a12"
+      ]
+    },
+    {
+      "id": "datastores",
+      "label": "datastores",
+      "members": ["s01", "s02", "s03", "s04", "s05", "s06"]
+    }
+  ]
+}

--- a/tests/fixtures/architecture/trivial.json
+++ b/tests/fixtures/architecture/trivial.json
@@ -1,0 +1,8 @@
+{
+  "version": "1",
+  "nodes": [
+    { "id": "user", "label": "User", "kind": "external" },
+    { "id": "app", "label": "App", "kind": "component" }
+  ],
+  "edges": [{ "from": "user", "to": "app", "kind": "call" }]
+}

--- a/tests/fixtures/architecture/zero-nodes.json
+++ b/tests/fixtures/architecture/zero-nodes.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "nodes": [],
+  "edges": []
+}

--- a/tests/render/architecture-ascii.test.ts
+++ b/tests/render/architecture-ascii.test.ts
@@ -1,0 +1,130 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §3 + Issue #107 — red-first tests for the architecture ASCII
+// renderer. Every fixture gets pinned against its rendered output; the
+// hard-80 / soft-40 invariants are asserted separately because the
+// oversized fixture is allowed to exceed the soft cap only after it's
+// been collapsed through group-fold logic.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { renderArchitectureAscii } from "../../src/render/architecture-ascii.ts";
+import {
+  parseArchitecture,
+  type Architecture,
+} from "../../src/state/architecture.ts";
+
+const FIXTURE_DIR = path.resolve(
+  import.meta.dir,
+  "..",
+  "fixtures",
+  "architecture",
+);
+
+function loadFixture(name: string): Architecture {
+  const raw = JSON.parse(
+    readFileSync(path.join(FIXTURE_DIR, name), "utf8"),
+  ) as unknown;
+  return parseArchitecture(raw);
+}
+
+function lineWidths(s: string): number[] {
+  // Unicode box-drawing characters are single-column for visual width;
+  // `.length` counts UTF-16 code units which coincide with column count
+  // for all characters in our renderer's output.
+  return s.split("\n").map((l) => l.length);
+}
+
+describe("renderArchitectureAscii — zero-node placeholder", () => {
+  test("empty schema renders the single-line placeholder", () => {
+    const out = renderArchitectureAscii(loadFixture("zero-nodes.json"));
+    expect(out).toBe("(architecture not yet specified)");
+  });
+});
+
+describe("renderArchitectureAscii — trivial schema", () => {
+  test("renders each node as a labeled box + the single edge", () => {
+    const out = renderArchitectureAscii(loadFixture("trivial.json"));
+    // Nodes appear in schema order.
+    const userIdx = out.indexOf("User");
+    const appIdx = out.indexOf("App");
+    expect(userIdx).toBeGreaterThanOrEqual(0);
+    expect(appIdx).toBeGreaterThan(userIdx);
+    // Box-drawing characters are used for the node box frame.
+    expect(out).toMatch(/┌─+┐/u);
+    expect(out).toMatch(/└─+┘/u);
+    // Edge is rendered below the boxes.
+    expect(out).toContain("user → app");
+  });
+
+  test("every rendered line is <= 80 columns", () => {
+    const out = renderArchitectureAscii(loadFixture("trivial.json"));
+    for (const w of lineWidths(out)) {
+      expect(w).toBeLessThanOrEqual(80);
+    }
+  });
+});
+
+describe("renderArchitectureAscii — grouped schema", () => {
+  test("lists the group and its members when under the soft cap", () => {
+    const out = renderArchitectureAscii(loadFixture("grouped.json"));
+    expect(out).toContain("Lead adapter");
+    expect(out).toContain("Claude adapter");
+    expect(out).toContain("Codex adapter");
+    expect(out).toContain("Gemini adapter");
+    // Group heading present.
+    expect(out).toMatch(/adapters.*claude.*codex.*gemini/is);
+  });
+
+  test("edges to a group id render with the group label", () => {
+    const out = renderArchitectureAscii(loadFixture("grouped.json"));
+    expect(out).toContain("lead → adapters");
+  });
+});
+
+describe("renderArchitectureAscii — oversized schema", () => {
+  test("collapses groups under the soft cap when full render would blow ~40 lines", () => {
+    const out = renderArchitectureAscii(loadFixture("oversized.json"));
+    // The un-collapsed oversized fixture has 20 nodes × 3 lines/box =
+    // 60+ lines. The collapsed form must NOT individually render every
+    // adapter or datastore member.
+    expect(out).not.toContain("adapter 01");
+    expect(out).not.toContain("adapter 12");
+    expect(out).not.toContain("datastore 01");
+    // But the collapsed group pill IS present, carrying the member count.
+    expect(out).toContain("[12 adapters]");
+    expect(out).toContain("[6 datastores]");
+  });
+
+  test("oversized schema stays within the 80-col hard cap", () => {
+    const out = renderArchitectureAscii(loadFixture("oversized.json"));
+    for (const w of lineWidths(out)) {
+      expect(w).toBeLessThanOrEqual(80);
+    }
+  });
+});
+
+describe("renderArchitectureAscii — label truncation", () => {
+  test("labels that would blow 80 cols are truncated with ellipsis", () => {
+    const longLabel = "x".repeat(200);
+    const out = renderArchitectureAscii({
+      version: "1",
+      nodes: [{ id: "n", label: longLabel, kind: "component" }],
+      edges: [],
+    });
+    for (const w of lineWidths(out)) {
+      expect(w).toBeLessThanOrEqual(80);
+    }
+    expect(out).toContain("…");
+  });
+});
+
+describe("renderArchitectureAscii — determinism", () => {
+  test("two calls on the same schema produce byte-identical output", () => {
+    const a = renderArchitectureAscii(loadFixture("grouped.json"));
+    const b = renderArchitectureAscii(loadFixture("grouped.json"));
+    expect(a).toBe(b);
+  });
+});

--- a/tests/render/architecture-spec.test.ts
+++ b/tests/render/architecture-spec.test.ts
@@ -1,0 +1,151 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §3 + Issue #107 — red-first tests for SPEC.md sentinel block
+// injection. The sentinels are literal HTML comments so they survive
+// Markdown rendering everywhere; the renderer replaces the block on
+// iterate without touching surrounding prose.
+
+import { describe, expect, test } from "bun:test";
+
+import { injectArchitectureBlock } from "../../src/render/architecture-spec.ts";
+import type { Architecture } from "../../src/state/architecture.ts";
+
+const BEGIN = "<!-- architecture:begin -->";
+const END = "<!-- architecture:end -->";
+
+function trivialArch(): Architecture {
+  return {
+    version: "1",
+    nodes: [
+      { id: "user", label: "User", kind: "external" },
+      { id: "app", label: "App", kind: "component" },
+    ],
+    edges: [{ from: "user", to: "app", kind: "call" }],
+  };
+}
+
+describe("injectArchitectureBlock — replace existing sentinels", () => {
+  test("replaces the content between sentinels, preserving surroundings", () => {
+    const spec = [
+      "# demo",
+      "",
+      "## 3. Architecture",
+      "",
+      "Some prose that must be preserved verbatim.",
+      "",
+      BEGIN,
+      "old diagram content",
+      END,
+      "",
+      "## 4. Next section",
+      "",
+      "Trailing prose also preserved.",
+      "",
+    ].join("\n");
+    const out = injectArchitectureBlock(spec, trivialArch());
+    expect(out).toContain("Some prose that must be preserved verbatim.");
+    expect(out).toContain("Trailing prose also preserved.");
+    // Old content gone.
+    expect(out).not.toContain("old diagram content");
+    // New content between sentinels.
+    const begin = out.indexOf(BEGIN);
+    const end = out.indexOf(END);
+    expect(begin).toBeGreaterThan(0);
+    expect(end).toBeGreaterThan(begin);
+    const block = out.slice(begin, end + END.length);
+    expect(block).toContain("User");
+    expect(block).toContain("App");
+    expect(block).toContain("user → app");
+  });
+
+  test("idempotent on re-injection with the same architecture", () => {
+    const spec = [
+      "# demo",
+      "",
+      "## 3. Architecture",
+      "",
+      BEGIN,
+      END,
+      "",
+      "## 4. Other",
+      "",
+    ].join("\n");
+    const once = injectArchitectureBlock(spec, trivialArch());
+    const twice = injectArchitectureBlock(once, trivialArch());
+    expect(twice).toBe(once);
+  });
+});
+
+describe("injectArchitectureBlock — inject sentinels when absent", () => {
+  test("inserts sentinel block under an Architecture heading", () => {
+    const spec = [
+      "# demo",
+      "",
+      "## 2. Why",
+      "",
+      "Body of section 2.",
+      "",
+      "## 3. Architecture",
+      "",
+      "Existing prose.",
+      "",
+      "## 4. Next",
+      "",
+      "More.",
+      "",
+    ].join("\n");
+    const out = injectArchitectureBlock(spec, trivialArch());
+    expect(out).toContain(BEGIN);
+    expect(out).toContain(END);
+    // Block lives after the Architecture heading and before the next `##`.
+    const archIdx = out.indexOf("## 3. Architecture");
+    const nextIdx = out.indexOf("## 4. Next");
+    const beginIdx = out.indexOf(BEGIN);
+    expect(beginIdx).toBeGreaterThan(archIdx);
+    expect(beginIdx).toBeLessThan(nextIdx);
+    // Existing prose preserved.
+    expect(out).toContain("Existing prose.");
+    expect(out).toContain("Body of section 2.");
+  });
+
+  test("appends a new Architecture section when no matching heading exists", () => {
+    const spec = ["# demo", "", "## 2. Why", "", "Body.", ""].join("\n");
+    const out = injectArchitectureBlock(spec, trivialArch());
+    expect(out).toContain(BEGIN);
+    expect(out).toContain(END);
+    expect(out).toContain("Body.");
+    // The added section's heading carries "Architecture".
+    expect(out).toMatch(/^##\s+.*Architecture/im);
+  });
+
+  test("does not mutate a spec that has neither sentinels nor Architecture section, when scan-only is requested", () => {
+    // Sanity: direct call always mutates; we just ensure the output
+    // still contains the original body when the append-fallback fires.
+    const spec = "# demo\n\nThis is a tiny spec.\n";
+    const out = injectArchitectureBlock(spec, trivialArch());
+    expect(out).toContain("This is a tiny spec.");
+    expect(out).toContain(BEGIN);
+  });
+});
+
+describe("injectArchitectureBlock — zero-node placeholder", () => {
+  test("empty architecture renders the placeholder inside sentinels", () => {
+    const spec = [
+      "# demo",
+      "",
+      "## 3. Architecture",
+      "",
+      BEGIN,
+      "stale",
+      END,
+      "",
+    ].join("\n");
+    const out = injectArchitectureBlock(spec, {
+      version: "1",
+      nodes: [],
+      edges: [],
+    });
+    expect(out).toContain("(architecture not yet specified)");
+    expect(out).not.toContain("stale");
+  });
+});

--- a/tests/state/architecture-schema.test.ts
+++ b/tests/state/architecture-schema.test.ts
@@ -1,0 +1,217 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// SPEC §3 + Issue #107 — red-first schema tests for architecture.json.
+// The schema is the canonical machine-readable representation; the
+// ASCII renderer and SPEC.md injection both consume it. Tests here
+// cover the Zod shape + cross-field refinements (unique ids, edge
+// endpoint resolution, group membership, zero-node legality).
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  ARCHITECTURE_EDGE_KINDS,
+  ARCHITECTURE_NODE_KINDS,
+  architectureSchema,
+  emptyArchitecture,
+  parseArchitecture,
+} from "../../src/state/architecture.ts";
+
+const FIXTURE_DIR = path.resolve(
+  import.meta.dir,
+  "..",
+  "fixtures",
+  "architecture",
+);
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(path.join(FIXTURE_DIR, name), "utf8"),
+  ) as unknown;
+}
+
+describe("architectureSchema — constant tables", () => {
+  test("node kinds are exactly { external, component, datastore, boundary }", () => {
+    expect([...ARCHITECTURE_NODE_KINDS]).toEqual([
+      "external",
+      "component",
+      "datastore",
+      "boundary",
+    ]);
+  });
+
+  test("edge kinds are exactly { call, data, control }", () => {
+    expect([...ARCHITECTURE_EDGE_KINDS]).toEqual(["call", "data", "control"]);
+  });
+});
+
+describe("architectureSchema — accepts valid fixtures", () => {
+  test("trivial 2-node graph parses", () => {
+    const result = architectureSchema.safeParse(loadFixture("trivial.json"));
+    expect(result.success).toBe(true);
+  });
+
+  test("grouped fixture parses (edge resolves to a group id)", () => {
+    const result = architectureSchema.safeParse(loadFixture("grouped.json"));
+    expect(result.success).toBe(true);
+  });
+
+  test("oversized fixture parses (20 nodes + 2 groups)", () => {
+    const result = architectureSchema.safeParse(loadFixture("oversized.json"));
+    expect(result.success).toBe(true);
+  });
+
+  test("zero-node fixture parses (valid placeholder)", () => {
+    const result = architectureSchema.safeParse(loadFixture("zero-nodes.json"));
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("architectureSchema — rejects invalid shapes", () => {
+  test("rejects missing version field", () => {
+    const result = architectureSchema.safeParse({
+      nodes: [{ id: "a", label: "A", kind: "component" }],
+      edges: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects version other than '1'", () => {
+    const result = architectureSchema.safeParse({
+      version: "2",
+      nodes: [],
+      edges: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects unknown node kind", () => {
+    const result = architectureSchema.safeParse({
+      version: "1",
+      nodes: [{ id: "a", label: "A", kind: "service" }],
+      edges: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects unknown edge kind", () => {
+    const result = architectureSchema.safeParse({
+      version: "1",
+      nodes: [
+        { id: "a", label: "A", kind: "component" },
+        { id: "b", label: "B", kind: "component" },
+      ],
+      edges: [{ from: "a", to: "b", kind: "chirp" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects duplicate node ids", () => {
+    const result = architectureSchema.safeParse({
+      version: "1",
+      nodes: [
+        { id: "a", label: "A1", kind: "component" },
+        { id: "a", label: "A2", kind: "component" },
+      ],
+      edges: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects unresolved edge.from", () => {
+    const result = architectureSchema.safeParse({
+      version: "1",
+      nodes: [{ id: "a", label: "A", kind: "component" }],
+      edges: [{ from: "ghost", to: "a", kind: "call" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects unresolved edge.to", () => {
+    const result = architectureSchema.safeParse({
+      version: "1",
+      nodes: [{ id: "a", label: "A", kind: "component" }],
+      edges: [{ from: "a", to: "ghost", kind: "call" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects group member that is not a node", () => {
+    const result = architectureSchema.safeParse({
+      version: "1",
+      nodes: [{ id: "a", label: "A", kind: "component" }],
+      edges: [],
+      groups: [{ id: "g", label: "g", members: ["a", "phantom"] }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects group id that clashes with a node id", () => {
+    const result = architectureSchema.safeParse({
+      version: "1",
+      nodes: [{ id: "dup", label: "Dup", kind: "component" }],
+      edges: [],
+      groups: [{ id: "dup", label: "group", members: ["dup"] }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid id grammar", () => {
+    const result = architectureSchema.safeParse({
+      version: "1",
+      nodes: [{ id: "Has Space", label: "x", kind: "component" }],
+      edges: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects unknown top-level keys (strict mode)", () => {
+    const result = architectureSchema.safeParse({
+      version: "1",
+      nodes: [],
+      edges: [],
+      extra: "ignored",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("architectureSchema — edges pointing at groups resolve", () => {
+  test("edge targeting a group id is accepted", () => {
+    const result = architectureSchema.safeParse({
+      version: "1",
+      nodes: [
+        { id: "lead", label: "lead", kind: "component" },
+        { id: "r1", label: "r1", kind: "component" },
+        { id: "r2", label: "r2", kind: "component" },
+      ],
+      edges: [{ from: "lead", to: "reviewers", kind: "call" }],
+      groups: [{ id: "reviewers", label: "reviewers", members: ["r1", "r2"] }],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("parseArchitecture + emptyArchitecture", () => {
+  test("parseArchitecture returns the parsed doc on valid input", () => {
+    const doc = parseArchitecture(loadFixture("trivial.json"));
+    expect(doc.version).toBe("1");
+    expect(doc.nodes.length).toBe(2);
+  });
+
+  test("parseArchitecture throws on invalid input", () => {
+    expect(() =>
+      parseArchitecture({ version: "1", nodes: "oops", edges: [] }),
+    ).toThrow(/schema/);
+  });
+
+  test("emptyArchitecture is version-1 with no nodes or edges", () => {
+    const doc = emptyArchitecture();
+    expect(doc.version).toBe("1");
+    expect(doc.nodes).toEqual([]);
+    expect(doc.edges).toEqual([]);
+    const result = architectureSchema.safeParse(doc);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #107.

## Summary

- `.samo/spec/<slug>/architecture.json` is the canonical architecture schema (Zod-validated). Shape: `{ version: "1", nodes, edges, groups?, notes? }`. Node kinds: `external | component | datastore | boundary`. Edge kinds: `call | data | control`. IDs must be unique; edge endpoints must resolve to a node or group; zero-node docs are legal.
- `renderArchitectureAscii` emits a hard-80-col / soft-~40-line diagram. When the soft cap trips, sibling groups collapse to a single `[N <label>]` pill. Labels that would blow the column budget truncate with `…` (full label stays in the JSON). Zero-node schemas render the `(architecture not yet specified)` placeholder.
- SPEC.md auto-embeds the rendered diagram between `<!-- architecture:begin -->` / `<!-- architecture:end -->` sentinels. The renderer replaces the block each round without touching surrounding prose. Specs without sentinels get them injected additively (under the Architecture heading if present; otherwise a new section is appended).
- `new`, `iterate`, and `resume` now produce and maintain architecture.json alongside SPEC.md. The architecture block is a pure function of architecture.json, so the ASCII stays in lockstep with the schema even when the lead regenerates SPEC.md prose each round.
- architecture.json is listed in `specCommit(...)` paths in all three commands so git tracks every schema change (per the #94 auto-commit fix).

## Design note

Chose **post-processing over augmenting the lead prompt.** Reasons:

- **Determinism**: the ASCII block is a pure function of architecture.json, independent of however the lead phrased SPEC.md this round.
- **Round-trip safety**: iterate may regenerate SPEC.md text every round; the block is always re-rendered from JSON so it can't drift from the schema.
- **Backward compatibility**: specs without sentinels get them added additively — no existing SPEC.md gets its prose rearranged.

v0.1 ships with an empty-placeholder architecture.json on `samospec new`. A follow-up PR can extend the lead prompt to author a populated schema; the plumbing here already renders whatever JSON the lead or a user writes.

## Test plan

- Red/green per phase, with red commits cited below:
  - `74ae081` red → `57d8635` green — Zod schema + validators (21 tests)
  - `381f1a1` red → `5a81e07` green — ASCII renderer (9 tests, 4 fixtures)
  - `9f6a981` red → `da57b99` green — SPEC.md injection (6 tests)
  - `7dfef7c` red → `a08a291` green — new + iterate wiring (4 tests)
- Full suite: `bun test` → **1414 pass / 0 fail**
- `bun run typecheck`, `bun run lint`, `bun run format:check` — all clean.
- Manual smoke: rendered the trivial / grouped / oversized / zero-node fixtures end-to-end; verified 80-col invariant holds, soft-cap collapse fires on oversized, placeholder text renders for zero-node, injection preserves surrounding prose and is idempotent on re-inject.

## Deferred (in scope of #107 but intentionally not shipped)

- Lead adapter prompt authoring a populated architecture.json — v0.1 ships the empty placeholder; renderer already handles whatever shape lands in the JSON.
- No migration path for future `version` changes (explicitly non-goal per scope comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)