### PR TITLE
ci(publish): write .npmrc explicitly instead of NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,6 +114,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -Eeuo pipefail
+          IFS=$'\n\t'
           {
             echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
             echo "registry=https://registry.npmjs.org/"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,14 +101,34 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Write project .npmrc with auth token
+        # Avoids the setup-node `NODE_AUTH_TOKEN` substitution path
+        # (which has intermittently produced 404 on PUT in this repo
+        # despite the same token publishing fine locally). Write the
+        # token directly so npm CLI reads it straight from .npmrc.
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          {
+            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
+            echo "registry=https://registry.npmjs.org/"
+            echo "always-auth=true"
+          } > .npmrc
+          chmod 600 .npmrc
+
+      - name: Sanity-check auth (whoami)
+        run: npm whoami --registry https://registry.npmjs.org/
 
       - name: Publish to npm
         # --provenance requires a trusted-publisher config on npmjs;
         # skip it until that's set up. Re-enable via follow-up PR.
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Scrub .npmrc
+        if: always()
+        run: rm -f .npmrc

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ coverage/
 .env.*
 !.env.example
 
+# npm auth — never commit a real .npmrc
+.npmrc
+
 # Ephemeral PR body drafts used by gh pr create
 PR_BODY.md
 


### PR DESCRIPTION
## Summary

The setup-node@v4 `registry-url` + \`NODE_AUTH_TOKEN\` env substitution path has produced \`npm error 404 PUT /samospec\` on every CI publish attempt (both v0.4.1 and v0.5.0), while the **same \`NPM_TOKEN\` value publishes fine locally** from an explicit \`.npmrc\`.

Root cause not fully isolated — likely either:
- setup-node writes the .npmrc to a location the publish step's shell doesn't read, or
- \`NODE_AUTH_TOKEN\` env isn't reaching the \`npm publish\` subprocess under the bun-installed runtime.

## Fix

Write a project-local \`.npmrc\` with the literal token value in a dedicated step, sanity-check with \`npm whoami\`, then publish, then scrub. \`npm\` always reads the project \`.npmrc\` so auth is unambiguous.

Drive-bys:
- Drop \`registry-url\` from \`setup-node\` (no longer needed).
- \`chmod 600 .npmrc\`.
- Scrub .npmrc in an \`if: always()\` step so a failed publish doesn't leak the file.

## Test plan

- [ ] CI green on this PR (publish workflow doesn't run on PR, only on release).
- [ ] After merge, trigger via \`workflow_dispatch\` with \`tag=v0.5.0\`:
  - Expected: \`whoami\` prints \`postgres_ai\`
  - Publish step gets 403 \`cannot publish over previously-published version\` — the correct signal that auth + publish path both work, since \`samospec@0.5.0\` is already live (I published locally after CI kept failing).
- [ ] Next real release (v0.5.1 or later) lands via CI end-to-end.

## Context

\`samospec@0.5.0\` is live on npm as of this evening with Apache-2.0 correctly set: https://www.npmjs.com/package/samospec

🤖 Generated with [Claude Code](https://claude.com/claude-code)