### PR TITLE
fix(cli): consume --verbose flag in runNew (#77)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ const USAGE =
   "  init                        Create or refresh .samo/ in the current repo.\n" +
   "  doctor                      Diagnose CLI availability, auth, git, lock, and config.\n" +
   "  new <slug> [--idea ...] [--force] [--skip <sections>]\n" +
-  "            [--max-session-wall-clock-ms <ms>]\n" +
+  "            [--max-session-wall-clock-ms <ms>] [--verbose]\n" +
   "                              Start a new spec (persona + 5-question interview).\n" +
   "                              --force archives any existing run before starting\n" +
   "                              fresh. --skip omits named baseline sections from\n" +
@@ -60,6 +60,8 @@ const USAGE =
   "                              budget.max_session_wall_clock_minutes in config.json\n" +
   "                              or 600000 (10 min). On cap, exits 4 with reason\n" +
   "                              `session-wall-clock`.\n" +
+  "                              --verbose emits targeted per-phase and per-file\n" +
+  "                              diagnostic lines on stderr (stdout stays concise).\n" +
   "  resume [<slug>]             Resume an in-progress spec from state.json.\n" +
   "  iterate [<slug>] [--rounds N] [--no-push] [--remote <name>] [--quiet]\n" +
   "                              Run review rounds until a stopping condition fires.\n" +
@@ -152,6 +154,7 @@ interface NewArgs {
   readonly skipSections?: readonly string[];
   readonly force: boolean;
   readonly maxSessionWallClockMs?: number;
+  readonly verbose: boolean;
 }
 
 interface ResumeArgs {
@@ -206,6 +209,7 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
   let idea: string | null = null;
   let explain = false;
   let force = false;
+  let verbose = false;
   let skipSections: readonly string[] | undefined;
   let maxSessionWallClockMs: number | undefined;
   for (let i = 0; i < argv.length; i += 1) {
@@ -217,6 +221,13 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
     }
     if (token === "--force") {
       force = true;
+      continue;
+    }
+    if (token === "--verbose") {
+      // Issue #77: gate targeted per-phase + per-file diagnostic lines
+      // on stderr. stdout stays concise so pipelines that parse the
+      // happy-path output don't break.
+      verbose = true;
       continue;
     }
     if (token === "--idea") {
@@ -275,6 +286,7 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
     idea: idea ?? slug,
     explain,
     force,
+    verbose,
     ...(skipSections !== undefined ? { skipSections } : {}),
     ...(maxSessionWallClockMs !== undefined ? { maxSessionWallClockMs } : {}),
   };
@@ -407,6 +419,7 @@ async function runNewCommand(rest: readonly string[]) {
       idea: parsed.idea,
       explain: parsed.explain,
       force: parsed.force,
+      verbose: parsed.verbose,
       resolvers: interactiveResolvers(),
       now: new Date().toISOString(),
       ...(parsed.skipSections !== undefined

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -266,6 +266,7 @@ export async function runNew(
 ): Promise<RunNewResult> {
   const lines: string[] = [];
   const errors: string[] = [];
+  const verboseLines: string[] = [];
   const notice = (line: string): void => {
     lines.push(line);
   };
@@ -273,6 +274,24 @@ export async function runNew(
   // Session wall-clock guard (#81): track start time and cap.
   const sessionStartMs = Date.now();
   const sessionLimitMs = resolveSessionWallClockMs(input);
+
+  // Issue #77: `--verbose` — when on, emit targeted diagnostic lines to
+  // **stderr** (matching `iterate`'s progress-stream convention). stdout
+  // stays the concise summary so pipelines parsing the happy-path output
+  // don't break. No-op when verbose is false/omitted.
+  const verboseEnabled = input.verbose === true;
+  const trace = (line: string): void => {
+    if (!verboseEnabled) return;
+    const elapsed = Date.now() - sessionStartMs;
+    verboseLines.push(`[verbose +${String(elapsed)}ms] ${line}`);
+  };
+  const buildStderr = (): string => {
+    const parts: string[] = [];
+    if (verboseLines.length > 0) parts.push(verboseLines.join("\n"));
+    if (errors.length > 0) parts.push(errors.join("\n"));
+    if (parts.length === 0) return "";
+    return `${parts.join("\n")}\n`;
+  };
 
   const samoDir = path.join(input.cwd, ".samo");
   const specsDir = path.join(samoDir, "spec");
@@ -302,7 +321,7 @@ export async function runNew(
       return {
         exitCode: 1,
         stdout: lines.join("\n"),
-        stderr: `${errors.join("\n")}\n`,
+        stderr: buildStderr(),
       };
     }
   }
@@ -327,7 +346,7 @@ export async function runNew(
       return {
         exitCode: 2,
         stdout: lines.join("\n"),
-        stderr: `${errors.join("\n")}\n`,
+        stderr: buildStderr(),
       };
     }
     throw err;
@@ -380,7 +399,7 @@ export async function runNew(
           return {
             exitCode: consent.exitCode ?? CONSENT_ABORT_EXIT_CODE,
             stdout: lines.join("\n"),
-            stderr: `${errors.join("\n")}\n`,
+            stderr: buildStderr(),
           };
         }
         if (consent.decision === "downshift") {
@@ -421,7 +440,7 @@ export async function runNew(
       return {
         exitCode: 2,
         stdout: lines.join("\n"),
-        stderr: `${errors.join("\n")}\n`,
+        stderr: buildStderr(),
       };
     }
     if (branchResult.kind === "created") {
@@ -465,7 +484,7 @@ export async function runNew(
         return {
           exitCode: 2,
           stdout: lines.join("\n"),
-          stderr: `${errors.join("\n")}\n`,
+          stderr: buildStderr(),
         };
       }
     } else if (branchResult.kind === "skipped") {
@@ -494,6 +513,7 @@ export async function runNew(
     // Phase 2 — persona.
     state = advancePhase(state, "persona", { now: input.now });
     writeState(statePath, state);
+    trace(`phase persona: entering (adapter=${adapter.vendor})`);
 
     const subAuth = await resolveSubscriptionAuth(adapter);
     let persona: PersonaProposal;
@@ -526,7 +546,7 @@ export async function runNew(
         return {
           exitCode: 4,
           stdout: lines.join("\n"),
-          stderr: `${errors.join("\n")}\n`,
+          stderr: buildStderr(),
         };
       }
       if (err instanceof PersonaTerminalError) {
@@ -540,7 +560,7 @@ export async function runNew(
         return {
           exitCode: 4,
           stdout: lines.join("\n"),
-          stderr: `${errors.join("\n")}\n`,
+          stderr: buildStderr(),
         };
       }
       throw err;
@@ -557,6 +577,7 @@ export async function runNew(
     // Phase 3 — context discovery (SPEC §7).
     state = advancePhase(state, "context", { now: input.now });
     writeState(statePath, state);
+    trace(`phase context: discovering tracked + untracked files`);
 
     const ctxPath = contextJsonPath(input.cwd, input.slug);
     let chunks: readonly string[] = [];
@@ -598,6 +619,7 @@ export async function runNew(
     // Phase 4 — interview.
     state = advancePhase(state, "interview", { now: input.now });
     writeState(statePath, state);
+    trace(`phase interview: soliciting 5 questions`);
 
     const interviewPath = path.join(slugDir, "interview.json");
     let interview: InterviewResult;
@@ -633,7 +655,7 @@ export async function runNew(
         return {
           exitCode: 4,
           stdout: lines.join("\n"),
-          stderr: `${errors.join("\n")}\n`,
+          stderr: buildStderr(),
         };
       }
       if (err instanceof InterviewTerminalError) {
@@ -647,7 +669,7 @@ export async function runNew(
         return {
           exitCode: 4,
           stdout: lines.join("\n"),
-          stderr: `${errors.join("\n")}\n`,
+          stderr: buildStderr(),
         };
       }
       errors.push(
@@ -659,7 +681,7 @@ export async function runNew(
       return {
         exitCode: 3,
         stdout: lines.join("\n"),
-        stderr: `${errors.join("\n")}\n`,
+        stderr: buildStderr(),
       };
     }
 
@@ -670,6 +692,7 @@ export async function runNew(
     // Phase 5 — v0.1 draft.
     state = advancePhase(state, "draft", { now: input.now });
     writeState(statePath, state);
+    trace(`phase draft: authoring v0.1 via revise()`);
 
     let draft;
     try {
@@ -705,7 +728,7 @@ export async function runNew(
         return {
           exitCode: 4,
           stdout: lines.join("\n"),
-          stderr: `${errors.join("\n")}\n`,
+          stderr: buildStderr(),
         };
       }
       if (err instanceof DraftTerminalError) {
@@ -718,7 +741,7 @@ export async function runNew(
         return {
           exitCode: 4,
           stdout: lines.join("\n"),
-          stderr: `${errors.join("\n")}\n`,
+          stderr: buildStderr(),
         };
       }
       throw err;
@@ -750,11 +773,19 @@ export async function runNew(
       ensureTrailingNewline(specWithArchitecture),
       "utf8",
     );
+    trace(
+      `wrote ${path.relative(input.cwd, specPath)} ` +
+        `(${String(Buffer.byteLength(specWithArchitecture, "utf8"))} bytes)`,
+    );
 
     // TLDR.md: heuristic render. Pass state so the Next-action section
     // is derived from state via computeNextAction (#96).
     const tldr = renderTldr(draft.spec, { slug: input.slug, state });
     writeFileSync(tldrPath, tldr, "utf8");
+    trace(
+      `wrote ${path.relative(input.cwd, tldrPath)} ` +
+        `(${String(Buffer.byteLength(tldr, "utf8"))} bytes)`,
+    );
 
     // decisions.md: empty seed; populated by the review loop.
     writeFileSync(
@@ -846,7 +877,7 @@ export async function runNew(
           return {
             exitCode: 2,
             stdout: lines.join("\n"),
-            stderr: `${errors.join("\n")}\n`,
+            stderr: buildStderr(),
           };
         }
         throw err;
@@ -890,7 +921,7 @@ export async function runNew(
     return {
       exitCode: 0,
       stdout: lines.length === 0 ? "" : `${lines.join("\n")}\n`,
-      stderr: "",
+      stderr: buildStderr(),
     };
   } finally {
     releaseLock(handle);

--- a/tests/cli/new-verbose.test.ts
+++ b/tests/cli/new-verbose.test.ts
@@ -1,0 +1,184 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #77 — PR #74 wired `RunNewInput.verbose` + accepted `--verbose` on
+// the CLI (by virtue of permissive unknown-flag passthrough), but `runNew`
+// never actually consumed the field. A user passing `--verbose` saw
+// identical output. This file asserts the fix: when verbose=true, `runNew`
+// emits several additional diagnostic lines on **stderr** (progress /
+// spawn / per-file write paths), while stdout stays the quiet summary.
+//
+// The targeted lines are the inter-phase timings + the per-file write
+// paths for the committed-artifact set (SPEC §9). These are the signals
+// an operator debugging a hang actually wants to see.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type { Adapter, AskInput, AskOutput } from "../../src/adapter/types.ts";
+import { runInit } from "../../src/cli/init.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+
+const NOW = "2026-04-21T12:00:00Z";
+
+function askOut(answer: string): AskOutput {
+  return { answer, usage: null, effort_used: "max" };
+}
+
+const personaJson = (skill: string): string =>
+  JSON.stringify({
+    persona: `Veteran "${skill}" expert`,
+    rationale: "pragmatic choice",
+  });
+
+const questionsJson = (
+  items: readonly { id: string; text: string }[],
+): string =>
+  JSON.stringify({
+    questions: items.map((q) => ({
+      id: q.id,
+      text: q.text,
+      options: ["opt A", "opt B"],
+    })),
+  });
+
+function makeLeadAdapter(answers: readonly string[]): Adapter {
+  const base = createFakeAdapter({});
+  let call = 0;
+  return {
+    ...base,
+    ask: (_input: AskInput): Promise<AskOutput> => {
+      const a = answers[call] ?? answers[answers.length - 1] ?? "";
+      call += 1;
+      return Promise.resolve(askOut(a));
+    },
+  };
+}
+
+function acceptResolver(): ChoiceResolvers {
+  return {
+    persona: () => Promise.resolve({ kind: "accept" }),
+    question: () => Promise.resolve({ choice: "decide for me" }),
+  };
+}
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-verbose-77-"));
+  runInit({ cwd: tmp });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("samospec new --verbose (#77)", () => {
+  test("verbose=true emits additional diagnostic lines on stderr", async () => {
+    const adapter = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([
+        { id: "q1", text: "framework?" },
+        { id: "q2", text: "db?" },
+      ]),
+    ]);
+
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo-verbose",
+        idea: "a CLI for turning ideas into specs",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: NOW,
+        verbose: true,
+      },
+      adapter,
+    );
+
+    expect(result.exitCode).toBe(0);
+    // With verbose on, stderr must carry diagnostic lines. The bar is
+    // loose on purpose: we only care that the flag is actually consumed.
+    const stderrLines = result.stderr
+      .split("\n")
+      .filter((l) => l.trim().length > 0);
+    expect(stderrLines.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("verbose=true produces strictly more stderr than verbose=false", async () => {
+    const makePair = (): Adapter =>
+      makeLeadAdapter([
+        personaJson("CLI engineer"),
+        questionsJson([
+          { id: "q1", text: "framework?" },
+          { id: "q2", text: "db?" },
+        ]),
+      ]);
+
+    const quiet = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo-quiet",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: NOW,
+        verbose: false,
+      },
+      makePair(),
+    );
+
+    // Fresh sandbox for the verbose pass — otherwise `samospec new`
+    // refuses to clobber the existing slug dir.
+    const tmp2 = mkdtempSync(path.join(tmpdir(), "samospec-verbose-77b-"));
+    try {
+      runInit({ cwd: tmp2 });
+      const verbose = await runNew(
+        {
+          cwd: tmp2,
+          slug: "demo-verbose",
+          idea: "x",
+          explain: false,
+          resolvers: acceptResolver(),
+          now: NOW,
+          verbose: true,
+        },
+        makePair(),
+      );
+      expect(verbose.exitCode).toBe(0);
+      expect(quiet.exitCode).toBe(0);
+      expect(verbose.stderr.length).toBeGreaterThan(quiet.stderr.length);
+    } finally {
+      rmSync(tmp2, { recursive: true, force: true });
+    }
+  });
+
+  test("verbose=true marks each of draft phases 2-5 on stderr", async () => {
+    const adapter = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([{ id: "q1", text: "framework?" }]),
+    ]);
+
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo-phases",
+        idea: "x",
+        explain: false,
+        resolvers: acceptResolver(),
+        now: NOW,
+        verbose: true,
+      },
+      adapter,
+    );
+
+    expect(result.exitCode).toBe(0);
+    // Each of the post-preflight draft phases should be traced once.
+    // We assert on a phase-enter token that only a verbose pass would
+    // emit — e.g. `[phase] persona` / `[phase] interview` / `[phase] draft`.
+    const stderr = result.stderr;
+    expect(stderr).toContain("persona");
+    expect(stderr).toContain("interview");
+    expect(stderr).toContain("draft");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #77.

PR #74 added `RunNewInput.verbose` and accepted `--verbose` on `samospec new` via the permissive unknown-flag passthrough, but `runNew` never read the field. Passing the flag changed no output; the test that ostensibly covered it passed vacuously.

This PR wires `--verbose` to four targeted diagnostic log points on **stderr** (stdout stays the concise summary):

- Phase-enter traces for `persona`, `context`, `interview`, `draft`, each prefixed with `[verbose +<elapsed>ms]` so operators see which step is slow.
- Per-file write paths + byte size for `SPEC.md` and `TLDR.md` — the two largest artifacts the run produces.

`src/cli.ts` `parseNewArgs` now explicitly accepts `--verbose` and threads it into `runNew`; USAGE advertises the new flag.

## Changes

- `src/cli/new.ts`: `trace()` helper writes to a new `verboseLines[]` that `buildStderr()` merges with the existing `errors[]` on every return path. No-op when `verbose` is false/omitted. Success-path stderr is now `verboseLines` (or empty).
- `src/cli.ts`: explicit `--verbose` parse in `parseNewArgs`, threaded into the `runNew` call; USAGE block updated.
- `tests/cli/new-verbose.test.ts`: RED-first coverage — landed in commit `ff83dd4` failing against `main`, turns green with the impl commit `ba787a6`.

## Checklist

- [x] Tests added (red-green TDD visible in commit history)
- [x] `bun test` — 1421 pass, 0 fail (single flaky unrelated `tests/cli/integration.test.ts` spawn-timeout in the combined run; passes in isolation)
- [x] `bun run format:check` clean
- [x] Typecheck clean on the changed files
- [x] Copyright header present on the new test file
- [x] No secrets introduced

## Testing evidence

- `bun test tests/cli/new-verbose.test.ts` — 3/3 pass.
- `bun test tests/cli/verbose-budget.test.ts` — 2/2 pass (existing PR #74 budget test still holds).
- `bun test tests/cli/new.test.ts tests/cli/new.e2e.test.ts tests/cli/new-*.test.ts` — 46/46 pass.

## Out-of-scope / follow-ups

- `runIterate` / `runPublish` verbose threading — tracked in the same bug body but left for a separate PR so this stays focused on the regression.
- The default-stdout < 3000 char threshold is already locked by `tests/cli/verbose-budget.test.ts`; no change here.

Generated with [Claude Code](https://claude.com/claude-code)