### PR TITLE
Improve npm publish diagnostics and logging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,17 +128,34 @@ jobs:
           chmod 600 .npmrc
 
       - name: npm environment (diagnostic)
+        # Token-sensitive output is filtered: `npm config ls -l` prints
+        # `_authToken` values, so grep them out. The whoami probe uses
+        # the token as a bearer but discards the response body — only
+        # the HTTP status code is logged, so the token owner is not
+        # disclosed beyond what CI already has access to.
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -Eeuo pipefail
           IFS=$'\n\t'
           echo "node: $(node --version)"
           echo "npm: $(npm --version)"
           npm config get registry
+          npm config ls -l 2>&1 \
+            | grep -v -iE '(authtoken|password|_auth\b)' || true
+          printf 'whoami http status: '
+          curl -sS -o /dev/null -w '%{http_code}\n' \
+            -H "Authorization: Bearer ${NPM_TOKEN}" \
+            https://registry.npmjs.org/-/whoami
 
       - name: Publish to npm
         # --provenance requires a trusted-publisher config on npmjs;
         # skip it until that's set up. Re-enable via follow-up PR.
-        run: npm publish --access public
+        # --loglevel=http surfaces the full HTTP conversation so the
+        # 404-on-new-version behavior from CI (issue #121) can be
+        # diffed against a local `npm publish --loglevel=http` log.
+        # npm redacts the Authorization header in this output.
+        run: npm publish --access public --loglevel=http
 
       - name: Scrub .npmrc
         if: always()


### PR DESCRIPTION
## Summary

Enhance the npm publish workflow with better diagnostic output and HTTP-level logging to aid in debugging publish issues (particularly the 404-on-new-version behavior from issue #121).

Changes:
- Add token-safe diagnostic output: `npm config ls -l` with auth token filtering, and `npm whoami` HTTP status probe
- Enable `--loglevel=http` on `npm publish` to surface the full HTTP conversation for debugging
- Add explanatory comments documenting the diagnostic approach and logging rationale

## Checklist

- [x] No tests needed (workflow/CI configuration change)
- [x] No code behavior changes (diagnostic and logging improvements only)
- [x] CI will validate the workflow syntax
- [x] No secrets exposed (token-sensitive output is filtered; Authorization header is redacted by npm)
- [x] No documentation changes required

## Testing evidence

This is a CI workflow configuration change. The modifications will be validated when the workflow runs on the next publish attempt. The token filtering and HTTP logging will provide better visibility into publish operations without exposing sensitive credentials.

## Out-of-scope / follow-ups

Actual resolution of issue #121 (404-on-new-version behavior) is deferred; this PR provides the diagnostic infrastructure to investigate it.

https://claude.ai/code/session_012ikjhHdW3yz3bhPbs1mWsR