### PR TITLE
ci(publish): drop npm whoami sanity-check — token is write-only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,9 +122,6 @@ jobs:
           } > .npmrc
           chmod 600 .npmrc
 
-      - name: Sanity-check auth (whoami)
-        run: npm whoami --registry https://registry.npmjs.org/
-
       - name: Publish to npm
         # --provenance requires a trusted-publisher config on npmjs;
         # skip it until that's set up. Re-enable via follow-up PR.


### PR DESCRIPTION
## Summary

Fixes the CI publish workflow I introduced in #111. The `npm whoami` sanity-check step fails with 401 Unauthorized because our `NPM_TOKEN` is a granular token with **`package.write` only, no `read` permission** — whoami is a read op, so it's denied even though publish (write) works.

Verified via token introspection:
\`\`\`json
\"permissions\": [{\"name\": \"package\", \"action\": \"write\"}]
\`\`\`

Remove the whoami step. Publish-step failures surface the same error as any other auth issue; a separate probe isn't needed.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, trigger `workflow_dispatch` with `tag=v0.5.0` — expected: publish step 403 "cannot publish over previously-published version" (confirms auth + publish path both work).
- [ ] Next real release (v0.5.1+) lands via CI end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)