### PR TITLE
fix(iterate): honor --max-session-wall-clock-ms (#91)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,9 +62,13 @@ const USAGE =
   "                              `session-wall-clock`.\n" +
   "  resume [<slug>]             Resume an in-progress spec from state.json.\n" +
   "  iterate [<slug>] [--rounds N] [--no-push] [--remote <name>] [--quiet]\n" +
+  "           [--max-session-wall-clock-ms <ms>]\n" +
   "                              Run review rounds until a stopping condition fires.\n" +
   "                              --quiet suppresses per-phase progress + heartbeat\n" +
   "                              (default: verbose progress on stderr).\n" +
+  "                              --max-session-wall-clock-ms caps the review loop\n" +
+  "                              session wall-clock (positive integer ms). On cap,\n" +
+  "                              exits 4 with reason `session-wall-clock`.\n" +
   "  status [<slug>]             Print phase, round, cost, wall-clock, and next action.\n" +
   "  publish [<slug>] [--no-lint] [--remote <name>]\n" +
   "                              Promote to blueprints/<slug>/SPEC.md, commit, push, open PR.\n" +
@@ -446,7 +450,23 @@ interface IterateArgs {
   readonly noPush: boolean;
   readonly remote: string;
   readonly quiet: boolean;
+  readonly maxSessionWallClockMs?: number;
 }
+
+/**
+ * Centralised allow-list of long flags recognised by `samospec iterate`
+ * (Issue #91). Parser compares every `--…` token against this set and
+ * rejects unknown flags instead of silently dropping them — this catches
+ * typos like `--rouns 5`. Keep bare names (no `=value` suffix); the
+ * parser strips `=…` before lookup.
+ */
+const ITERATE_ALLOWED_FLAGS: ReadonlySet<string> = new Set([
+  "--rounds",
+  "--no-push",
+  "--remote",
+  "--quiet",
+  "--max-session-wall-clock-ms",
+]);
 
 function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
   let slug: string | null = null;
@@ -454,6 +474,7 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
   let noPush = false;
   let remote = "origin";
   let quiet = false;
+  let maxSessionWallClockMs: number | undefined;
   for (let i = 0; i < argv.length; i += 1) {
     const t = argv[i];
     if (t === undefined) continue;
@@ -491,7 +512,37 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
       remote = t.slice("--remote=".length);
       continue;
     }
-    if (t.startsWith("--")) continue;
+    if (t === "--max-session-wall-clock-ms") {
+      const raw = argv[i + 1] ?? "";
+      i += 1;
+      const parsed = parseMaxSessionWallClockMs(raw);
+      if (typeof parsed === "string") {
+        // Rewrite the `new`-prefixed error so the CLI path matches
+        // `iterate` (same helper; different subcommand).
+        return parsed.replace("samospec new", "samospec iterate");
+      }
+      maxSessionWallClockMs = parsed;
+      continue;
+    }
+    if (t.startsWith("--max-session-wall-clock-ms=")) {
+      const raw = t.slice("--max-session-wall-clock-ms=".length);
+      const parsed = parseMaxSessionWallClockMs(raw);
+      if (typeof parsed === "string") {
+        return parsed.replace("samospec new", "samospec iterate");
+      }
+      maxSessionWallClockMs = parsed;
+      continue;
+    }
+    if (t.startsWith("--")) {
+      // Issue #91: reject unknown flags instead of silently dropping
+      // them. Strip any `=value` suffix before the allow-list lookup
+      // so `--rouns=5` is caught the same as `--rouns 5`.
+      const bareFlag = t.includes("=") ? t.slice(0, t.indexOf("=")) : t;
+      if (!ITERATE_ALLOWED_FLAGS.has(bareFlag)) {
+        return `samospec iterate: unknown flag '${bareFlag}'`;
+      }
+      continue;
+    }
     slug ??= t;
   }
   if (slug === null || slug.length === 0) {
@@ -503,6 +554,7 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
     remote,
     quiet,
     ...(rounds !== undefined ? { rounds } : {}),
+    ...(maxSessionWallClockMs !== undefined ? { maxSessionWallClockMs } : {}),
   };
 }
 
@@ -629,6 +681,9 @@ async function runIterateCommand(rest: readonly string[]) {
     pushOptions,
     quiet: parsed.quiet,
     ...(parsed.rounds !== undefined ? { maxRounds: parsed.rounds } : {}),
+    ...(parsed.maxSessionWallClockMs !== undefined
+      ? { maxSessionWallClockMs: parsed.maxSessionWallClockMs }
+      : {}),
   });
   return {
     exitCode: result.exitCode,

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -114,6 +114,11 @@ import {
 const DEFAULT_MAX_ROUNDS = 10 as const;
 const DEFAULT_WALL_CLOCK_MS = 240 * 60 * 1000; // 240 minutes
 const DEFAULT_MAX_WALL_CLOCK_MIN = 240;
+// Issue #91: session wall-clock cap default for `samospec iterate`,
+// mirroring `samospec new`. Configurable via
+// `budget.max_session_wall_clock_minutes` in `.samo/config.json` or
+// overridden per-call via `IterateInput.maxSessionWallClockMs`.
+const DEFAULT_SESSION_WALL_CLOCK_MS = 10 * 60 * 1_000;
 
 // ---------- types ----------
 
@@ -212,6 +217,18 @@ export interface IterateInput {
    * heartbeat can be exercised without real wall-clock sleeps.
    */
   readonly progress?: ProgressOptions;
+  /**
+   * Issue #91: session wall-clock cap in milliseconds. Mirrors the
+   * `--max-session-wall-clock-ms` semantics in `samospec new`: when the
+   * total elapsed time since `runIterate()` entry exceeds this value,
+   * the current round / seat call is preempted and `runIterate` returns
+   * exit 4 with a `session-wall-clock` message in stderr. Falls back to
+   * `budget.max_session_wall_clock_minutes` in `.samo/config.json`, then
+   * to `DEFAULT_SESSION_WALL_CLOCK_MS` (10 min). Independent of the
+   * SPEC §11 "one more round fits" guard (`maxWallClockMs`) — the two
+   * caps compose: whichever is tighter fires first.
+   */
+  readonly maxSessionWallClockMs?: number;
 }
 
 export interface IterateResult {
@@ -342,6 +359,15 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
     const sessionStartedMs = input.sessionStartedAtMs ?? Date.parse(input.now);
     const nowMsFn = (): number => input.nowMs ?? Date.now();
 
+    // Issue #91: session wall-clock guard. The live-repro showed a
+    // stuck revise at round 7 running 1h 41m under a 40-min cap; this
+    // deadline preempts any round (or seat call) that runs past the
+    // cap. Uses a real wall clock (`Date.now()`) — cannot be silenced
+    // by tests that freeze `input.nowMs`, so the hanging-adapter tests
+    // in `tests/cli/iterate-wall-clock.test.ts` actually preempt.
+    const sessionWallClockStartMs = Date.now();
+    const sessionWallClockLimitMs = resolveSessionWallClockMs(input);
+
     // Initial state tracking.
     let currentState: State = state;
     let currentSpec: string = readFileSync(paths.specPath, "utf8");
@@ -410,6 +436,48 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
             cwd: input.cwd,
             slug: input.slug,
           });
+        }
+
+        // Issue #91: session wall-clock guard BEFORE each round starts.
+        // Independent from the SPEC §11 "one more round fits" gate above
+        // — this cap is the user-facing `--max-session-wall-clock-ms`
+        // (or config-derived) budget, and must fire even if per-call
+        // timeouts would also let another round fit.
+        const sessionElapsedMs = Date.now() - sessionWallClockStartMs;
+        if (sessionElapsedMs >= sessionWallClockLimitMs) {
+          const leadTerm: State = {
+            ...currentState,
+            round_state: "lead_terminal",
+            updated_at: nowIso(),
+            exit: {
+              code: 4,
+              reason: "lead-terminal:wall_clock",
+              round_index: currentState.round_index,
+            },
+          };
+          writeState(paths.statePath, leadTerm);
+          error(
+            `samospec: session-wall-clock exceeded before round ` +
+              `${String(roundIndex)} (${String(sessionElapsedMs)}ms ` +
+              `elapsed, limit ${String(sessionWallClockLimitMs)}ms). ` +
+              `Restart with a larger --max-session-wall-clock-ms or ` +
+              `increase budget.max_session_wall_clock_minutes.`,
+          );
+          finalizeBookkeeping({
+            cwd: input.cwd,
+            slug: input.slug,
+            statePath: paths.statePath,
+            tldrPath: paths.tldrPath,
+            roundIndex: leadTerm.round_index,
+          });
+          return {
+            exitCode: 4,
+            stdout: lines.join("\n"),
+            stderr: `${errLines.join("\n")}\n`,
+            roundsRun: Math.max(0, roundsRun - 1),
+            finalVersion: currentState.version,
+            stopReason: "lead-terminal",
+          };
         }
 
         // Manual-edit detection BEFORE each round.
@@ -520,21 +588,83 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
         // Run the round.
         // #100: thread a wall-clock source so round.json records real
         // started_at / completed_at instead of a single frozen `now`.
-        const roundOutcome = await runRound({
-          now: input.now,
-          nowFn: (): string => new Date(nowMsFn()).toISOString(),
-          roundNumber: roundIndex,
-          dirs,
-          specText: currentSpec,
-          decisionsHistory,
-          adapters: wrappedAdapters,
-          critiqueTimeoutMs: callTimeouts.criticA_ms,
-          reviseTimeoutMs: callTimeouts.revise_ms,
-          ...(manualEditDirective !== undefined ? { manualEditDirective } : {}),
-          ...(ideaForRound !== undefined
-            ? { idea: ideaForRound, slug: input.slug }
-            : {}),
-        });
+        // #91: wrap the entire round in `withSessionDeadline` so a
+        // hanging reviewer / lead call cannot exceed the user's
+        // --max-session-wall-clock-ms cap. The per-call timeouts in
+        // runRound (CRITIQUE_TIMEOUT_MS / REVISE_TIMEOUT_MS) still
+        // apply inside the round; this is the outer bound.
+        let roundOutcome: Awaited<ReturnType<typeof runRound>>;
+        try {
+          roundOutcome = await withSessionDeadline(
+            runRound({
+              now: input.now,
+              nowFn: (): string => new Date(nowMsFn()).toISOString(),
+              roundNumber: roundIndex,
+              dirs,
+              specText: currentSpec,
+              decisionsHistory,
+              adapters: wrappedAdapters,
+              critiqueTimeoutMs: callTimeouts.criticA_ms,
+              reviseTimeoutMs: callTimeouts.revise_ms,
+              ...(manualEditDirective !== undefined
+                ? { manualEditDirective }
+                : {}),
+              ...(ideaForRound !== undefined
+                ? { idea: ideaForRound, slug: input.slug }
+                : {}),
+            }),
+            `round_${String(roundIndex)}`,
+            sessionWallClockStartMs,
+            sessionWallClockLimitMs,
+          );
+        } catch (err) {
+          if (err instanceof SessionWallClockError) {
+            // #91: the cap fired mid-round. Persist a lead_terminal
+            // state with a wall-clock sub-reason, scoop any untracked
+            // round artefacts into a finalize commit, and surface the
+            // `session-wall-clock` token in stderr so scripts can
+            // pattern-match on it (matches src/cli/new.ts verbiage).
+            const leadTerm: State = {
+              ...currentState,
+              round_state: "lead_terminal",
+              round_index: roundIndex - 1,
+              updated_at: nowIso(),
+              exit: {
+                code: 4,
+                reason: "lead-terminal:wall_clock",
+                round_index: roundIndex,
+              },
+            };
+            writeState(paths.statePath, leadTerm);
+            error(
+              `samospec: session-wall-clock exceeded during round ` +
+                `${String(roundIndex)} (${String(err.elapsedMs)}ms ` +
+                `elapsed, limit ${String(err.limitMs)}ms). Restart with ` +
+                `a larger --max-session-wall-clock-ms or increase ` +
+                `budget.max_session_wall_clock_minutes.`,
+            );
+            finalizeBookkeeping({
+              cwd: input.cwd,
+              slug: input.slug,
+              statePath: paths.statePath,
+              tldrPath: paths.tldrPath,
+              roundIndex: leadTerm.round_index,
+              // Scoop any round-N artefacts (reviews/rNN/) created
+              // before the cap tripped so the tree is clean on exit.
+              // Same pattern as the existing lead_terminal branch.
+              extraPaths: [dirs.roundDir],
+            });
+            return {
+              exitCode: 4,
+              stdout: lines.join("\n"),
+              stderr: `${errLines.join("\n")}\n`,
+              roundsRun,
+              finalVersion: currentState.version,
+              stopReason: "lead-terminal",
+            };
+          }
+          throw err;
+        }
 
         // Persist state at round boundary (round_state tracking).
         // The round started in "planned" then advanced to "running" inside
@@ -971,6 +1101,103 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
 }
 
 // ---------- helpers ----------
+
+// ---------- session wall-clock guard (#91) ----------
+
+/**
+ * Thrown by `withSessionDeadline()` when the iterate session wall-clock
+ * cap is exceeded. Mirrors `SessionWallClockError` in `src/cli/new.ts`
+ * so both subcommands surface the same `session-wall-clock` token in
+ * stderr and exit with code 4.
+ */
+class SessionWallClockError extends Error {
+  readonly phase: string;
+  readonly elapsedMs: number;
+  readonly limitMs: number;
+  constructor(phase: string, elapsedMs: number, limitMs: number) {
+    super(
+      `session-wall-clock: ${phase} exceeded ${String(limitMs)}ms limit ` +
+        `(elapsed ${String(elapsedMs)}ms)`,
+    );
+    this.name = "SessionWallClockError";
+    this.phase = phase;
+    this.elapsedMs = elapsedMs;
+    this.limitMs = limitMs;
+  }
+}
+
+/**
+ * Race `promise` against a deadline derived from `startMs + limitMs`.
+ * If the deadline fires first, throws `SessionWallClockError`. Used at
+ * every seat call and between rounds so a hanging reviewer cannot run
+ * past the cap (see #91 live-repro: 40 min cap, 1h 41m runtime).
+ */
+async function withSessionDeadline<T>(
+  promise: Promise<T>,
+  phase: string,
+  startMs: number,
+  limitMs: number,
+): Promise<T> {
+  const remaining = limitMs - (Date.now() - startMs);
+  if (remaining <= 0) {
+    throw new SessionWallClockError(phase, Date.now() - startMs, limitMs);
+  }
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new SessionWallClockError(phase, Date.now() - startMs, limitMs));
+    }, remaining);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e: unknown) => {
+        clearTimeout(timer);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      },
+    );
+  });
+}
+
+/**
+ * Resolve the session wall-clock limit (ms) for `runIterate`:
+ *   1. `input.maxSessionWallClockMs` (explicit override, e.g. from
+ *      `--max-session-wall-clock-ms <ms>` on the CLI).
+ *   2. `budget.max_session_wall_clock_minutes` in `.samo/config.json`.
+ *   3. `DEFAULT_SESSION_WALL_CLOCK_MS` (10 min).
+ *
+ * Kept local to `iterate.ts` so changes to `new.ts`'s config layout
+ * cannot silently mutate iterate's cap; the two subcommands share the
+ * same schema but resolve it independently.
+ */
+function resolveSessionWallClockMs(input: IterateInput): number {
+  if (typeof input.maxSessionWallClockMs === "number") {
+    return input.maxSessionWallClockMs;
+  }
+  try {
+    const configPath = path.join(input.cwd, ".samo", "config.json");
+    if (existsSync(configPath)) {
+      const raw = readFileSync(configPath, "utf8");
+      const cfg = JSON.parse(raw) as Record<string, unknown>;
+      const budget = cfg["budget"];
+      if (
+        typeof budget === "object" &&
+        budget !== null &&
+        !Array.isArray(budget)
+      ) {
+        const minutes = (budget as Record<string, unknown>)[
+          "max_session_wall_clock_minutes"
+        ];
+        if (typeof minutes === "number" && minutes > 0) {
+          return Math.round(minutes * 60 * 1_000);
+        }
+      }
+    }
+  } catch {
+    // config unreadable — fall through to default.
+  }
+  return DEFAULT_SESSION_WALL_CLOCK_MS;
+}
 
 function ensureTrailingNewline(s: string): string {
   return s.endsWith("\n") ? s : `${s}\n`;

--- a/tests/cli/iterate-wall-clock.test.ts
+++ b/tests/cli/iterate-wall-clock.test.ts
@@ -1,0 +1,308 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED test for #91: iterate: --max-session-wall-clock-ms silently ignored.
+//
+// samospec new honors --max-session-wall-clock-ms; samospec iterate drops
+// the flag because the parser has no branch for it AND runIterate doesn't
+// accept a maxSessionWallClockMs field. Live-repro: flag set to 40min,
+// iterate ran 1h 41m before needing manual kill.
+//
+// Two test layers:
+//
+// 1. Parser layer (src/cli.ts `parseIterateArgs`): the flag must be
+//    accepted in both space-separated and `=value` forms. Unknown flags
+//    like `--rouns 5` (typo of `--rounds 5`) must be rejected with exit
+//    1 and "unknown flag" in stderr instead of silently dropped.
+//
+// 2. Runtime layer (src/cli/iterate.ts `runIterate`): with a mock
+//    adapter that hangs on `critique`, runIterate must exit 4 within
+//    ~2× the cap when maxSessionWallClockMs is honored, with
+//    `session-wall-clock` in stderr.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { runCli } from "../../src/cli.ts";
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type {
+  Adapter,
+  CritiqueInput,
+  CritiqueOutput,
+} from "../../src/adapter/types.ts";
+import { runIterate, type IterateResolvers } from "../../src/cli/iterate.ts";
+import { writeState } from "../../src/state/store.ts";
+import type { State } from "../../src/state/types.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-iter-wc-"));
+  initRepo(tmp);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function initRepo(cwd: string): void {
+  spawnSync("git", ["init", "-q"], { cwd });
+  spawnSync("git", ["config", "user.email", "test@example.com"], { cwd });
+  spawnSync("git", ["config", "user.name", "Test"], { cwd });
+  spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd });
+  spawnSync("git", ["checkout", "-q", "-b", "samospec/wc-slug"], { cwd });
+  writeFileSync(path.join(cwd, "README.md"), "seed\n", "utf8");
+  spawnSync("git", ["add", "README.md"], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "seed"], { cwd });
+}
+
+function seedSpec(cwd: string, slug: string): void {
+  const slugDir = path.join(cwd, ".samo", "spec", slug);
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(
+    path.join(slugDir, "SPEC.md"),
+    "# SPEC\n\ncontent v0.1\n",
+    "utf8",
+  );
+  writeFileSync(path.join(slugDir, "TLDR.md"), "# TLDR\n\n- old\n", "utf8");
+  writeFileSync(
+    path.join(slugDir, "decisions.md"),
+    "# decisions\n\n- No review-loop decisions yet.\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "changelog.md"),
+    "# changelog\n\n## v0.1 — seed\n\n- initial\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "interview.json"),
+    JSON.stringify({
+      slug,
+      persona: 'Veteran "wc-slug" expert',
+      generated_at: "2026-04-19T12:00:00Z",
+      questions: [],
+      answers: [],
+    }),
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "context.json"),
+    JSON.stringify({
+      phase: "draft",
+      files: [],
+      risk_flags: [],
+      budget: { phase: "draft", tokens_used: 0, tokens_budget: 0 },
+    }),
+    "utf8",
+  );
+  const state: State = {
+    slug,
+    phase: "review_loop",
+    round_index: 0,
+    version: "0.1.0",
+    persona: { skill: "wc-slug", accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: "2026-04-19T12:00:00Z",
+    updated_at: "2026-04-19T12:00:00Z",
+  };
+  writeState(path.join(slugDir, "state.json"), state);
+  spawnSync("git", ["add", "."], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "spec(wc-slug): draft v0.1"], {
+    cwd,
+  });
+}
+
+const ACCEPT_RESOLVERS: IterateResolvers = {
+  onManualEdit: () => Promise.resolve("incorporate"),
+  onDegraded: () => Promise.resolve("accept"),
+  onReviewerExhausted: () => Promise.resolve("abort"),
+};
+
+// ---------- 1. Parser: flag accepted ----------
+
+describe("iterate parser — --max-session-wall-clock-ms accepted (#91)", () => {
+  test("no state seeded, so the run fails at the state-missing precondition, but parsing does not", async () => {
+    // Parser must ACCEPT --max-session-wall-clock-ms. We feed a
+    // non-existent slug so the run aborts at the state-missing gate
+    // (exit 1, "no spec found") instead of mid-loop — that's fine for
+    // this test; we only care the parser did not reject the flag.
+    const res = await runCli([
+      "iterate",
+      "missing-slug",
+      "--max-session-wall-clock-ms",
+      "5000",
+    ]);
+    // Must NOT be the parser-failed path ("samospec iterate: missing
+    // <slug>" / usage echo). Exit 1 from runIterate's state precondition
+    // surfaces "no spec found" in stderr — proves we reached runIterate.
+    expect(res.stderr.toLowerCase()).toContain("no spec found");
+    expect(res.exitCode).toBe(1);
+  });
+
+  test("equals form --max-session-wall-clock-ms=5000 also accepted", async () => {
+    const res = await runCli([
+      "iterate",
+      "missing-slug",
+      "--max-session-wall-clock-ms=5000",
+    ]);
+    expect(res.stderr.toLowerCase()).toContain("no spec found");
+    expect(res.exitCode).toBe(1);
+  });
+
+  test("non-integer value rejected with exit 1 + flag name in stderr", async () => {
+    const res = await runCli([
+      "iterate",
+      "missing-slug",
+      "--max-session-wall-clock-ms",
+      "not-a-number",
+    ]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr.toLowerCase()).toContain("max-session-wall-clock-ms");
+  });
+});
+
+// ---------- 2. Parser: unknown flag rejected (typo guard) ----------
+
+describe("iterate parser — unknown --flag rejected (#91)", () => {
+  test("--rouns 5 (typo of --rounds) rejected with exit 1 + 'unknown flag' in stderr", async () => {
+    const res = await runCli(["iterate", "some-slug", "--rouns", "5"]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr.toLowerCase()).toContain("unknown flag");
+  });
+
+  test("bare unknown --foo rejected with exit 1 + 'unknown flag' in stderr", async () => {
+    const res = await runCli(["iterate", "some-slug", "--foo"]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr.toLowerCase()).toContain("unknown flag");
+  });
+
+  test("known flags --rounds, --no-push, --remote, --quiet still accepted", async () => {
+    const res = await runCli([
+      "iterate",
+      "missing-slug",
+      "--rounds",
+      "1",
+      "--no-push",
+      "--remote",
+      "origin",
+      "--quiet",
+    ]);
+    // These are valid flags — parser must not reject. Run falls through
+    // to runIterate's missing-spec gate.
+    expect(res.stderr.toLowerCase()).toContain("no spec found");
+    expect(res.exitCode).toBe(1);
+  });
+});
+
+// ---------- 3. Runtime: hanging reviewer honors the cap ----------
+
+function makeHangingCritiqueAdapter(): Adapter {
+  const base = createFakeAdapter({});
+  return {
+    ...base,
+    critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
+      new Promise(() => {
+        /* hangs forever */
+      }),
+  };
+}
+
+describe("runIterate — maxSessionWallClockMs caps a hanging round (#91)", () => {
+  test("hanging critique is preempted; exit 4 within ~2x cap; stderr contains session-wall-clock", async () => {
+    const slug = "wc-slug";
+    seedSpec(tmp, slug);
+
+    const lead = createFakeAdapter({
+      revise: {
+        spec: "# SPEC\n\nrevised\n",
+        ready: true,
+        rationale: "[]",
+        usage: null,
+        effort_used: "max",
+      },
+    });
+    const reviewerA = makeHangingCritiqueAdapter();
+    const reviewerB = makeHangingCritiqueAdapter();
+
+    const capMs = 2_000;
+    const startMs = Date.now();
+    const res = await runIterate({
+      cwd: tmp,
+      slug,
+      now: "2026-04-19T12:00:00Z",
+      resolvers: ACCEPT_RESOLVERS,
+      adapters: { lead, reviewerA, reviewerB },
+      maxRounds: 1,
+      // The hanging reviewer must be preempted by the session
+      // wall-clock guard, not by the per-call CRITIQUE_TIMEOUT_MS
+      // (which defaults to 300s — way past test timeout).
+      maxSessionWallClockMs: capMs,
+      // Pin SPEC §11's "one more round fits" gate to a neutral state
+      // so the new session-wall-clock cap (not the §11 gate) is what
+      // preempts. Without these, `now_ms - session_started_at_ms` runs
+      // off the `now` string vs real wall-clock and can trip §11 first.
+      sessionStartedAtMs: 0,
+      nowMs: 0,
+      maxWallClockMs: 60 * 60 * 1000,
+    });
+    const elapsedMs = Date.now() - startMs;
+
+    // Must terminate within ~2x the cap (generous allowance for
+    // cleanup + finalize commit + subprocess overhead).
+    expect(elapsedMs).toBeLessThan(capMs * 2 + 4_000);
+    expect(res.exitCode).toBe(4);
+    expect(res.stderr.toLowerCase()).toContain("session-wall-clock");
+  }, 15_000);
+
+  test("runIterate accepts maxSessionWallClockMs without throwing when all calls complete fast", async () => {
+    const slug = "wc-slug";
+    seedSpec(tmp, slug);
+
+    const lead = createFakeAdapter({
+      revise: {
+        spec: "# SPEC\n\nrevised fast\n",
+        ready: true,
+        rationale: "[]",
+        usage: null,
+        effort_used: "max",
+      },
+    });
+    const crit: CritiqueOutput = {
+      findings: [],
+      summary: "none",
+      suggested_next_version: "0.2",
+      usage: null,
+      effort_used: "max",
+    };
+    const reviewerA = createFakeAdapter({ critique: crit });
+    const reviewerB = createFakeAdapter({ critique: crit });
+
+    // Generous cap — the fake-adapter round completes in milliseconds.
+    const res = await runIterate({
+      cwd: tmp,
+      slug,
+      now: "2026-04-19T12:00:00Z",
+      resolvers: ACCEPT_RESOLVERS,
+      adapters: { lead, reviewerA, reviewerB },
+      maxRounds: 5,
+      maxSessionWallClockMs: 60_000,
+      // Explicit time inputs keep the pre-round shouldStartNextRound
+      // check from firing; see iterate.test.ts DEFAULT_TIME_INPUTS.
+      sessionStartedAtMs: 0,
+      nowMs: 0,
+      maxWallClockMs: 60 * 60 * 1000,
+    });
+
+    expect(res.exitCode).toBe(0);
+    expect(res.stopReason).toBe("ready");
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

- Parser now accepts `--max-session-wall-clock-ms <ms>` (space + `=` forms) for `samospec iterate`, reusing `parseMaxSessionWallClockMs` from `samospec new`.
- Parser now rejects unknown flags (e.g. the typo `--rouns 5`) with exit 1 + `unknown flag` in stderr instead of silently dropping them. Allowed flags are centralised in `ITERATE_ALLOWED_FLAGS`.
- `runIterate` threads `maxSessionWallClockMs` end-to-end: pre-round check and `withSessionDeadline` wrapper around every `runRound` call. On cap: exit 4, stderr contains `session-wall-clock`, `state.json` written `lead-terminal:wall_clock`, finalize commit scoops any round-N artefacts.

Fixes #91. Before this fix, iterate silently ran past the user's cap (live-repro: 40-min cap, 1h 41m runtime, revise hang at round 7).

## Test plan

- [x] `tests/cli/iterate-wall-clock.test.ts` — red first:
  - parser accepts `--max-session-wall-clock-ms 5000` (and `=5000`) without error
  - parser rejects non-integer value with flag name in stderr
  - unknown flag `--rouns 5` / bare `--foo` rejected with `unknown flag` in stderr
  - known flags (`--rounds`, `--no-push`, `--remote`, `--quiet`) still accepted
  - hanging critique preempted within ~2x cap; exit 4; `session-wall-clock` in stderr
  - fast run with the flag completes normally (`ready` exit)
- [x] `bun test` — 1426 tests pass, 0 fail
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run format:check` clean

Robot generated with [Claude Code](https://claude.com/claude-code)