### PR TITLE
ci(publish): upgrade to node 24 (npm 11.x) — test #113 hypothesis

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,7 +100,12 @@ jobs:
       - name: Install Node (for npm CLI)
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          # node 24 ships npm 11.x; node 20 ships npm 10.8.2 which
+          # may be the root of the mysterious 404 on PUT seen in
+          # previous publish attempts (issue #113). npm was
+          # verified working from local with 11.8.0 on the same
+          # token + .npmrc contents.
+          node-version: "24"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -121,6 +126,14 @@ jobs:
             echo "always-auth=true"
           } > .npmrc
           chmod 600 .npmrc
+
+      - name: npm environment (diagnostic)
+        run: |
+          set -Eeuo pipefail
+          IFS=$'\n\t'
+          echo "node: $(node --version)"
+          echo "npm: $(npm --version)"
+          npm config get registry
 
       - name: Publish to npm
         # --provenance requires a trusted-publisher config on npmjs;


### PR DESCRIPTION
## Summary

Tests the hypothesis in #113 that the mysterious 404 on PUT during CI publish is an npm 10.8.2 bug fixed in npm 11.x.

Evidence:
- Local: node 25.5.0 + npm 11.8.0 → publish **works** (samospec@0.4.1, @0.5.0, samodb@0.0.1 all published this way)
- CI: node 20.20.2 + npm 10.8.2 → **404 on PUT** every time, identical token + .npmrc

Node 24 ships npm 11.x, so switching CI to node 24 is a single-line test.

Also adds a short diagnostic step logging node/npm/registry before publish, so the next failure's root cause is one line of CI output away.

## Test plan

- [ ] CI green on this PR (publish workflow doesn't run on PR events, only release or workflow_dispatch).
- [ ] After merge, \`gh workflow run publish.yml --ref main -f tag=v0.5.0\` — expected: publish reports 403 \"cannot publish over previously-published version\" (confirms auth+publish path under npm 11.x). If we still see 404 → issue is elsewhere; investigate token/network path.
- [ ] On success, close #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)