### PR TITLE
fix(interview): guardrail lang-open prompt (#129)

### DIFF
--- a/src/cli/interview.ts
+++ b/src/cli/interview.ts
@@ -125,6 +125,11 @@ export interface RunInterviewInput {
   readonly now?: string;
   readonly effort?: EffortLevel;
   readonly timeoutMs?: number;
+  /**
+   * The user's raw idea/brief text. Used to detect whether a language
+   * is specified so the prompt can include the appropriate guardrail.
+   */
+  readonly idea?: string;
 }
 
 export interface InterviewResult {
@@ -146,16 +151,54 @@ export class InterviewTerminalError extends Error {
 
 // ---------- prompt builders ----------
 
+/**
+ * Returns true when the idea/brief does not specify a programming language
+ * (or explicitly says the language is open/flexible/any). Used to decide
+ * whether to inject the language-first guardrail into the prompt.
+ */
+export function ideaHasOpenLanguage(idea: string): boolean {
+  // Explicit open-language signals.
+  if (
+    /language\s+(choice\s+)?(is\s+)?(open|flexible|any|tbd|undecided)/i.test(
+      idea,
+    )
+  ) {
+    return true;
+  }
+  if (/(open|flexible|any)\s+(language|tech\s+stack)/i.test(idea)) {
+    return true;
+  }
+  // No specific language named -> treat as open.
+  const LANG_RE =
+    /\b(rust|python|go|golang|typescript|javascript|java|kotlin|swift|c\+\+|c#|ruby|elixir|haskell|scala|php|dart|zig)\b/i;
+  return !LANG_RE.test(idea);
+}
+
 function buildInterviewPrompt(input: {
   persona: string;
   explain: boolean;
+  idea?: string;
 }): string {
   const explainPreamble = input.explain
     ? "Use plain English for any user-facing copy. Avoid engineer-terse " +
       "jargon in prose fields. (Non-technical ICP.)\n\n"
     : "";
+
+  const langGuardrail =
+    input.idea !== undefined
+      ? ideaHasOpenLanguage(input.idea)
+        ? "Language guardrail: the brief does not specify a language (or " +
+          "says the language is open/flexible/any). Your FIRST question " +
+          "MUST be about language choice. Downstream questions must not " +
+          "presuppose any specific language.\n\n"
+        : "Language guardrail: the brief has already specified a language. " +
+          "Anchor your questions on that specified language choice; do not " +
+          "re-open it unless the user's brief explicitly invites it.\n\n"
+      : "";
+
   return (
     explainPreamble +
+    langGuardrail +
     `You are the samospec lead, playing the persona: ${input.persona}. ` +
     "Propose up to FIVE (5) high-signal strategic questions that the " +
     "user must answer to produce a v0.1 spec. Fewer is fine; more than 5 " +
@@ -195,6 +238,7 @@ export async function runInterview(
   const prompt = buildInterviewPrompt({
     persona: input.persona,
     explain: input.explain,
+    ...(input.idea !== undefined ? { idea: input.idea } : {}),
   });
 
   const askInput: AskInput = {

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -635,6 +635,7 @@ export async function runNew(
             onNotice: notice,
             outputPath: interviewPath,
             now: input.now,
+            idea: input.idea,
           },
           adapter,
         ),

--- a/src/cli/resume.ts
+++ b/src/cli/resume.ts
@@ -230,6 +230,9 @@ export async function runResume(
             onNotice: notice,
             outputPath: paths.interviewPath,
             now: input.now,
+            ...(state.input?.idea !== undefined
+              ? { idea: state.input.idea }
+              : {}),
           },
           adapter,
         );

--- a/tests/cli/interview.test.ts
+++ b/tests/cli/interview.test.ts
@@ -14,6 +14,7 @@ import {
   INTERVIEW_MAX_QUESTIONS,
   INTERVIEW_ESCAPE_HATCHES,
   InterviewFileSchema,
+  ideaHasOpenLanguage,
   readInterview,
   runInterview,
   writeInterview,
@@ -245,6 +246,48 @@ describe("runInterview — escape hatches always present (SPEC §5 Phase 4)", ()
   });
 });
 
+// ---------- ideaHasOpenLanguage ----------
+
+describe("ideaHasOpenLanguage — language-open detection (#129)", () => {
+  test("explicit 'language choice open' -> true", () => {
+    expect(ideaHasOpenLanguage("Build a TUI. Language choice open.")).toBe(
+      true,
+    );
+  });
+
+  test("'language open' -> true", () => {
+    expect(ideaHasOpenLanguage("some project, language open")).toBe(true);
+  });
+
+  test("'language flexible' -> true", () => {
+    expect(ideaHasOpenLanguage("REST API. Language flexible.")).toBe(true);
+  });
+
+  test("'language any' -> true", () => {
+    expect(ideaHasOpenLanguage("CLI tool. Language any.")).toBe(true);
+  });
+
+  test("no language keyword at all -> true (open by default)", () => {
+    expect(ideaHasOpenLanguage("Build a REST API service.")).toBe(true);
+  });
+
+  test("'in Rust' -> false (language specified)", () => {
+    expect(ideaHasOpenLanguage("Build a CLI in Rust.")).toBe(false);
+  });
+
+  test("'using Python' -> false", () => {
+    expect(ideaHasOpenLanguage("data pipeline using Python")).toBe(false);
+  });
+
+  test("'TypeScript backend' -> false", () => {
+    expect(ideaHasOpenLanguage("TypeScript backend with Express")).toBe(false);
+  });
+
+  test("'Go service' -> false", () => {
+    expect(ideaHasOpenLanguage("high-throughput Go service")).toBe(false);
+  });
+});
+
 // ---------- persona + explain wiring ----------
 
 describe("runInterview — persona + explain wiring (SPEC §7)", () => {
@@ -282,6 +325,65 @@ describe("runInterview — persona + explain wiring (SPEC §7)", () => {
     expect(first.prompt.toLowerCase()).toMatch(
       /plain english|plain-english|non-technical|everyday/,
     );
+  });
+
+  test("idea with open language -> prompt includes language-first guardrail", async () => {
+    const qs = [{ id: "q1", text: "something?" }];
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
+    await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        idea: "Build a TUI tool. Language choice open.",
+        onQuestion: (_q) => Promise.resolve({ choice: "decide for me" }),
+      },
+      adapter,
+    );
+    const first = adapter.asks[0];
+    expect(first.prompt).toMatch(
+      /language.*open|open.*language|first question.*language|language.*first question/i,
+    );
+  });
+
+  test("idea with no language -> prompt includes language-first guardrail", async () => {
+    const qs = [{ id: "q1", text: "something?" }];
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
+    await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        idea: "Build a REST API service.",
+        onQuestion: (_q) => Promise.resolve({ choice: "decide for me" }),
+      },
+      adapter,
+    );
+    const first = adapter.asks[0];
+    expect(first.prompt).toMatch(
+      /first question.*language|language.*first question/i,
+    );
+  });
+
+  test("idea specifying a language -> guardrail anchors on it, no lang-first mandate", async () => {
+    const qs = [{ id: "q1", text: "something?" }];
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
+    await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        idea: "Build a CLI in Rust.",
+        onQuestion: (_q) => Promise.resolve({ choice: "decide for me" }),
+      },
+      adapter,
+    );
+    const first = adapter.asks[0];
+    // Should NOT mandate language as first question; should anchor on Rust
+    expect(first.prompt).toMatch(/anchor|specified/i);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a language-guardrail clause to the lead's interview-generation prompt. When the user's brief does not name a specific language (or says "language open/flexible/any"), the prompt mandates the lead's FIRST question must be about language choice and downstream questions must not presuppose any language. When a language IS specified, the guardrail instead instructs the lead to anchor questions on it.
- Introduces `ideaHasOpenLanguage(idea: string): boolean` helper in `src/cli/interview.ts` (exported) that detects open-language briefs via explicit signals ("language open/flexible/any") and absence of known language names.
- Extends `RunInterviewInput` with optional `idea` field; both `new.ts` and `resume.ts` now pass the stored idea through.

Fixes #129

## Test plan

- [x] New unit tests for `ideaHasOpenLanguage` (9 cases: open signals, no-language, named languages)
- [x] New prompt-text tests asserting the guardrail clause appears (or does not appear) based on idea content
- [x] All 1469 existing tests still pass: `bun test`
- [x] Lint, format, typecheck clean: `bun run lint && bun run format:check && bun run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)