### PR TITLE
feat(cli): accept --verbose on iterate (#128)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -664,6 +664,8 @@ const ITERATE_ALLOWED_FLAGS: ReadonlySet<string> = new Set([
   "--no-push",
   "--remote",
   "--quiet",
+  // #128: no-op alias so `iterate --verbose` matches muscle-memory from `new`.
+  "--verbose",
   "--max-session-wall-clock-ms",
   // #114: non-TTY automation.
   "--on-dirty",
@@ -702,6 +704,11 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
       // Issue #101: suppress per-phase + heartbeat; final summary still
       // prints. No-op when combined with `--rounds 0` or similar.
       quiet = true;
+      continue;
+    }
+    if (t === "--verbose") {
+      // Issue #128: iterate is verbose by default; accept --verbose as a
+      // no-op alias so muscle-memory from `samospec new --verbose` works.
       continue;
     }
     if (t === "--on-dirty") {

--- a/tests/cli/iterate-verbose-flag.test.ts
+++ b/tests/cli/iterate-verbose-flag.test.ts
@@ -1,0 +1,33 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #128 — `samospec iterate --verbose` errored with
+// "unknown flag '--verbose'" because ITERATE_ALLOWED_FLAGS lacked
+// the entry. `samospec new` has --verbose; iterate is verbose by default
+// but should accept the flag as a no-op alias so muscle-memory works.
+
+import { describe, expect, test } from "bun:test";
+
+import { runCli } from "../../src/cli.ts";
+
+describe("iterate parser — --verbose accepted as no-op (#128)", () => {
+  test("--verbose alone does not produce 'unknown flag' error", async () => {
+    // Feed a nonexistent slug so the run aborts at the
+    // state-missing gate ("no spec found"), not at the parser.
+    const res = await runCli(["iterate", "missing-slug", "--verbose"]);
+    expect(res.stderr.toLowerCase()).not.toContain("unknown flag");
+    expect(res.stderr.toLowerCase()).toContain("no spec found");
+    expect(res.exitCode).toBe(1);
+  });
+
+  test("--verbose combined with --quiet does not produce 'unknown flag'", async () => {
+    const res = await runCli([
+      "iterate",
+      "missing-slug",
+      "--verbose",
+      "--quiet",
+    ]);
+    expect(res.stderr.toLowerCase()).not.toContain("unknown flag");
+    expect(res.stderr.toLowerCase()).toContain("no spec found");
+    expect(res.exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `--verbose` to `ITERATE_ALLOWED_FLAGS` so `samospec iterate <slug> --verbose` no longer errors with `unknown flag '--verbose'`
- Handles it as a no-op in `parseIterateArgs` (iterate is already verbose by default)
- Adds `tests/cli/iterate-verbose-flag.test.ts` with two cases: flag alone and combined with `--quiet`

Fixes #128

## Test plan

- [x] Red: new test failed before the fix (parser rejected `--verbose`)
- [x] Green: both test cases pass after adding the flag to the allowlist and parser
- [x] Full suite: `bun test` — 1459 pass, 0 fail
- [x] `bun run lint && bun run format:check && bun run typecheck` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)