### PR TITLE
fix(git): name built-in source in refusal (#126)

### DIFF
--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -41,6 +41,7 @@ import {
 import { specCommit } from "../git/commit.ts";
 import { ensureHasCommit } from "../git/ensure-has-commit.ts";
 import { ProtectedBranchError, GitLayerUsageError } from "../git/errors.ts";
+import { HARDCODED_PROTECTED_BRANCHES } from "../git/protected.ts";
 import { writeCalibrationSample } from "../policy/calibration.ts";
 import {
   CONSENT_ABORT_EXIT_CODE,
@@ -432,10 +433,15 @@ export async function runNew(
     //     so legacy tests that don't initialize a git repo still run.
     let branchResult = createBranch(input);
     if (branchResult.kind === "protected") {
+      const source = HARDCODED_PROTECTED_BRANCHES.includes(branchResult.branch)
+        ? "built-in default"
+        : "config";
       errors.push(
-        `samospec: refusing to branch on protected branch '${branchResult.branch}'. ` +
-          `Check out a feature branch first or override protection via ` +
-          `git config / .samo/config.json.`,
+        `samospec: refusing to branch on protected branch ` +
+          `'${branchResult.branch}' (${source}). ` +
+          `Override via .samo/config.json → git.protected_branches or ` +
+          `run on a feature branch. ` +
+          `Recommended: \`git checkout -b samospec/${input.slug}\`.`,
       );
       return {
         exitCode: 2,

--- a/tests/cli/new.test.ts
+++ b/tests/cli/new.test.ts
@@ -508,3 +508,61 @@ describe("samospec new — empty repo (no commits, Issue #65)", () => {
     );
   });
 });
+
+// ---------- protected-branch refusal message (Issue #126) ----------
+
+describe("samospec new — protected-branch refusal message (Issue #126)", () => {
+  let repoDir: string;
+  let repoCleanup: () => void;
+
+  beforeEach(() => {
+    // Set up a real git repo on 'main' (hardcoded-protected).
+    repoDir = mkdtempSync(path.join(tmpdir(), "samospec-protected-refusal-"));
+    const gitEnv = {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Samospec Test",
+      GIT_AUTHOR_EMAIL: "test@example.invalid",
+      GIT_COMMITTER_NAME: "Samospec Test",
+      GIT_COMMITTER_EMAIL: "test@example.invalid",
+    };
+    const gitRun = (args: string[]) =>
+      spawnSync("git", args, {
+        cwd: repoDir,
+        encoding: "utf8",
+        env: gitEnv,
+      });
+    gitRun(["init", "--initial-branch", "main", repoDir]);
+    gitRun(["config", "user.name", "Samospec Test"]);
+    gitRun(["config", "user.email", "test@example.invalid"]);
+    gitRun(["config", "commit.gpgsign", "false"]);
+    writeFileSync(path.join(repoDir, "README.md"), "# test\n");
+    gitRun(["add", "README.md"]);
+    gitRun(["commit", "-m", "chore: initial"]);
+    runInit({ cwd: repoDir });
+    repoCleanup = () => rmSync(repoDir, { recursive: true, force: true });
+  });
+  afterEach(() => repoCleanup());
+
+  test("refusal stderr names built-in default source and samospec/ hint", async () => {
+    const { adapter } = makeLeadAdapter([
+      personaJson("CLI engineer"),
+      questionsJson([{ id: "q1", text: "framework?" }]),
+    ]);
+    const result = await runNew(
+      {
+        cwd: repoDir,
+        slug: "myfeature",
+        idea: "some idea",
+        explain: false,
+        enableBranchCreation: true,
+        resolvers: acceptResolver(),
+        now: "2026-04-22T00:00:00Z",
+      },
+      adapter,
+    );
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("built-in default");
+    expect(result.stderr).toContain("samospec/");
+  });
+});


### PR DESCRIPTION
## Summary

- The protected-branch refusal message in `samospec new` now names the
  source of protection: `(built-in default)` for hardcoded branches
  (main, master, develop, trunk) or `(config)` for user-config-only ones.
- The message also suggests the recommended remedy:
  `git checkout -b samospec/<slug>`.

## Test plan

- [x] Added failing test (`tests/cli/new.test.ts` — "protected-branch
  refusal message" describe block) asserting stderr contains
  `built-in default` and `samospec/` on a protected-branch refusal.
- [x] Confirmed test fails before the fix and passes after.
- [x] `bun test` — 1458 tests pass, 0 fail.
- [x] `bun run lint` — clean.
- [x] `bun run format:check` — clean.
- [x] `bun run typecheck` — clean.

Fixes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)