### PR TITLE
feat: pin --yes contract + document it (#122)

### DIFF
--- a/.samo/blueprints/SPEC.md
+++ b/.samo/blueprints/SPEC.md
@@ -490,6 +490,7 @@ blueprints/
 samospec init                        # register .samo/ in an existing repo; idempotent
 samospec new <slug> [--idea "..."] [--persona "..."] [--effort max|high|medium|low]
                     [--context "<paths>"] [--no-commit] [--no-push] [--explain]
+                    [--yes|--accept-persona] [--answers-file <path>]
 samospec resume [<slug>]             # resume last or named spec
 samospec status [<slug>]             # phase, round state, version, next action, running cost
 samospec iterate                     # one round of review + revise
@@ -510,6 +511,8 @@ samospec version
 **Deferred to v1.1+:** `experts set`, `spec compare`, `spec diff`, `spec export` (md/pdf/html), `spec review --rounds N`, `spec ready`, `--sandbox`, non-software persona packs, OpenCode/Gemini adapters, Homebrew/apt/standalone-binary distribution. `experts set` is deferred because v1 ships only two adapter families — the one meaningful user choice (swap lead/reviewer between Claude and Codex) can be done by editing `.samo/config.json`; the command earns its keep once v1.1 ships Gemini/OpenCode. PDF/HTML drags in pandoc or Chromium headless — disproportionate dependency footprint for v1.
 
 **Interactive prompts** use plain numbered menus. Every prompt has a default in brackets; `Enter` does the safe, obvious thing.
+
+**Non-interactive automation** (issues #114 / #122): `samospec new --yes` skips the persona proposal prompt (auto-accept) and defaults every interview answer to `decide for me`. `--accept-persona` skips only the persona prompt and keeps the interview interactive. `--answers-file <path>` supplies all five interview answers from a JSON file (`{ "answers": [s, s, s, s, s] }`); combine with `--accept-persona` for a fully non-interactive run with steered answers. When stdin is not a TTY and no automation flag is set, `samospec new` exits 1 fast with an actionable message rather than readline-deadlocking. `samospec iterate --on-dirty <incorporate|overwrite|abort>` is the symmetric escape hatch for the uncommitted-edits prompt.
 
 **Exit codes:** `0` success; `1` user error; `2` infra/git/network/concurrency; `3` interrupted; `4` model refused or budget exceeded or `lead_terminal`; `5` consent refused (first push, preflight cost, sensitive-path read).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`--yes` flag documented in README (#122):** README now lists
+  `samospec new --yes` under the useful-flags section so samo.team's
+  headless UI (and any other automation surface) can discover it
+  without grepping the CHANGELOG. Also mentions `iterate`'s
+  `--on-dirty` for symmetry. No behavior change — the flag itself
+  landed in #114 / v0.6.0.
+
+### Tests
+
+- **Contract test for `--yes` headless path (#122):** new regression
+  test pins three invariants the UI depends on:
+  `state.json.persona.accepted === true`, every interview answer has
+  `choice === "decide for me"`, and the resolver path never reads
+  from `process.stdin`. Previous coverage only asserted `exitCode`.
+
 ---
 
 ## [0.6.0] - 2026-04-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+---
+
+## [0.6.1] - 2026-04-21
+
 ### Added
 
 - **`--yes` flag documented in README (#122):** README now lists
   `samospec new --yes` under the useful-flags section so samo.team's
   headless UI (and any other automation surface) can discover it
   without grepping the CHANGELOG. Also mentions `iterate`'s
-  `--on-dirty` for symmetry. No behavior change — the flag itself
-  landed in #114 / v0.6.0.
+  `--on-dirty` for symmetry. SPEC §10 v1 surface updated to include
+  the three non-TTY automation flags. No behavior change — the flag
+  itself landed in #114 / v0.6.0.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -139,9 +139,11 @@ Useful flags:
 - `samospec new --skip user-stories,sprint-plan,…` — opt out of baseline sections.
 - `samospec new --max-session-wall-clock-ms 1800000` — 30-min session cap.
 - `samospec new --force` — archive any existing `<slug>` dir as `.archived-YYYY-MM-DDThhmmssZ/` before starting.
+- `samospec new --yes` — fully non-interactive: auto-accept the lead's persona proposal and default every interview answer to `decide for me`. Pair with `--answers-file <path>` when you want to steer the five questions from JSON instead.
 - `samospec iterate --rounds 5` — cap rounds for this invocation.
 - `samospec iterate --no-push` — stay local this run.
 - `samospec iterate --quiet` — suppress the per-round progress + heartbeat stream on stderr (final summary still prints on stdout).
+- `samospec iterate --on-dirty <incorporate|overwrite|abort>` — non-interactive answer for the uncommitted-edits prompt.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Requires [Bun](https://bun.sh) ≥ 1.2.0.
 
 ```bash
 bun install -g samospec
-samospec --version   # 0.4.1
+samospec --version   # 0.6.1
 ```
 
 Or one-shot:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samospec",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Git-native CLI that turns a rough idea into a reviewed, versioned specification document.",
   "type": "module",
   "bin": {

--- a/tests/cli/new-yes-flag.test.ts
+++ b/tests/cli/new-yes-flag.test.ts
@@ -1,0 +1,195 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #122 — pin the `--yes` contract for samo.team's headless UI.
+//
+// The UI spawns `samospec new` without a TTY and depends on these
+// invariants. Without this test, a refactor of
+// `buildNonInteractiveResolvers` could silently regress the UI flow
+// and we would only notice when invocations start hitting the 10-min
+// session-wall-clock cap (exit 4) again.
+//
+// Contract pinned here:
+//   - passing `--yes` MUST auto-accept the lead's proposed persona
+//     (`state.json.persona.accepted === true`).
+//   - every interview answer MUST record `choice === "decide for me"`
+//     when the user supplies no answers (`--yes` alone, no
+//     `--answers-file`).
+//   - NO readline interface is constructed. We prove this by driving
+//     `runNew` with the resolvers the CLI picks when `--yes` is set,
+//     and asserting those resolvers never `throw` (they are pure
+//     promise-returning functions that never touch `process.stdin`).
+//   - `runNew` exits 0.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  ReviseInput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { runInit } from "../../src/cli/init.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+import { buildNonInteractiveResolvers } from "../../src/cli/non-interactive.ts";
+
+function askOut(answer: string): AskOutput {
+  return { answer, usage: null, effort_used: "max" };
+}
+
+function personaJson(skill: string): string {
+  return JSON.stringify({
+    persona: `Veteran "${skill}" expert`,
+    rationale: "pragmatic choice",
+  });
+}
+
+function questionsJson(items: readonly { id: string; text: string }[]): string {
+  return JSON.stringify({
+    questions: items.map((q) => ({
+      id: q.id,
+      text: q.text,
+      options: ["opt A", "opt B"],
+    })),
+  });
+}
+
+function makeLeadAdapter(answers: readonly string[]): Adapter {
+  const base = createFakeAdapter({});
+  let call = 0;
+  return {
+    ...base,
+    ask: (_input: AskInput): Promise<AskOutput> => {
+      const a = answers[call] ?? answers[answers.length - 1] ?? "";
+      call += 1;
+      return Promise.resolve(askOut(a));
+    },
+    revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+      Promise.resolve({
+        spec: "# spec\n\n## Goal\nshort\n\n## Scope\n- x\n\n## Non-goals\n- none\n",
+        ready: false,
+        rationale: "v0.1 draft complete",
+        usage: null,
+        effort_used: "max",
+      }),
+  };
+}
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-yes-flag-"));
+  runInit({ cwd: tmp });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("samospec new --yes (#122) — headless UI contract", () => {
+  test("auto-accepts persona and defaults every answer to 'decide for me'", async () => {
+    // Build the resolvers that `cli.ts` picks when `--yes` is present
+    // without `--answers-file`. This is the exact call shape in
+    // `buildNewResolvers` (src/cli.ts).
+    const resolvers: ChoiceResolvers = buildNonInteractiveResolvers({
+      acceptPersona: true,
+      answers: undefined,
+    });
+
+    const adapter = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([
+        { id: "q1", text: "framework?" },
+        { id: "q2", text: "db?" },
+        { id: "q3", text: "host?" },
+        { id: "q4", text: "lang?" },
+        { id: "q5", text: "auth?" },
+      ]),
+    ]);
+
+    const result = await runNew(
+      {
+        cwd: tmp,
+        slug: "demo",
+        idea: "a CLI for turning ideas into specs",
+        explain: false,
+        resolvers,
+        now: "2026-04-21T10:00:00Z",
+      },
+      adapter,
+    );
+
+    // Exits cleanly.
+    expect(result.exitCode).toBe(0);
+
+    // state.json.persona.accepted === true — the UI-critical assertion.
+    const statePath = path.join(tmp, ".samo", "spec", "demo", "state.json");
+    const state = JSON.parse(readFileSync(statePath, "utf8")) as {
+      persona: { skill: string; accepted: boolean };
+    };
+    expect(state.persona).toBeDefined();
+    expect(state.persona.accepted).toBe(true);
+
+    // Every interview answer records `choice: "decide for me"`.
+    const interviewPath = path.join(
+      tmp,
+      ".samo",
+      "spec",
+      "demo",
+      "interview.json",
+    );
+    const interview = JSON.parse(readFileSync(interviewPath, "utf8")) as {
+      answers: readonly { id: string; choice: string }[];
+    };
+    expect(interview.answers.length).toBe(5);
+    for (const a of interview.answers) {
+      expect(a.choice).toBe("decide for me");
+    }
+  });
+
+  test("non-interactive resolvers never read from process.stdin", async () => {
+    // Structural proof: drive the same resolvers with stdin wired to
+    // something that would deadlock if read from (a paused Readable
+    // with no data). If `buildNonInteractiveResolvers` ever reached
+    // for readline / process.stdin, this test would hang until the
+    // Bun per-test timeout fired. Passing means every call resolved
+    // purely — no stdin read was attempted.
+    const { Readable } = await import("node:stream");
+    const deadStdin = new Readable({ read() { /* never push */ } });
+    deadStdin.pause();
+    const originalStdin = process.stdin;
+    Object.defineProperty(process, "stdin", {
+      value: deadStdin,
+      configurable: true,
+    });
+    try {
+      const resolvers = buildNonInteractiveResolvers({
+        acceptPersona: true,
+        answers: undefined,
+      });
+      const personaChoice = await resolvers.persona({
+        persona: 'Veteran "CLI engineer" expert',
+        skill: "CLI engineer",
+        rationale: "r",
+        accepted: false,
+      });
+      expect(personaChoice.kind).toBe("accept");
+      for (let i = 0; i < 5; i += 1) {
+        const ans = await resolvers.question({
+          id: `q${String(i + 1)}`,
+          text: "pick one",
+          options: ["opt A", "opt B"],
+        });
+        expect(ans.choice).toBe("decide for me");
+      }
+    } finally {
+      Object.defineProperty(process, "stdin", {
+        value: originalStdin,
+        configurable: true,
+      });
+    }
+  });
+});

--- a/tests/cli/new-yes-flag.test.ts
+++ b/tests/cli/new-yes-flag.test.ts
@@ -158,7 +158,11 @@ describe("samospec new --yes (#122) — headless UI contract", () => {
     // Bun per-test timeout fired. Passing means every call resolved
     // purely — no stdin read was attempted.
     const { Readable } = await import("node:stream");
-    const deadStdin = new Readable({ read() { /* never push */ } });
+    const deadStdin = new Readable({
+      read() {
+        /* never push */
+      },
+    });
     deadStdin.pause();
     const originalStdin = process.stdin;
     Object.defineProperty(process, "stdin", {


### PR DESCRIPTION
## Summary

- Pins the non-TTY contract samo.team's headless UI depends on with a new
  regression test (`tests/cli/new-yes-flag.test.ts`): `--yes` auto-accepts
  the lead's proposed persona, every interview answer records
  `choice === "decide for me"`, and the non-interactive resolvers never
  read from `process.stdin`.
- Documents `--yes` in `README.md` under the useful-flags section (was
  missing — only in inline USAGE and CHANGELOG entries) and in SPEC §10 v1
  surface.
- Adds the three non-TTY automation flags (`--yes`, `--accept-persona`,
  `--answers-file`) to the SPEC §10 CLI grammar block, plus a paragraph
  describing the headless-automation escape hatches and the symmetric
  `iterate --on-dirty`.
- Patch bump to `0.6.1`. No behavior change — the `--yes` feature itself
  shipped in #114 / v0.6.0.

Closes #122.

## Why a pure docs+tests PR

The agent task brief was written against v0.4.1 ("add `--yes` that auto-
accepts persona + defaults answers to 'decide for me'"), but main has
since advanced to v0.6.0 where that feature already shipped
(`buildNonInteractiveResolvers`, wired from `cli.ts::buildNewResolvers`).
What was missing was a contract test that specifically pinned
`state.json.persona.accepted === true` and per-answer
`choice === "decide for me"` — the existing `--accept-persona` coverage
only asserted `exitCode === 0`, so a refactor of the non-interactive
resolvers could have silently regressed the UI flow. Also missing: any
README mention of `--yes`.

## Test plan

- [x] `bun test tests/cli/new-yes-flag.test.ts` — 2/2 pass
- [x] `bun test` — 1457/1457 pass, 9312 expect() calls, ~52s
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean

Red/green evidence: the new test is red against any `cli/non-interactive.ts`
that flips either invariant (verified by flipping `acceptPersona: false`
locally — test fails on the `state.persona.accepted` assertion). Green
against current main + this branch.

## Notes

- Version bump is 0.6.0 → 0.6.1 (patch, tests+docs only). The task brief
  mentioned 0.4.1 → 0.5.0 but that jump was already made in #109 / #110.
- Per CLAUDE.md, no amend / no force-push / no `--no-verify`. One small
  prettier follow-up commit (18a901a) instead of amending the test commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)