### PR TITLE
feat(cli): non-TTY automation for new + iterate (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Non-TTY automation for `new` + `iterate` (#114):** `samospec new`
+  now accepts `--yes`, `--accept-persona`, and `--answers-file <path>`
+  so it can run in CI / piped / background contexts without touching
+  readline. `--answers-file` loads a JSON file shaped
+  `{ "answers": [s, s, s, s, s] }` (exactly 5 entries). `samospec
+iterate` gained `--on-dirty <incorporate|overwrite|abort>`. When
+  stdin is not a TTY and neither flag is set, both commands now exit 1
+  fast with an actionable message instead of crashing with
+  `ERR_USE_AFTER_CLOSE` or readline-deadlocking.
+
 ---
 
 ## [0.5.0] - 2026-04-22

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,11 +13,16 @@ import { runDoctor, type DoctorAdapterBinding } from "./cli/doctor.ts";
 import {
   runIterate,
   type IterateResolvers,
+  type ManualEditResolver,
   type PushOptions,
   type SeatDiagnostics,
 } from "./cli/iterate.ts";
 import { describePrCapability } from "./git/push-consent.ts";
 import { runNew, type ChoiceResolvers } from "./cli/new.ts";
+import {
+  buildNonInteractiveResolvers,
+  loadAnswersFile,
+} from "./cli/non-interactive.ts";
 import { runPublish } from "./cli/publish.ts";
 import {
   PERSONA_FORM_RE,
@@ -27,6 +32,7 @@ import {
 } from "./cli/persona.ts";
 import { runResume } from "./cli/resume.ts";
 import { runStatus, type StatusAdapterBinding } from "./cli/status.ts";
+import type { ManualEditChoice } from "./git/manual-edit.ts";
 import packageJson from "../package.json" with { type: "json" };
 
 export interface CliResult {
@@ -48,6 +54,7 @@ const USAGE =
   "  doctor                      Diagnose CLI availability, auth, git, lock, and config.\n" +
   "  new <slug> [--idea ...] [--force] [--skip <sections>]\n" +
   "            [--max-session-wall-clock-ms <ms>] [--verbose]\n" +
+  "            [--yes] [--accept-persona] [--answers-file <path>]\n" +
   "                              Start a new spec (persona + 5-question interview).\n" +
   "                              --force archives any existing run before starting\n" +
   "                              fresh. --skip omits named baseline sections from\n" +
@@ -62,15 +69,24 @@ const USAGE =
   "                              `session-wall-clock`.\n" +
   "                              --verbose emits targeted per-phase and per-file\n" +
   "                              diagnostic lines on stderr (stdout stays concise).\n" +
+  "                              --yes / --accept-persona skip the persona-proposal\n" +
+  "                              readline prompt. --answers-file <path> loads the\n" +
+  "                              5-question interview answers from a JSON file\n" +
+  '                              (`{ "answers": [s, s, s, s, s] }`). At least one of\n' +
+  "                              these is required when stdin is not a TTY (#114).\n" +
   "  resume [<slug>]             Resume an in-progress spec from state.json.\n" +
   "  iterate [<slug>] [--rounds N] [--no-push] [--remote <name>] [--quiet]\n" +
   "           [--max-session-wall-clock-ms <ms>]\n" +
+  "           [--on-dirty <incorporate|overwrite|abort>]\n" +
   "                              Run review rounds until a stopping condition fires.\n" +
   "                              --quiet suppresses per-phase progress + heartbeat\n" +
   "                              (default: verbose progress on stderr).\n" +
   "                              --max-session-wall-clock-ms caps the review loop\n" +
   "                              session wall-clock (positive integer ms). On cap,\n" +
   "                              exits 4 with reason `session-wall-clock`.\n" +
+  "                              --on-dirty answers the uncommitted-edits prompt\n" +
+  "                              without reading stdin; required when stdin is not\n" +
+  "                              a TTY and `.samo/spec/<slug>/` has dirty edits (#114).\n" +
   "  status [<slug>]             Print phase, round, cost, wall-clock, and next action.\n" +
   "  publish [<slug>] [--no-lint] [--remote <name>]\n" +
   "                              Promote to blueprints/<slug>/SPEC.md, commit, push, open PR.\n" +
@@ -159,6 +175,17 @@ interface NewArgs {
   readonly force: boolean;
   readonly maxSessionWallClockMs?: number;
   readonly verbose: boolean;
+  /**
+   * #114: non-TTY automation surface.
+   *   - `acceptPersona`: accept the lead's persona proposal without prompting.
+   *   - `answersFile`: absolute or relative path to a JSON file with
+   *     `{ "answers": [string x 5] }`. When present, skips the 5Q readline.
+   *   - `yes`: broad "accept everything" — implies `acceptPersona=true` and
+   *     lets interview fall back to `"decide for me"` for every question.
+   */
+  readonly acceptPersona: boolean;
+  readonly yes: boolean;
+  readonly answersFile?: string;
 }
 
 interface ResumeArgs {
@@ -216,6 +243,9 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
   let verbose = false;
   let skipSections: readonly string[] | undefined;
   let maxSessionWallClockMs: number | undefined;
+  let acceptPersona = false;
+  let yes = false;
+  let answersFile: string | undefined;
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
     if (token === undefined) continue;
@@ -232,6 +262,31 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
       // on stderr. stdout stays concise so pipelines that parse the
       // happy-path output don't break.
       verbose = true;
+      continue;
+    }
+    if (token === "--yes" || token === "--no-interactive") {
+      yes = true;
+      continue;
+    }
+    if (token === "--accept-persona") {
+      acceptPersona = true;
+      continue;
+    }
+    if (token === "--answers-file") {
+      const raw = argv[i + 1] ?? "";
+      i += 1;
+      if (raw.length === 0 || raw.startsWith("--")) {
+        return "samospec new: --answers-file requires a path";
+      }
+      answersFile = raw;
+      continue;
+    }
+    if (token.startsWith("--answers-file=")) {
+      const raw = token.slice("--answers-file=".length);
+      if (raw.length === 0) {
+        return "samospec new: --answers-file requires a path";
+      }
+      answersFile = raw;
       continue;
     }
     if (token === "--idea") {
@@ -291,8 +346,11 @@ function parseNewArgs(argv: readonly string[]): NewArgs | string {
     explain,
     force,
     verbose,
+    acceptPersona,
+    yes,
     ...(skipSections !== undefined ? { skipSections } : {}),
     ...(maxSessionWallClockMs !== undefined ? { maxSessionWallClockMs } : {}),
+    ...(answersFile !== undefined ? { answersFile } : {}),
   };
 }
 
@@ -415,6 +473,18 @@ async function runNewCommand(rest: readonly string[]) {
   if (typeof parsed === "string") {
     return { exitCode: 1, stdout: "", stderr: `${parsed}\n\n${USAGE}` };
   }
+  // Non-TTY / automation guard (#114). Decide the resolver strategy
+  // BEFORE any readline interface is created — the pre-#114 code
+  // constructed a readline at module-import time, which crashed with
+  // ERR_USE_AFTER_CLOSE the moment a non-TTY stdin got closed.
+  const resolversOrErr = buildNewResolvers(parsed);
+  if (typeof resolversOrErr === "string") {
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `${resolversOrErr}\n\n${USAGE}`,
+    };
+  }
   const adapter = leadAdapter();
   return runNew(
     {
@@ -424,7 +494,7 @@ async function runNewCommand(rest: readonly string[]) {
       explain: parsed.explain,
       force: parsed.force,
       verbose: parsed.verbose,
-      resolvers: interactiveResolvers(),
+      resolvers: resolversOrErr,
       now: new Date().toISOString(),
       ...(parsed.skipSections !== undefined
         ? { skipSections: [...parsed.skipSections] }
@@ -435,6 +505,49 @@ async function runNewCommand(rest: readonly string[]) {
     },
     adapter,
   );
+}
+
+/**
+ * #114 — pick the `ChoiceResolvers` strategy for `samospec new` based
+ * on the parsed flags and whether stdin is a TTY.
+ *
+ *   - stdin is TTY: default to the interactive readline resolver.
+ *   - stdin is NOT a TTY and any of `--yes`, `--accept-persona`,
+ *     `--answers-file` is present: build a non-interactive resolver.
+ *   - stdin is NOT a TTY and NO automation flag: return an error
+ *     string so the CLI exits 1 fast with actionable guidance, rather
+ *     than crashing on the first `rl.question()` call.
+ *
+ * When `--answers-file` is present but malformed, surface the loader's
+ * error verbatim so the user can jump to the offending line.
+ */
+function buildNewResolvers(parsed: NewArgs): ChoiceResolvers | string {
+  const hasAutomationFlag =
+    parsed.yes || parsed.acceptPersona || parsed.answersFile !== undefined;
+  const stdinIsTty = process.stdin.isTTY === true;
+
+  if (!stdinIsTty && !hasAutomationFlag) {
+    return (
+      "samospec new: stdin is not a TTY (piped, CI, background). " +
+      "Pass one of --yes, --accept-persona, or --answers-file <path> " +
+      "to run non-interactively."
+    );
+  }
+
+  let answers: readonly string[] | undefined;
+  if (parsed.answersFile !== undefined) {
+    const loaded = loadAnswersFile(parsed.answersFile);
+    if (!loaded.ok) return loaded.error;
+    answers = loaded.answers;
+  }
+
+  if (hasAutomationFlag) {
+    return buildNonInteractiveResolvers({
+      acceptPersona: parsed.yes || parsed.acceptPersona,
+      answers,
+    });
+  }
+  return interactiveResolvers();
 }
 
 async function runResumeCommand(rest: readonly string[]) {
@@ -464,6 +577,35 @@ interface IterateArgs {
   readonly remote: string;
   readonly quiet: boolean;
   readonly maxSessionWallClockMs?: number;
+  /**
+   * #114: when set, `iterate` answers the uncommitted-edits prompt
+   * without reading stdin. Required in non-TTY contexts where
+   * `.samo/spec/<slug>/` has dirty edits.
+   */
+  readonly onDirty?: ManualEditChoice;
+}
+
+const ON_DIRTY_CHOICES: readonly ManualEditChoice[] = [
+  "incorporate",
+  "overwrite",
+  "abort",
+];
+
+type ParseOnDirtyResult =
+  | { readonly ok: true; readonly value: ManualEditChoice }
+  | { readonly ok: false; readonly error: string };
+
+function parseOnDirty(raw: string): ParseOnDirtyResult {
+  const norm = raw.trim().toLowerCase();
+  if (ON_DIRTY_CHOICES.includes(norm as ManualEditChoice)) {
+    return { ok: true, value: norm as ManualEditChoice };
+  }
+  return {
+    ok: false,
+    error:
+      `samospec iterate: --on-dirty must be one of ${ON_DIRTY_CHOICES.join("|")} ` +
+      `(got '${raw}')`,
+  };
 }
 
 /**
@@ -479,6 +621,8 @@ const ITERATE_ALLOWED_FLAGS: ReadonlySet<string> = new Set([
   "--remote",
   "--quiet",
   "--max-session-wall-clock-ms",
+  // #114: non-TTY automation.
+  "--on-dirty",
 ]);
 
 function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
@@ -488,6 +632,7 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
   let remote = "origin";
   let quiet = false;
   let maxSessionWallClockMs: number | undefined;
+  let onDirty: ManualEditChoice | undefined;
   for (let i = 0; i < argv.length; i += 1) {
     const t = argv[i];
     if (t === undefined) continue;
@@ -513,6 +658,21 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
       // Issue #101: suppress per-phase + heartbeat; final summary still
       // prints. No-op when combined with `--rounds 0` or similar.
       quiet = true;
+      continue;
+    }
+    if (t === "--on-dirty") {
+      const raw = argv[i + 1] ?? "";
+      i += 1;
+      const parsed = parseOnDirty(raw);
+      if (!parsed.ok) return parsed.error;
+      onDirty = parsed.value;
+      continue;
+    }
+    if (t.startsWith("--on-dirty=")) {
+      const raw = t.slice("--on-dirty=".length);
+      const parsed = parseOnDirty(raw);
+      if (!parsed.ok) return parsed.error;
+      onDirty = parsed.value;
       continue;
     }
     if (t === "--remote") {
@@ -568,6 +728,7 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
     quiet,
     ...(rounds !== undefined ? { rounds } : {}),
     ...(maxSessionWallClockMs !== undefined ? { maxSessionWallClockMs } : {}),
+    ...(onDirty !== undefined ? { onDirty } : {}),
   };
 }
 
@@ -597,28 +758,65 @@ function buildReviewLoopAdapters(): {
   return { lead, reviewerA, reviewerB };
 }
 
-function interactiveIterateResolvers(): IterateResolvers {
+/**
+ * #114 — build the manual-edit resolver.
+ *
+ *   - `onDirty` flag set: return a resolver that answers without any
+ *     readline call, so `iterate` never touches stdin.
+ *   - stdin is NOT a TTY and `onDirty` is NOT set: return a resolver
+ *     that surfaces a clear error string via `throw` when the dirty
+ *     path fires. `iterate` catches this and exits 1 cleanly rather
+ *     than deadlocking the readline prompt.
+ *   - default: the legacy interactive prompt.
+ */
+function buildManualEditResolver(
+  rl: readline.Interface,
+  onDirty: ManualEditChoice | undefined,
+): ManualEditResolver {
+  if (onDirty !== undefined) {
+    return (_files) => Promise.resolve(onDirty);
+  }
+  const stdinIsTty = process.stdin.isTTY === true;
+  if (!stdinIsTty) {
+    return (files) => {
+      const detail =
+        files.length === 0 ? "(0 files)" : `(${String(files.length)} file(s))`;
+      return Promise.reject(
+        new Error(
+          `samospec iterate: uncommitted edits under .samo/spec/ ${detail} ` +
+            "but stdin is not a TTY. Pass --on-dirty " +
+            "<incorporate|overwrite|abort> to run non-interactively.",
+        ),
+      );
+    };
+  }
+  return async (files) => {
+    process.stdout.write(
+      `\nUncommitted edits detected under .samo/spec/ (${String(files.length)} file(s)):\n`,
+    );
+    for (const f of files) process.stdout.write(`  - ${f}\n`);
+    const ans = (
+      await rl.question(
+        "[I]ncorporate / [O]verwrite / [A]bort [Enter=incorporate]: ",
+      )
+    )
+      .trim()
+      .toLowerCase();
+    if (ans === "o" || ans === "overwrite") return "overwrite";
+    if (ans === "a" || ans === "abort") return "abort";
+    return "incorporate";
+  };
+}
+
+function interactiveIterateResolvers(
+  onDirty: ManualEditChoice | undefined,
+): IterateResolvers {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
   return {
-    onManualEdit: async (files) => {
-      process.stdout.write(
-        `\nUncommitted edits detected under .samo/spec/ (${String(files.length)} file(s)):\n`,
-      );
-      for (const f of files) process.stdout.write(`  - ${f}\n`);
-      const ans = (
-        await rl.question(
-          "[I]ncorporate / [O]verwrite / [A]bort [Enter=incorporate]: ",
-        )
-      )
-        .trim()
-        .toLowerCase();
-      if (ans === "o" || ans === "overwrite") return "overwrite";
-      if (ans === "a" || ans === "abort") return "abort";
-      return "incorporate";
-    },
+    onManualEdit: buildManualEditResolver(rl, onDirty),
     onDegraded: async (summary) => {
       process.stdout.write(`\n${summary}\n`);
       const ans = (await rl.question("[A]ccept / [B]bort [Enter=accept]: "))
@@ -685,24 +883,35 @@ async function runIterateCommand(rest: readonly string[]) {
     remote: parsed.remote,
     noPush: parsed.noPush,
   };
-  const result = await runIterate({
-    cwd: process.cwd(),
-    slug: parsed.slug,
-    now: new Date().toISOString(),
-    resolvers: interactiveIterateResolvers(),
-    adapters,
-    pushOptions,
-    quiet: parsed.quiet,
-    ...(parsed.rounds !== undefined ? { maxRounds: parsed.rounds } : {}),
-    ...(parsed.maxSessionWallClockMs !== undefined
-      ? { maxSessionWallClockMs: parsed.maxSessionWallClockMs }
-      : {}),
-  });
-  return {
-    exitCode: result.exitCode,
-    stdout: result.stdout,
-    stderr: result.stderr,
-  };
+  try {
+    const result = await runIterate({
+      cwd: process.cwd(),
+      slug: parsed.slug,
+      now: new Date().toISOString(),
+      resolvers: interactiveIterateResolvers(parsed.onDirty),
+      adapters,
+      pushOptions,
+      quiet: parsed.quiet,
+      ...(parsed.rounds !== undefined ? { maxRounds: parsed.rounds } : {}),
+      ...(parsed.maxSessionWallClockMs !== undefined
+        ? { maxSessionWallClockMs: parsed.maxSessionWallClockMs }
+        : {}),
+    });
+    return {
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  } catch (err) {
+    // #114: the non-TTY manual-edit resolver rejects with an Error so
+    // iterate exits cleanly instead of readline-deadlocking. Translate
+    // the rejection to an exit-1 CliResult with the actionable message.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("--on-dirty")) {
+      return { exitCode: 1, stdout: "", stderr: `${msg}\n` };
+    }
+    throw err;
+  }
 }
 
 async function runStatusCommand(rest: readonly string[]) {

--- a/src/cli/non-interactive.ts
+++ b/src/cli/non-interactive.ts
@@ -1,0 +1,186 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #114 — non-TTY automation helpers for `samospec new` and
+// `samospec iterate`.
+//
+// Two public surfaces:
+//
+//   - loadAnswersFile(path): parse a `--answers-file <path>` JSON file.
+//     Shape: `{ "answers": [string, string, string, string, string] }`
+//     (exactly 5 entries — the SPEC §5 interview cap). Returns a tagged
+//     union so the caller can surface the error verbatim above USAGE.
+//
+//   - buildNonInteractiveResolvers({ acceptPersona, answers }): a
+//     `ChoiceResolvers` that NEVER touches readline / stdin. Persona
+//     accepts the lead's proposal as-is; questions pull from the
+//     supplied answers list in order, falling back to `decide for me`
+//     (a canonical schema option from SPEC §5) when no answer is
+//     supplied or the list is exhausted.
+//
+// Both surfaces are tested in isolation before the CLI wires them;
+// see tests/cli/new-answers-file.test.ts and
+// tests/cli/new-accept-persona.test.ts.
+
+import { readFileSync } from "node:fs";
+
+import type { ChoiceResolvers } from "./new.ts";
+
+// ---------- answers-file loader ----------
+
+/** Expected interview answer count (SPEC §5 Phase 4 hard cap). */
+export const INTERVIEW_ANSWER_COUNT = 5 as const;
+
+export type LoadAnswersResult =
+  | { readonly ok: true; readonly answers: readonly string[] }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Parse a `--answers-file <path>` JSON file. The file must be:
+ *   { "answers": [string, ...] }  // length === INTERVIEW_ANSWER_COUNT
+ *
+ * Line numbers are reported for malformed JSON where possible so the
+ * user can jump straight to the offending row.
+ */
+export function loadAnswersFile(filePath: string): LoadAnswersResult {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: `samospec new: --answers-file could not be read: ${filePath} (${reason})`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const line = extractLineNumber(raw, err);
+    const lineHint =
+      line !== null ? ` (line ${String(line)})` : " (line unknown)";
+    return {
+      ok: false,
+      error: `samospec new: --answers-file has invalid JSON${lineHint}: ${msg}`,
+    };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      error:
+        "samospec new: --answers-file must be a JSON object with an `answers` array " +
+        `(got ${Array.isArray(parsed) ? "array" : typeof parsed})`,
+    };
+  }
+  const answersRaw = (parsed as Record<string, unknown>)["answers"];
+  if (!Array.isArray(answersRaw)) {
+    return {
+      ok: false,
+      error:
+        "samospec new: --answers-file is missing `answers` array (expected " +
+        `{ "answers": [string x${String(INTERVIEW_ANSWER_COUNT)}] })`,
+    };
+  }
+  for (let i = 0; i < answersRaw.length; i += 1) {
+    if (typeof answersRaw[i] !== "string") {
+      return {
+        ok: false,
+        error: `samospec new: --answers-file[${String(i)}] is not a string (got ${typeof answersRaw[i]})`,
+      };
+    }
+  }
+  if (answersRaw.length !== INTERVIEW_ANSWER_COUNT) {
+    return {
+      ok: false,
+      error:
+        `samospec new: --answers-file must contain exactly ${String(INTERVIEW_ANSWER_COUNT)} ` +
+        `answers (got ${String(answersRaw.length)})`,
+    };
+  }
+  return { ok: true, answers: answersRaw as readonly string[] };
+}
+
+/**
+ * Best-effort line extractor for JSON.parse errors. V8 messages look
+ * like `... in JSON at position 42 (line 3 column 5)`; older runtimes
+ * only carry the character offset. We handle both.
+ */
+function extractLineNumber(raw: string, err: unknown): number | null {
+  if (!(err instanceof Error)) return null;
+  // V8 ≥ 20: "line 3 column 5".
+  const lineMatch = /line (\d+)/i.exec(err.message);
+  if (lineMatch !== null) {
+    const n = Number.parseInt(lineMatch[1] ?? "", 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  // V8 < 20 / Bun fallback: "position 42".
+  const posMatch = /position (\d+)/i.exec(err.message);
+  if (posMatch !== null) {
+    const pos = Number.parseInt(posMatch[1] ?? "", 10);
+    if (Number.isFinite(pos) && pos >= 0) {
+      // Count newlines up to pos.
+      const before = raw.slice(0, Math.min(pos, raw.length));
+      const nl = before.split("\n").length; // line = count(\n) + 1
+      return nl;
+    }
+  }
+  return null;
+}
+
+// ---------- non-interactive resolvers ----------
+
+export interface NonInteractiveResolverInput {
+  /** `--accept-persona` / `--yes`: accept the lead's proposal as-is. */
+  readonly acceptPersona: boolean;
+  /**
+   * Pre-loaded answer list. When undefined OR shorter than the question
+   * count, remaining slots fall back to `"decide for me"` (a canonical
+   * option the interview prompt always accepts).
+   */
+  readonly answers: readonly string[] | undefined;
+}
+
+/**
+ * Build a `ChoiceResolvers` that NEVER calls readline. Safe for CI,
+ * piped invocations, background tool-use.
+ *
+ * - persona: ignores the proposal-shape; always returns `accept`.
+ * - question: consumes `answers` in order. If an answer matches one of
+ *   the question's `options`, returns that; otherwise falls back to
+ *   `"decide for me"` (always a valid interview escape hatch). When
+ *   the answers list is exhausted, continues to return `"decide for me"`
+ *   so the flow never stalls.
+ */
+export function buildNonInteractiveResolvers(
+  input: NonInteractiveResolverInput,
+): ChoiceResolvers {
+  const answers = input.answers ?? [];
+  let cursor = 0;
+  return {
+    persona: (_p) => {
+      // `acceptPersona: false` here would be nonsensical — if we're in
+      // non-interactive mode and did NOT opt in to accepting the
+      // persona, the CLI should have aborted before building resolvers.
+      // Treat this as accept for safety.
+      void input.acceptPersona;
+      return Promise.resolve({ kind: "accept" });
+    },
+    question: (q) => {
+      const next = answers[cursor];
+      cursor += 1;
+      if (next === undefined) {
+        return Promise.resolve({ choice: "decide for me" });
+      }
+      // If the provided answer matches an option, pass through;
+      // otherwise treat as a `custom` answer (the interview schema
+      // always accepts custom free-text).
+      if (q.options.includes(next)) {
+        return Promise.resolve({ choice: next });
+      }
+      return Promise.resolve({ choice: "custom", custom: next });
+    },
+  };
+}

--- a/tests/cli/iterate-on-dirty.test.ts
+++ b/tests/cli/iterate-on-dirty.test.ts
@@ -1,0 +1,197 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #114 — `samospec iterate --on-dirty <incorporate|overwrite|abort>`
+// skips the uncommitted-edits readline so `iterate` works in non-TTY.
+// Without the flag and with dirty `.samo/spec/<slug>/`, non-TTY stdin
+// must exit 1 fast with a clear message — never readline-deadlock.
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { writeState } from "../../src/state/store.ts";
+import type { State } from "../../src/state/types.ts";
+
+const CLI_PATH = path.resolve(import.meta.dir, "..", "..", "src", "main.ts");
+
+let tmp: string;
+let fakeHome: string;
+let fakeBin: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-iterate-ondirty-"));
+  fakeHome = mkdtempSync(path.join(tmpdir(), "samospec-iterate-ondirty-home-"));
+  fakeBin = mkdtempSync(path.join(tmpdir(), "samospec-iterate-ondirty-bin-"));
+
+  const stubBody =
+    '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then ' +
+    "echo '0.0.0'; exit 0; fi\nsleep 60\n";
+  for (const name of ["claude", "codex"]) {
+    const p = path.join(fakeBin, name);
+    writeFileSync(p, stubBody);
+    chmodSync(p, 0o755);
+  }
+
+  // Init a real git repo with a samospec/<slug> branch.
+  spawnSync("git", ["init", "-q", "--initial-branch", "main"], { cwd: tmp });
+  spawnSync("git", ["config", "user.email", "t@example.invalid"], { cwd: tmp });
+  spawnSync("git", ["config", "user.name", "t"], { cwd: tmp });
+  spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: tmp });
+  writeFileSync(path.join(tmp, "README.md"), "seed\n");
+  spawnSync("git", ["add", "README.md"], { cwd: tmp });
+  spawnSync("git", ["commit", "-q", "-m", "seed"], { cwd: tmp });
+  spawnSync("git", ["checkout", "-q", "-b", "samospec/demo"], { cwd: tmp });
+
+  // Seed a complete .samo/spec/demo/ from the iterate test helper shape.
+  const slugDir = path.join(tmp, ".samo", "spec", "demo");
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(
+    path.join(slugDir, "SPEC.md"),
+    "# SPEC\n\ncontent v0.1\n",
+    "utf8",
+  );
+  writeFileSync(path.join(slugDir, "TLDR.md"), "# TLDR\n\n- old\n", "utf8");
+  writeFileSync(
+    path.join(slugDir, "decisions.md"),
+    "# decisions\n\n- none.\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "changelog.md"),
+    "# changelog\n\n## v0.1 — seed\n\n- initial\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "interview.json"),
+    JSON.stringify({
+      slug: "demo",
+      persona: 'Veteran "demo" expert',
+      generated_at: "2026-04-19T12:00:00Z",
+      questions: [],
+      answers: [],
+    }),
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "context.json"),
+    JSON.stringify({
+      phase: "draft",
+      files: [],
+      risk_flags: [],
+      budget: { phase: "draft", tokens_used: 0, tokens_budget: 0 },
+    }),
+    "utf8",
+  );
+  const state: State = {
+    slug: "demo",
+    phase: "review_loop",
+    round_index: 0,
+    version: "0.1.0",
+    persona: { skill: "demo", accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: "2026-04-19T12:00:00Z",
+    updated_at: "2026-04-19T12:00:00Z",
+  };
+  writeState(path.join(slugDir, "state.json"), state);
+  spawnSync("git", ["add", "."], { cwd: tmp });
+  spawnSync("git", ["commit", "-q", "-m", "spec(demo): draft v0.1"], {
+    cwd: tmp,
+  });
+
+  // Now dirty SPEC.md in the working tree so detectManualEdits fires.
+  writeFileSync(
+    path.join(slugDir, "SPEC.md"),
+    "# SPEC\n\ncontent v0.1 + user edit\n",
+    "utf8",
+  );
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  rmSync(fakeHome, { recursive: true, force: true });
+  rmSync(fakeBin, { recursive: true, force: true });
+});
+
+function runCli(args: readonly string[]): {
+  stdout: string;
+  stderr: string;
+  status: number;
+  elapsedMs: number;
+} {
+  const bun = Bun.argv[0];
+  const env: Record<string, string> = {
+    PATH: `${fakeBin}:/usr/bin:/bin:/usr/local/bin`,
+    HOME: fakeHome,
+    NO_COLOR: "1",
+    ANTHROPIC_API_KEY: "sk-fake-test-key",
+  };
+  const devNull = openSync("/dev/null", "r");
+  const started = Date.now();
+  const r = spawnSync(bun, ["run", CLI_PATH, ...(args as string[])], {
+    cwd: tmp,
+    encoding: "utf8",
+    env,
+    stdio: [devNull, "pipe", "pipe"],
+    timeout: 15_000,
+  });
+  return {
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? "",
+    status: r.status ?? 1,
+    elapsedMs: Date.now() - started,
+  };
+}
+
+describe("samospec iterate --on-dirty (#114)", () => {
+  test("dirty + non-TTY + no --on-dirty -> fast exit 1 with actionable message", () => {
+    const res = runCli(["iterate", "demo", "--rounds", "1", "--no-push"]);
+    expect(res.elapsedMs).toBeLessThan(12_000);
+    expect(res.status).not.toBe(0);
+    // No readline crash, no deadlock.
+    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    expect(res.stderr.toLowerCase()).toContain("--on-dirty");
+  });
+
+  test("dirty + --on-dirty abort -> exits cleanly (0) without readline", () => {
+    const res = runCli([
+      "iterate",
+      "demo",
+      "--rounds",
+      "1",
+      "--no-push",
+      "--on-dirty",
+      "abort",
+    ]);
+    expect(res.elapsedMs).toBeLessThan(12_000);
+    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    expect(res.status).toBe(0);
+  });
+
+  test("invalid --on-dirty value -> exit 1 with validation error", () => {
+    const res = runCli([
+      "iterate",
+      "demo",
+      "--rounds",
+      "1",
+      "--no-push",
+      "--on-dirty",
+      "bogus",
+    ]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain("--on-dirty");
+  });
+});

--- a/tests/cli/new-accept-persona.test.ts
+++ b/tests/cli/new-accept-persona.test.ts
@@ -1,0 +1,146 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #114 — `samospec new --accept-persona` skips the persona prompt
+// entirely and accepts the lead's proposal as-is. Combined with an
+// `--answers-file` a fully non-interactive happy path completes under
+// non-TTY stdin. This is the primary automation / CI path.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  ReviseInput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { runInit } from "../../src/cli/init.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+import { buildNonInteractiveResolvers } from "../../src/cli/non-interactive.ts";
+
+function askOut(answer: string): AskOutput {
+  return { answer, usage: null, effort_used: "max" };
+}
+
+function personaJson(skill: string): string {
+  return JSON.stringify({
+    persona: `Veteran "${skill}" expert`,
+    rationale: "pragmatic choice",
+  });
+}
+
+function questionsJson(items: readonly { id: string; text: string }[]): string {
+  return JSON.stringify({
+    questions: items.map((q) => ({
+      id: q.id,
+      text: q.text,
+      options: ["opt A", "opt B"],
+    })),
+  });
+}
+
+function makeLeadAdapter(answers: readonly string[]): Adapter {
+  const base = createFakeAdapter({});
+  let call = 0;
+  return {
+    ...base,
+    ask: (_input: AskInput): Promise<AskOutput> => {
+      const a = answers[call] ?? answers[answers.length - 1] ?? "";
+      call += 1;
+      return Promise.resolve(askOut(a));
+    },
+    revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+      Promise.resolve({
+        spec: "# spec\n\n## Goal\nshort\n\n## Scope\n- x\n\n## Non-goals\n- none\n",
+        ready: false,
+        rationale: "v0.1 draft complete",
+        usage: null,
+        effort_used: "max",
+      }),
+  };
+}
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-accept-persona-"));
+  runInit({ cwd: tmp });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("buildNonInteractiveResolvers (#114) — --accept-persona", () => {
+  test("returns resolvers whose persona always accepts and question uses canned answer", async () => {
+    const resolvers = buildNonInteractiveResolvers({
+      acceptPersona: true,
+      answers: undefined,
+    });
+    const choice = await resolvers.persona({
+      persona: 'Veteran "x" expert',
+      skill: "x",
+      rationale: "r",
+      accepted: false,
+    });
+    expect(choice.kind).toBe("accept");
+  });
+
+  test("defaults to 'decide for me' when no answers supplied", async () => {
+    const resolvers = buildNonInteractiveResolvers({
+      acceptPersona: true,
+      answers: undefined,
+    });
+    const r = await resolvers.question({
+      id: "q1",
+      text: "pick?",
+      options: ["opt A", "opt B"],
+    });
+    expect(r.choice).toBe("decide for me");
+  });
+});
+
+describe("samospec new — --accept-persona + answers-file end-to-end", () => {
+  test("fully non-interactive happy path completes (no readline)", async () => {
+    const answersPath = path.join(tmp, "answers.json");
+    writeFileSync(
+      answersPath,
+      JSON.stringify({
+        answers: ["opt A", "opt B", "opt A", "opt B", "opt A"],
+      }),
+      "utf8",
+    );
+
+    const adapter = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([
+        { id: "q1", text: "framework?" },
+        { id: "q2", text: "db?" },
+        { id: "q3", text: "host?" },
+        { id: "q4", text: "lang?" },
+        { id: "q5", text: "auth?" },
+      ]),
+    ]);
+
+    const resolvers: ChoiceResolvers = buildNonInteractiveResolvers({
+      acceptPersona: true,
+      answers: ["opt A", "opt B", "opt A", "opt B", "opt A"],
+    });
+
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "a CLI for turning ideas into specs",
+        explain: false,
+        resolvers,
+        now: "2026-04-19T10:00:00Z",
+      },
+      adapter,
+    );
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/tests/cli/new-answers-file.test.ts
+++ b/tests/cli/new-answers-file.test.ts
@@ -1,0 +1,117 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #114 — `samospec new --answers-file <path>` loads the 5
+// interview answers from a JSON file:
+//   { "answers": ["...", "...", "...", "...", "..."] }
+// length must be 5; fewer/more is exit 1.
+// Malformed JSON is exit 1 with a line number where possible.
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  loadAnswersFile,
+  type LoadAnswersResult,
+} from "../../src/cli/non-interactive.ts";
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-answers-file-"));
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeFile(name: string, body: string): string {
+  const p = path.join(tmp, name);
+  writeFileSync(p, body, "utf8");
+  return p;
+}
+
+function expectOk(
+  r: LoadAnswersResult,
+): asserts r is { readonly ok: true; readonly answers: readonly string[] } {
+  if (!r.ok) {
+    throw new Error(`expected ok, got: ${r.error}`);
+  }
+}
+
+function expectErr(
+  r: LoadAnswersResult,
+): asserts r is { readonly ok: false; readonly error: string } {
+  if (r.ok) {
+    throw new Error("expected error, got ok");
+  }
+}
+
+describe("loadAnswersFile (#114)", () => {
+  test("valid 5-element answers array -> ok", () => {
+    const p = writeFile(
+      "good.json",
+      JSON.stringify({ answers: ["a", "b", "c", "d", "e"] }),
+    );
+    const r = loadAnswersFile(p);
+    expectOk(r);
+    expect(r.answers).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  test("missing file -> error names the path", () => {
+    const missing = path.join(tmp, "does-not-exist.json");
+    const r = loadAnswersFile(missing);
+    expectErr(r);
+    expect(r.error).toContain(missing);
+  });
+
+  test("malformed JSON -> error mentions line number", () => {
+    // One broken char on line 2 — line numbers start at 1.
+    const p = writeFile("bad.json", '{\n  "answers": [\n    "a",\n    b\n]}\n');
+    const r = loadAnswersFile(p);
+    expectErr(r);
+    expect(r.error.toLowerCase()).toContain("line");
+  });
+
+  test("wrong length (4) -> exit-1-shaped error names count", () => {
+    const p = writeFile(
+      "four.json",
+      JSON.stringify({ answers: ["a", "b", "c", "d"] }),
+    );
+    const r = loadAnswersFile(p);
+    expectErr(r);
+    expect(r.error).toContain("5");
+  });
+
+  test("wrong length (6) -> exit-1-shaped error names count", () => {
+    const p = writeFile(
+      "six.json",
+      JSON.stringify({ answers: ["a", "b", "c", "d", "e", "f"] }),
+    );
+    const r = loadAnswersFile(p);
+    expectErr(r);
+    expect(r.error).toContain("5");
+  });
+
+  test("missing answers key -> error", () => {
+    const p = writeFile("noans.json", JSON.stringify({ foo: "bar" }));
+    const r = loadAnswersFile(p);
+    expectErr(r);
+    expect(r.error.toLowerCase()).toContain("answers");
+  });
+
+  test("answers not an array -> error", () => {
+    const p = writeFile("notarr.json", JSON.stringify({ answers: "x" }));
+    const r = loadAnswersFile(p);
+    expectErr(r);
+    expect(r.error.toLowerCase()).toContain("answers");
+  });
+
+  test("non-string element -> error", () => {
+    const p = writeFile(
+      "notstr.json",
+      JSON.stringify({ answers: ["a", "b", "c", 4, "e"] }),
+    );
+    const r = loadAnswersFile(p);
+    expectErr(r);
+  });
+});

--- a/tests/cli/new-non-tty.test.ts
+++ b/tests/cli/new-non-tty.test.ts
@@ -1,0 +1,128 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #114 — `samospec new` MUST NOT call readline when stdin is not a
+// TTY. The pre-fix behavior crashed with `ERR_USE_AFTER_CLOSE` at
+// `proposePersonaInteractive`, blocking all CI / piped / background use.
+//
+// RED: with stdin fed from `/dev/null` and no automation flag
+// (`--yes`, `--accept-persona`, `--answers-file`), `samospec new`
+// MUST exit 1 quickly with a clear message — never throw readline
+// internals.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const CLI_PATH = path.resolve(import.meta.dir, "..", "..", "src", "main.ts");
+
+let tmp: string;
+let fakeHome: string;
+let fakeBin: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-non-tty-"));
+  fakeHome = mkdtempSync(path.join(tmpdir(), "samospec-non-tty-home-"));
+  fakeBin = mkdtempSync(path.join(tmpdir(), "samospec-non-tty-bin-"));
+
+  // Stub `claude` + `codex` with trivial returners so the adapter layer
+  // is satisfied and we reach the persona-proposal / interview prompts.
+  // They must never actually be called — the non-TTY guard fires first.
+  const stubBody =
+    '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then ' +
+    "echo '0.0.0'; exit 0; fi\nsleep 60\n";
+  for (const name of ["claude", "codex"]) {
+    const p = path.join(fakeBin, name);
+    writeFileSync(p, stubBody);
+    chmodSync(p, 0o755);
+  }
+
+  // Init git + samospec in the sandbox.
+  spawnSync("git", ["init", "--initial-branch", "work", tmp], {
+    encoding: "utf8",
+  });
+  spawnSync("git", ["config", "user.email", "t@example.invalid"], { cwd: tmp });
+  spawnSync("git", ["config", "user.name", "t"], { cwd: tmp });
+  spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: tmp });
+  spawnSync("git", ["commit", "--allow-empty", "-m", "seed"], {
+    cwd: tmp,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@example.invalid",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@example.invalid",
+    },
+  });
+  runCli(["init", "--yes"]);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  rmSync(fakeHome, { recursive: true, force: true });
+  rmSync(fakeBin, { recursive: true, force: true });
+});
+
+function runCli(args: readonly string[]): {
+  stdout: string;
+  stderr: string;
+  status: number;
+  elapsedMs: number;
+} {
+  const bun = Bun.argv[0];
+  const env: Record<string, string> = {
+    PATH: `${fakeBin}:/usr/bin:/bin:/usr/local/bin`,
+    HOME: fakeHome,
+    NO_COLOR: "1",
+    ANTHROPIC_API_KEY: "sk-fake-test-key",
+  };
+  // Pipe /dev/null on stdin so it's a non-TTY.
+  const devNull = openSync("/dev/null", "r");
+  const started = Date.now();
+  try {
+    const r = spawnSync(bun, ["run", CLI_PATH, ...(args as string[])], {
+      cwd: tmp,
+      encoding: "utf8",
+      env,
+      stdio: [devNull, "pipe", "pipe"],
+      timeout: 15_000,
+    });
+    return {
+      stdout: r.stdout ?? "",
+      stderr: r.stderr ?? "",
+      status: r.status ?? 1,
+      elapsedMs: Date.now() - started,
+    };
+  } finally {
+    // spawnSync closes the fd itself, but be defensive.
+  }
+}
+
+describe("samospec new — non-TTY stdin guard (#114)", () => {
+  test("pipes /dev/null + no automation flag → exit 1 fast, actionable message", () => {
+    const res = runCli(["new", "foo", "--idea", "x"]);
+    // Must exit non-zero within a few seconds (never hang).
+    expect(res.elapsedMs).toBeLessThan(12_000);
+    expect(res.status).not.toBe(0);
+    // Must not leak readline internals.
+    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    expect(res.stderr).not.toMatch(/node:readline/);
+    // Actionable message: name the required flags.
+    const stderr = res.stderr.toLowerCase();
+    expect(stderr).toContain("tty");
+    // At least one of the automation flags must be mentioned.
+    const flagMentioned =
+      stderr.includes("--yes") ||
+      stderr.includes("--accept-persona") ||
+      stderr.includes("--answers-file");
+    expect(flagMentioned).toBe(true);
+  });
+});

--- a/tests/cli/preflight-codex-oauth-e2e.test.ts
+++ b/tests/cli/preflight-codex-oauth-e2e.test.ts
@@ -116,14 +116,19 @@ function runSamospecNew(slug: string): {
 
   // Run with a timeout; the preflight is printed before any AI call,
   // so even if the process later fails it will have already emitted it.
+  //
+  // #114: `--yes` is required because `input: "\n\n\n\n\n"` makes stdin
+  // a non-TTY pipe, which would otherwise trip the new non-TTY guard
+  // BEFORE preflight runs. `--yes` accepts the persona automatically
+  // and falls back to `decide for me` for interview answers, so the
+  // preflight line still lands on stdout before any readline call.
   const result = spawnSync(
     bun,
-    ["run", CLI_PATH, "new", slug, "--idea", "test"],
+    ["run", CLI_PATH, "new", slug, "--idea", "test", "--yes"],
     {
       cwd: tmp,
       encoding: "utf8",
       env,
-      // Pipe "\n" answers for any interactive prompts; timeout after 20s.
       input: "\n\n\n\n\n",
       timeout: 20_000,
     },


### PR DESCRIPTION
## Summary

- `samospec new` crashed with `ERR_USE_AFTER_CLOSE` when stdin was not a TTY (piped, CI, background) because `proposePersonaInteractive` always constructed a readline prompt. `samospec iterate`'s uncommitted-edits readline prompt also deadlocked in non-TTY. This blocked all automation / CI / scripted use.
- Adds `--yes`, `--accept-persona`, `--answers-file <path>` to `new`, and `--on-dirty <incorporate|overwrite|abort>` to `iterate`.
- When stdin is not a TTY and no automation flag is present, both commands now exit 1 fast with an actionable message naming the required flags — they never touch readline.

Closes #114. Target: v0.6.0 (new feature, not a patch fix).

## Design

- `src/cli/non-interactive.ts` — pure-logic helpers `loadAnswersFile(path)` (parses `{ "answers": [string x 5] }` with line-number hints on malformed JSON) and `buildNonInteractiveResolvers({ acceptPersona, answers })` (a `ChoiceResolvers` that never touches readline; question resolver consumes answers in order, passing matches through as `choice` and treating free-text as `{ choice: "custom", custom }`).
- `src/cli.ts` — `buildNewResolvers(parsed)` decides between `interactiveResolvers()` and the non-interactive path BEFORE any readline is constructed. A new `buildManualEditResolver(rl, onDirty)` wraps the iterate manual-edit prompt: flag set → return the choice directly; non-TTY without flag → reject with an actionable Error that `runIterateCommand` translates into exit 1.
- `--yes` implies `--accept-persona` and lets the interview fall back to `"decide for me"` (a canonical SPEC §5 escape option).

## Test plan

- [x] `tests/cli/new-non-tty.test.ts` — pipe `/dev/null` into `samospec new foo --idea x` → exit 1 within ~1s, stderr names `tty` + at least one automation flag, never emits `ERR_USE_AFTER_CLOSE` or `node:readline`.
- [x] `tests/cli/new-accept-persona.test.ts` — unit coverage of `buildNonInteractiveResolvers` (persona always accepts, question defaults to `decide for me`) + full `runNew()` happy path with `--accept-persona` + answers.
- [x] `tests/cli/new-answers-file.test.ts` — 8 cases: valid 5-element file, missing file (error names path), malformed JSON (error names line number), wrong length (4 and 6), missing `answers` key, `answers` not an array, non-string element.
- [x] `tests/cli/iterate-on-dirty.test.ts` — dirty `.samo/spec/<slug>/`, non-TTY: no flag → exit 1 with `--on-dirty` hint, `--on-dirty abort` → exit 0, `--on-dirty bogus` → exit 1 validation error.
- [x] `tests/cli/preflight-codex-oauth-e2e.test.ts` — updated to pass `--yes` now that the spawned test pipes stdin (spawn `input:` closes stdin, trips the new guard). Test still asserts the preflight line lands on stdout.
- [x] Full suite: 1433 pass, 0 fail. Lint + typecheck + format clean.

CI gate + REV review still required before merge.