### PR TITLE
fix(adapter): actionable error on invalid key (#127)

### DIFF
--- a/src/adapter/claude.ts
+++ b/src/adapter/claude.ts
@@ -368,15 +368,30 @@ export class ClaudeAdapter implements Adapter {
       return outcome.value;
     }
 
+    // Issue #127: promote "other" to "claude_cli_auth_failed" when the
+    // detail carries the invalid-key sentinel token.
+    const isAuthFail =
+      outcome.detail !== undefined && isInvalidApiKeyDetail(outcome.detail);
+    const resolvedReason: ClaudeAdapterErrorPayload["reason"] = isAuthFail
+      ? "claude_cli_auth_failed"
+      : outcome.reason;
+    // Strip the sentinel token prefix from the user-visible detail.
+    const resolvedDetail =
+      outcome.detail !== undefined
+        ? isAuthFail
+          ? outcome.detail.replace(`${INVALID_API_KEY_DETAIL_TOKEN} | `, "")
+          : outcome.detail
+        : undefined;
+
     const base: ClaudeAdapterErrorPayload = {
       kind: "terminal",
-      reason: outcome.reason,
-      retryable: outcome.reason === "timeout",
+      reason: resolvedReason,
+      retryable: resolvedReason === "timeout",
       attempts: outcome.attempts,
     };
     const payload: ClaudeAdapterErrorPayload = {
       ...base,
-      ...(outcome.detail !== undefined ? { detail: outcome.detail } : {}),
+      ...(resolvedDetail !== undefined ? { detail: resolvedDetail } : {}),
       ...(sawRateLimit ? { rate_limit: true } : {}),
     };
     throw new ClaudeAdapterError(payload);
@@ -409,6 +424,16 @@ export class ClaudeAdapter implements Adapter {
     }
     if (first.exitCode !== 0) {
       return classifyExit(first.exitCode, first.stderr);
+    }
+
+    // Issue #127: CLI exits 0 but stdout signals an auth failure.
+    // Detect before JSON parsing so users get an actionable message.
+    if (isInvalidApiKeyStdout(first.stdout)) {
+      return {
+        ok: false,
+        reason: "other",
+        detail: INVALID_API_KEY_DETAIL,
+      };
     }
 
     if (!args.structured) {
@@ -745,6 +770,31 @@ function isRateLimitStderr(stderr: string): boolean {
 
 function isRateLimitDetail(detail: string): boolean {
   return detail.includes(RATE_LIMIT_DETAIL_TOKEN);
+}
+
+// Issue #127: Claude CLI exits 0 but prints "Invalid API key · Fix
+// external API key" to stdout when ANTHROPIC_API_KEY is bogus. Match
+// case-insensitively so minor wording variations are caught too.
+const INVALID_API_KEY_PATTERN = /invalid api key/i;
+
+// Stable token embedded in the detail string so `runWithRetries` can
+// promote the reason from "other" to "claude_cli_auth_failed".
+const INVALID_API_KEY_DETAIL_TOKEN = "claude_cli_auth_failed";
+
+const INVALID_API_KEY_DETAIL =
+  `${INVALID_API_KEY_DETAIL_TOKEN} | ` +
+  "Claude CLI reports Invalid API key. " +
+  "If you intended to use the Claude subscription/OAuth session, " +
+  "run: unset ANTHROPIC_API_KEY — then retry. " +
+  "If you intended to use an API key, verify it at " +
+  "https://console.anthropic.com/settings/keys.";
+
+function isInvalidApiKeyStdout(stdout: string): boolean {
+  return INVALID_API_KEY_PATTERN.test(stdout);
+}
+
+function isInvalidApiKeyDetail(detail: string): boolean {
+  return detail.startsWith(INVALID_API_KEY_DETAIL_TOKEN);
 }
 
 function classifyExit(exitCode: number, stderr: string): AttemptResult<string> {

--- a/tests/adapter/claude-invalid-api-key.test.ts
+++ b/tests/adapter/claude-invalid-api-key.test.ts
@@ -1,0 +1,174 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #127: when Claude CLI exits 0 but prints "Invalid API key"
+// to stdout, the adapter must surface an actionable error that tells
+// the user to `unset ANTHROPIC_API_KEY` or verify the key.
+//
+// The pattern: `claude -p "…"` returns exit 0 with stdout:
+//   "Invalid API key · Fix external API key\n"
+// This is NOT valid JSON, so without the fix the adapter falls through
+// to schema_violation, producing a blank/unhelpful error.
+//
+// After the fix the thrown ClaudeAdapterError must:
+//   - have reason "claude_cli_auth_failed"
+//   - have detail containing "unset ANTHROPIC_API_KEY"
+//   - have detail containing "https://console.anthropic.com/settings/keys"
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ClaudeAdapter, ClaudeAdapterError } from "../../src/adapter/claude.ts";
+import type { SpawnCliInput, SpawnCliResult } from "../../src/adapter/spawn.ts";
+
+function makeFakeBinaryDir(
+  name: string,
+  script: string,
+): { dir: string; binary: string } {
+  const dir = mkdtempSync(join(tmpdir(), "samospec-inv-key-"));
+  const binary = join(dir, name);
+  writeFileSync(binary, `#!/usr/bin/env bash\n${script}\n`);
+  chmodSync(binary, 0o755);
+  return { dir, binary };
+}
+
+function makeInstalledHost(): Record<string, string | undefined> {
+  const { dir } = makeFakeBinaryDir("claude", 'echo "2.1.118"');
+  return {
+    PATH: dir,
+    HOME: "/tmp",
+    ANTHROPIC_API_KEY: "sk-ant-api03-OBVIOUSLY_FAKE",
+  };
+}
+
+/**
+ * A spawn spy that returns exit 0 with the exact stdout the Claude CLI
+ * emits when ANTHROPIC_API_KEY is invalid.
+ */
+function makeInvalidKeySpawn(
+  stdout: string,
+): (input: SpawnCliInput) => Promise<SpawnCliResult> {
+  return (_input: SpawnCliInput): Promise<SpawnCliResult> => {
+    return Promise.resolve({
+      ok: true,
+      exitCode: 0,
+      stdout,
+      stderr: "",
+    });
+  };
+}
+
+describe("ClaudeAdapter — Invalid API key stdout detection (issue #127)", () => {
+  test(
+    "ask() with 'Invalid API key' stdout → " +
+      "ClaudeAdapterError reason=claude_cli_auth_failed",
+    async () => {
+      const host = makeInstalledHost();
+      const adapter = new ClaudeAdapter({
+        host,
+        spawn: makeInvalidKeySpawn("Invalid API key · Fix external API key\n"),
+      });
+
+      let err: unknown;
+      try {
+        await adapter.ask({
+          prompt: "ping",
+          context: "",
+          opts: { effort: "max", timeout: 5_000 },
+        });
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toBeInstanceOf(ClaudeAdapterError);
+      if (err instanceof ClaudeAdapterError) {
+        expect(err.payload.reason).toBe("claude_cli_auth_failed");
+        expect(err.payload.kind).toBe("terminal");
+      }
+    },
+  );
+
+  test("error detail contains 'unset ANTHROPIC_API_KEY' guidance", async () => {
+    const host = makeInstalledHost();
+    const adapter = new ClaudeAdapter({
+      host,
+      spawn: makeInvalidKeySpawn("Invalid API key · Fix external API key\n"),
+    });
+
+    let err: unknown;
+    try {
+      await adapter.ask({
+        prompt: "ping",
+        context: "",
+        opts: { effort: "max", timeout: 5_000 },
+      });
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).toBeInstanceOf(ClaudeAdapterError);
+    if (err instanceof ClaudeAdapterError) {
+      const detail = err.payload.detail ?? "";
+      expect(detail.toLowerCase()).toContain("unset anthropic_api_key");
+      expect(detail).toContain("https://console.anthropic.com/settings/keys");
+    }
+  });
+
+  test(
+    "detection is case-insensitive: 'invalid api key' (lowercase) " +
+      "also triggers the auth error",
+    async () => {
+      const host = makeInstalledHost();
+      const adapter = new ClaudeAdapter({
+        host,
+        spawn: makeInvalidKeySpawn("invalid api key · fix external api key\n"),
+      });
+
+      let err: unknown;
+      try {
+        await adapter.ask({
+          prompt: "ping",
+          context: "",
+          opts: { effort: "max", timeout: 5_000 },
+        });
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toBeInstanceOf(ClaudeAdapterError);
+      if (err instanceof ClaudeAdapterError) {
+        expect(err.payload.reason).toBe("claude_cli_auth_failed");
+      }
+    },
+  );
+
+  test(
+    "unrelated stdout ('some other error') still falls through " +
+      "to schema_violation — no false positive",
+    async () => {
+      const host = makeInstalledHost();
+      const adapter = new ClaudeAdapter({
+        host,
+        spawn: makeInvalidKeySpawn("some other error output\n"),
+      });
+
+      let err: unknown;
+      try {
+        await adapter.ask({
+          prompt: "ping",
+          context: "",
+          opts: { effort: "max", timeout: 5_000 },
+        });
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toBeInstanceOf(ClaudeAdapterError);
+      if (err instanceof ClaudeAdapterError) {
+        // Must NOT be misclassified as an auth failure.
+        expect(err.payload.reason).not.toBe("claude_cli_auth_failed");
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Detects `"Invalid API key"` in Claude CLI stdout (exit 0 case) in
  `runSingleAttempt`, before the JSON pre-parser runs.
- Surfaces `reason: "claude_cli_auth_failed"` on the thrown
  `ClaudeAdapterError` with an actionable detail message telling the
  user to `unset ANTHROPIC_API_KEY` or verify their key at
  `https://console.anthropic.com/settings/keys`.
- Detection is case-insensitive (`/invalid api key/i`); a stable token
  in the detail string promotes the error reason from `"other"` to
  `"claude_cli_auth_failed"` in `runWithRetries`.
- No behavior change for any other error shapes (false-positive test
  included).

Fixes #127

## Test plan

- [ ] `bun test tests/adapter/claude-invalid-api-key.test.ts` — 4
  new tests: reason classification, detail guidance text, case
  insensitivity, no false positive.
- [ ] `bun test` — full suite (1461 tests) passes.
- [ ] `bun run lint && bun run format:check && bun run typecheck` — all
  green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)