### PR TITLE
chore(init): bump codex default to gpt-5.4

### DIFF
--- a/.samo/blueprints/SPEC.md
+++ b/.samo/blueprints/SPEC.md
@@ -525,7 +525,7 @@ samospec version
 Both adapters are pinned with the same discipline — no "strongest available" handwaving.
 
 - **Lead:** `claude` CLI, model `claude-opus-4-7`, effort `max`. Fallback chain: `claude-opus-4-7 → claude-sonnet-4-6 → terminal`.
-- **Reviewer A:** `codex` CLI, model `gpt-5.1-codex-max`. `reasoning_effort: high`. Three-tier fallback chain: `gpt-5.1-codex-max → gpt-5.1-codex → account-default (no --model flag) → terminal`. The account-default tier (#54) fires only when both explicit pins fail with `model_unavailable` (e.g. ChatGPT-account auth does not support the pinned models); it lets codex pick whatever the account supports. When the account-default tier is used, `state.json` records `account_default: true` and `samospec status` surfaces it as a degraded resolution. The `adapters.reviewer_a.account_default_fallback` config key (default `true`) can be set to `false` to force explicit-pin-only mode. Persona "Paranoid security/ops engineer". The pin is updated per `samospec` release — no runtime "strongest available" discovery.
+- **Reviewer A:** `codex` CLI, model `gpt-5.4`. `reasoning_effort: xhigh` (maps from logical effort `max`). Three-tier fallback chain: `gpt-5.4 → gpt-5.3-codex → account-default (no --model flag) → terminal`. The account-default tier (#54) fires only when both explicit pins fail with `model_unavailable` (e.g. ChatGPT-account auth does not support the pinned models); it lets codex pick whatever the account supports. When the account-default tier is used, `state.json` records `account_default: true` and `samospec status` surfaces it as a degraded resolution. The `adapters.reviewer_a.account_default_fallback` config key (default `true`) can be set to `false` to force explicit-pin-only mode. Persona "Paranoid security/ops engineer". The pin is updated per `samospec` release — no runtime "strongest available" discovery.
 - **Reviewer B:** `claude` CLI (separate session from lead), model `claude-opus-4-7`, effort `max`. Persona "Pedantic QA / testability reviewer". **Follows the lead's fallback chain in lockstep** — if the lead resolves to Sonnet, Reviewer B does too (recorded in `state.json` as `coupled_fallback: true`). **v1.1+ auto-prefers Gemini/OpenCode** for this seat when those adapters ship, which also breaks the lockstep.
 - Post-v1 adapter policy (Gemini, OpenCode) is opt-in + accounting-required + fail-closed, with the subscription-auth escape (below) as the sole exception.
 
@@ -538,7 +538,7 @@ The resolved `{ adapter, model_id, effort_requested, effort_used }` for each rol
 
 ### Degraded-resolution visibility
 
-Any non-default resolution — lead fallback to Sonnet, Codex fallback to `gpt-5.1-codex`, Codex account-default tier (`account_default: true`), or Reviewer B in `coupled_fallback: true` — is surfaced to the user:
+Any non-default resolution — lead fallback to Sonnet, Codex fallback to `gpt-5.3-codex`, Codex account-default tier (`account_default: true`), or Reviewer B in `coupled_fallback: true` — is surfaced to the user:
 
 - `samospec status` prints a `running with degraded model resolution: <summary>` line whenever `state.json` records a fallback.
 - On the **first round** to enter a degraded resolution mid-session, the loop prompts once at round-start: `[accept / abort]`.
@@ -550,7 +550,7 @@ This prevents the "silent thesis drift" case where lead + Reviewer B both degrad
 
 | Logical | Claude | Codex / OpenAI-family | Gemini (post-v1) |
 |---|---|---|---|
-| `max` | extended thinking, budget unconstrained | `reasoning_effort: high` | thinking budget unconstrained |
+| `max` | extended thinking, budget unconstrained | `reasoning_effort: xhigh` | thinking budget unconstrained |
 | `high` | extended thinking, bounded | `reasoning_effort: high` | bounded |
 | `medium` | standard | `reasoning_effort: medium` | standard |
 | `low` | standard | `reasoning_effort: low` | standard |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,16 +61,16 @@ samospec doctor
 
 ```
 samospec: terminal — model_unavailable: all fallbacks exhausted:
-  gpt-5.1-codex-max → gpt-5.1-codex → account-default (no --model flag);
+  gpt-5.4 → gpt-5.3-codex → account-default (no --model flag);
   account is not authorized or no model is available
 ```
 
 Codex under ChatGPT-account auth (browser login via `codex auth`) does not
-support the pinned models `gpt-5.1-codex-max` and `gpt-5.1-codex`. The
+support the pinned models `gpt-5.4` and `gpt-5.3-codex`. The
 adapter tries a three-tier fallback chain:
 
-- `gpt-5.1-codex-max` (default pin)
-- `gpt-5.1-codex` (explicit fallback)
+- `gpt-5.4` (default pin — flagship model, effort xhigh)
+- `gpt-5.3-codex` (explicit fallback)
 - account-default: no `--model` flag, letting codex pick the account's
   supported model
 

--- a/src/adapter/codex.ts
+++ b/src/adapter/codex.ts
@@ -20,11 +20,11 @@
 //   engineer" with an explicit advisory weighting toward
 //   `missing-risk`, `weak-implementation`, `unnecessary-scope` (SPEC §7
 //   Model roles). Literal wording per issue #23.
-// - Effort mapping per SPEC §11: logical max/high → reasoning_effort
-//   high, medium → medium, low → low, off → minimal. Passed as a
-//   `--reasoning_effort <level>` flag on every work call.
-// - Pinned default model: `gpt-5.1-codex-max`. Fallback chain on
-//   model-unavailable failure: `gpt-5.1-codex-max → gpt-5.1-codex →
+// - Effort mapping per SPEC §11: logical max → reasoning_effort xhigh,
+//   high → high, medium → medium, low → low, off → minimal. Passed as
+//   a `--reasoning_effort <level>` flag on every work call.
+// - Pinned default model: `gpt-5.4`. Fallback chain on
+//   model-unavailable failure: `gpt-5.4 → gpt-5.3-codex →
 //   terminal` (SPEC §11). Fallback is triggered by a stderr heuristic
 //   on non-zero exit; resolved model is preserved within a call but
 //   not across calls (callers observe via `state.json` at round start).
@@ -96,11 +96,11 @@ const CODEX_AUTH_ENV_KEYS: readonly string[] = ["OPENAI_API_KEY"];
 // SPEC §11 pinned model + fallback chain. First entry is the default;
 // subsequent entries form the ordered fallback chain.
 const DEFAULT_MODELS: readonly ModelInfo[] = [
-  { id: "gpt-5.1-codex-max", family: "codex" },
-  { id: "gpt-5.1-codex", family: "codex" },
+  { id: "gpt-5.4", family: "codex" },
+  { id: "gpt-5.3-codex", family: "codex" },
 ];
 
-const DEFAULT_MODEL_ID = "gpt-5.1-codex-max";
+const DEFAULT_MODEL_ID = "gpt-5.4";
 
 // Sentinel value appended to the runtime fallback chain to represent
 // the account-default tier: codex is invoked with --model omitted so
@@ -109,8 +109,9 @@ const DEFAULT_MODEL_ID = "gpt-5.1-codex-max";
 const ACCOUNT_DEFAULT_SENTINEL = "__account_default__" as const;
 
 // SPEC §11 effort-level table (Codex / OpenAI-family column).
+// `max` maps to `xhigh` — the highest reasoning level gpt-5.4 supports.
 const EFFORT_TO_REASONING: Readonly<Record<EffortLevel, string>> = {
-  max: "high",
+  max: "xhigh",
   high: "high",
   medium: "medium",
   low: "low",
@@ -142,14 +143,14 @@ export interface CodexAdapterOpts {
    */
   readonly spawn?: SpawnFn;
   /**
-   * Models override. Defaults to pinned `gpt-5.1-codex-max` +
-   * `gpt-5.1-codex` fallback. Order matters: the first entry is the
+   * Models override. Defaults to pinned `gpt-5.4` +
+   * `gpt-5.3-codex` fallback. Order matters: the first entry is the
    * preferred model; subsequent entries are the fallback chain.
    */
   readonly models?: readonly ModelInfo[];
   /**
    * Default model id. Used as the first entry of the runtime fallback
-   * chain. Default `gpt-5.1-codex-max`.
+   * chain. Default `gpt-5.4`.
    */
   readonly defaultModel?: string;
   /**

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -33,8 +33,8 @@ export interface LeadAdapterDefaults {
 
 export interface ReviewerAAdapterDefaults {
   readonly adapter: "codex";
-  readonly model_id: "gpt-5.1-codex-max";
-  readonly effort: "high";
+  readonly model_id: "gpt-5.4";
+  readonly effort: "max";
   readonly fallback_chain: readonly string[];
 }
 
@@ -100,7 +100,7 @@ export interface DefaultConfig {
 /**
  * Pinned v1 defaults. SPEC §11.
  * - Lead: claude / claude-opus-4-7 / max
- * - Reviewer A: codex / gpt-5.1-codex-max / high
+ * - Reviewer A: codex / gpt-5.4 / max (xhigh reasoning effort)
  * - Reviewer B: claude / claude-opus-4-7 / max (same family as lead)
  * - Budget: generous defaults (SPEC §11 Budget guardrails).
  * - Git: remote_probe off by default (SPEC §14 threat model).
@@ -116,9 +116,9 @@ export const DEFAULT_CONFIG: DefaultConfig = {
     },
     reviewer_a: {
       adapter: "codex",
-      model_id: "gpt-5.1-codex-max",
-      effort: "high",
-      fallback_chain: ["gpt-5.1-codex-max", "gpt-5.1-codex", "terminal"],
+      model_id: "gpt-5.4",
+      effort: "max",
+      fallback_chain: ["gpt-5.4", "gpt-5.3-codex", "terminal"],
     },
     reviewer_b: {
       adapter: "claude",

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -1575,7 +1575,7 @@ function inferResolutions(
     },
     reviewer_a: {
       adapter: adapters.reviewerA.vendor,
-      model_id: stateAdapters.reviewer_a?.model_id ?? "gpt-5.1-codex-max",
+      model_id: stateAdapters.reviewer_a?.model_id ?? "gpt-5.4",
     },
     reviewer_b: {
       adapter: adapters.reviewerB.vendor,

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -276,7 +276,7 @@ function inferStatusResolutions(
     },
     reviewer_a: {
       adapter: roleOf("reviewer_a")?.adapter.vendor ?? "codex",
-      model_id: stateAdapters.reviewer_a?.model_id ?? "gpt-5.1-codex-max",
+      model_id: stateAdapters.reviewer_a?.model_id ?? "gpt-5.4",
     },
     reviewer_b: {
       adapter: roleOf("reviewer_b")?.adapter.vendor ?? "claude",

--- a/src/loop/degradation.ts
+++ b/src/loop/degradation.ts
@@ -4,7 +4,7 @@
  * SPEC §11 — degraded-resolution visibility.
  *
  * Any non-default resolution — lead fallback from Opus to Sonnet, Codex
- * fallback from `gpt-5.1-codex-max` to `gpt-5.1-codex`, or Reviewer B
+ * fallback from `gpt-5.4` to `gpt-5.3-codex`, or Reviewer B
  * in coupled_fallback — is surfaced to the user:
  *   - `samospec status` prints `running with degraded model resolution:
  *     <summary>` whenever `state.json` records a fallback.
@@ -20,7 +20,7 @@
 
 export const DEFAULT_LEAD_MODEL = "claude-opus-4-7" as const;
 export const DEFAULT_REVIEWER_B_MODEL = "claude-opus-4-7" as const;
-export const DEFAULT_CODEX_MODEL = "gpt-5.1-codex-max" as const;
+export const DEFAULT_CODEX_MODEL = "gpt-5.4" as const;
 
 export interface AdapterResolutionSnapshot {
   readonly adapter: string;

--- a/tests/adapter/codex-chatgpt-auth.test.ts
+++ b/tests/adapter/codex-chatgpt-auth.test.ts
@@ -180,7 +180,7 @@ describe("Bug #54-1: ChatGPT-auth error on stdout exit-0 → model_unavailable",
             error: {
               type: "invalid_request_error",
               message:
-                "The 'gpt-5.1-codex-max' model is not supported " +
+                "The 'gpt-5.4' model is not supported " +
                 "when using Codex with a ChatGPT account.",
             },
           }) +
@@ -193,7 +193,7 @@ describe("Bug #54-1: ChatGPT-auth error on stdout exit-0 → model_unavailable",
         spawn: spy.spawn,
         // Single-model list + no account-default so we test
         // classification in isolation without the fallback chain.
-        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+        models: [{ id: "gpt-5.4", family: "codex" }],
         accountDefaultFallback: false,
       });
 
@@ -225,7 +225,7 @@ describe("Bug #54-1: ChatGPT-auth error on stdout exit-0 → model_unavailable",
         host,
         spawn: spy.spawn,
         // Disable account-default to isolate the classification test.
-        models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+        models: [{ id: "gpt-5.4", family: "codex" }],
         accountDefaultFallback: false,
       });
 
@@ -266,7 +266,7 @@ describe("Bug #54-2: account-default fallback after both explicit pins fail", ()
     // The adapter must succeed using the account-default tier.
     expect(out.answer).toBe("account-default-ok");
 
-    // Three spawns: gpt-5.1-codex-max (fail), gpt-5.1-codex (fail),
+    // Three spawns: gpt-5.4 (fail), gpt-5.3-codex (fail),
     // account-default (no --model flag, success).
     expect(spy.calls.length).toBe(3);
 
@@ -285,7 +285,7 @@ describe("Bug #54-2: account-default fallback after both explicit pins fail", ()
       // The adapter must expose whether it fell back to account-default
       // so the resolver can write it to state.json for visibility.
       const spy = makeSpy([
-        // gpt-5.1-codex-max: ChatGPT-auth error (exit 0, stdout)
+        // gpt-5.4: ChatGPT-auth error (exit 0, stdout)
         {
           ok: true,
           exitCode: 0,
@@ -297,14 +297,14 @@ describe("Bug #54-2: account-default fallback after both explicit pins fail", ()
               error: {
                 type: "invalid_request_error",
                 message:
-                  "The 'gpt-5.1-codex-max' model is not supported " +
+                  "The 'gpt-5.4' model is not supported " +
                   "when using Codex with a ChatGPT account.",
               },
             }) +
             "\n",
           stderr: "",
         },
-        // gpt-5.1-codex: ChatGPT-auth error (exit 0, stdout)
+        // gpt-5.3-codex: ChatGPT-auth error (exit 0, stdout)
         {
           ok: true,
           exitCode: 0,
@@ -316,7 +316,7 @@ describe("Bug #54-2: account-default fallback after both explicit pins fail", ()
               error: {
                 type: "invalid_request_error",
                 message:
-                  "The 'gpt-5.1-codex' model is not supported " +
+                  "The 'gpt-5.3-codex' model is not supported " +
                   "when using Codex with a ChatGPT account.",
               },
             }) +
@@ -370,8 +370,8 @@ describe("Bug #54-3: terminal with informative message when all tiers fail", () 
       });
 
       const spy = makeSpy([
-        chatGptError("gpt-5.1-codex-max"),
-        chatGptError("gpt-5.1-codex"),
+        chatGptError("gpt-5.4"),
+        chatGptError("gpt-5.3-codex"),
         // Account-default also fails: same error shape, no model name.
         {
           ok: true,

--- a/tests/adapter/codex-pinned-model-fallback.test.ts
+++ b/tests/adapter/codex-pinned-model-fallback.test.ts
@@ -92,12 +92,12 @@ const ACCOUNT_DEFAULT_OK: SpawnCliResult = {
 describe("Bug #88-1: exit-1 + invalid_request_error stdout → model_unavailable", () => {
   test("classifies exit-1 invalid_request_error stdout as model_unavailable, not other/schema_violation", async () => {
     // Single-model, no account-default: isolates the classification.
-    const spy = makeSpy([makePinnedModelExit1Response("gpt-5.1-codex-max")]);
+    const spy = makeSpy([makePinnedModelExit1Response("gpt-5.4")]);
     const adapter = new CodexAdapter({
       host: FAKE_HOST,
       spawn: spy.spawn,
       binary: "/usr/bin/codex",
-      models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+      models: [{ id: "gpt-5.4", family: "codex" }],
       accountDefaultFallback: false,
     });
 
@@ -127,14 +127,14 @@ describe("Bug #88-1: exit-1 + invalid_request_error stdout → model_unavailable
       exitCode: 1,
       stdout:
         "Reading prompt from stdin...\nOpenAI Codex v0.120.0 (research preview)\n" +
-        "--------\nworkdir: /private/tmp/x\nmodel: gpt-5.1-codex-max\n--------\n" +
+        "--------\nworkdir: /private/tmp/x\nmodel: gpt-5.4\n--------\n" +
         JSON.stringify({
           type: "error",
           status: 400,
           error: {
             type: "invalid_request_error",
             message:
-              "The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account.",
+              "The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.",
           },
         }) +
         "\n",
@@ -145,7 +145,7 @@ describe("Bug #88-1: exit-1 + invalid_request_error stdout → model_unavailable
       host: FAKE_HOST,
       spawn: spy.spawn,
       binary: "/usr/bin/codex",
-      models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+      models: [{ id: "gpt-5.4", family: "codex" }],
       accountDefaultFallback: false,
     });
 
@@ -165,10 +165,10 @@ describe("Bug #88-1: exit-1 + invalid_request_error stdout → model_unavailable
 // ---------- Bug #88-1b: fallback chain must trigger ----------
 
 describe("Bug #88-1 fallback: exit-1 invalid_request_error fires account-default fallback", () => {
-  test("gpt-5.1-codex-max exit-1 → gpt-5.1-codex exit-1 → account-default (no --model) succeeds", async () => {
+  test("gpt-5.4 exit-1 → gpt-5.3-codex exit-1 → account-default (no --model) succeeds", async () => {
     const spy = makeSpy([
-      makePinnedModelExit1Response("gpt-5.1-codex-max"),
-      makePinnedModelExit1Response("gpt-5.1-codex"),
+      makePinnedModelExit1Response("gpt-5.4"),
+      makePinnedModelExit1Response("gpt-5.3-codex"),
       ACCOUNT_DEFAULT_OK,
     ]);
     const adapter = new CodexAdapter({
@@ -194,8 +194,8 @@ describe("Bug #88-1 fallback: exit-1 invalid_request_error fires account-default
 
   test("exit-1 invalid_request_error with account-default succeeds → account_default: true in output", async () => {
     const spy = makeSpy([
-      makePinnedModelExit1Response("gpt-5.1-codex-max"),
-      makePinnedModelExit1Response("gpt-5.1-codex"),
+      makePinnedModelExit1Response("gpt-5.4"),
+      makePinnedModelExit1Response("gpt-5.3-codex"),
       ACCOUNT_DEFAULT_OK,
     ]);
     const adapter = new CodexAdapter({

--- a/tests/adapter/codex-spawn-flags.test.ts
+++ b/tests/adapter/codex-spawn-flags.test.ts
@@ -72,7 +72,7 @@ function sampleAsk(level: EffortLevel): AskInput {
 
 describe("codex spawn flags — -c model_reasoning_effort=<level> (Issue #52)", () => {
   const cases: readonly [EffortLevel, string][] = [
-    ["max", "high"],
+    ["max", "xhigh"],
     ["high", "high"],
     ["medium", "medium"],
     ["low", "low"],

--- a/tests/adapter/codex-stderr-error-classification.test.ts
+++ b/tests/adapter/codex-stderr-error-classification.test.ts
@@ -95,12 +95,12 @@ function realCodexStderrErrorResponse(model: string): SpawnCliResult {
 
 describe("Bug #88-followup: invalid_request_error on STDERR → model_unavailable", () => {
   test("empty stdout + stderr-carried invalid_request_error (exit 1) classifies as model_unavailable", async () => {
-    const spy = makeSpy([realCodexStderrErrorResponse("gpt-5.1-codex-max")]);
+    const spy = makeSpy([realCodexStderrErrorResponse("gpt-5.4")]);
     const adapter = new CodexAdapter({
       host: FAKE_HOST,
       spawn: spy.spawn,
       binary: "/usr/bin/codex",
-      models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+      models: [{ id: "gpt-5.4", family: "codex" }],
       accountDefaultFallback: false,
     });
 
@@ -122,8 +122,8 @@ describe("Bug #88-followup: invalid_request_error on STDERR → model_unavailabl
 
   test("stderr-carried error with 'not supported' phrase triggers full fallback chain to account-default", async () => {
     const spy = makeSpy([
-      realCodexStderrErrorResponse("gpt-5.1-codex-max"),
-      realCodexStderrErrorResponse("gpt-5.1-codex"),
+      realCodexStderrErrorResponse("gpt-5.4"),
+      realCodexStderrErrorResponse("gpt-5.3-codex"),
       {
         ok: true,
         exitCode: 0,
@@ -142,7 +142,7 @@ describe("Bug #88-followup: invalid_request_error on STDERR → model_unavailabl
     expect(out.answer).toBe("account-default-ok");
     expect((out as Record<string, unknown>)["account_default"]).toBe(true);
 
-    // Three spawns: pinned-max (fail on stderr), pinned (fail on stderr),
+    // Three spawns: gpt-5.4 (fail on stderr), gpt-5.3-codex (fail on stderr),
     // account-default (success).
     expect(spy.calls.length).toBe(3);
     // Third call has no --model flag.
@@ -164,7 +164,7 @@ describe("Bug #88-followup: classifyExit recognizes 'not supported' as model_una
         exitCode: 1,
         stdout: "",
         stderr:
-          "Error: The 'gpt-5.1-codex-max' model is not supported when " +
+          "Error: The 'gpt-5.4' model is not supported when " +
           "using Codex with a ChatGPT account.\n",
       },
     ]);
@@ -172,7 +172,7 @@ describe("Bug #88-followup: classifyExit recognizes 'not supported' as model_una
       host: FAKE_HOST,
       spawn: spy.spawn,
       binary: "/usr/bin/codex",
-      models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+      models: [{ id: "gpt-5.4", family: "codex" }],
       accountDefaultFallback: false,
     });
 
@@ -201,7 +201,7 @@ describe("Bug #88-followup: classifyExit recognizes 'not supported' as model_una
       host: FAKE_HOST,
       spawn: spy.spawn,
       binary: "/usr/bin/codex",
-      models: [{ id: "gpt-5.1-codex-max", family: "codex" }],
+      models: [{ id: "gpt-5.4", family: "codex" }],
       accountDefaultFallback: false,
     });
 

--- a/tests/adapter/codex.effort.test.ts
+++ b/tests/adapter/codex.effort.test.ts
@@ -81,7 +81,7 @@ function sampleAskWithEffort(level: EffortLevel): AskInput {
 
 describe("CodexAdapter effort-level mapping (SPEC §11 table)", () => {
   const cases: readonly [EffortLevel, string][] = [
-    ["max", "high"],
+    ["max", "xhigh"],
     ["high", "high"],
     ["medium", "medium"],
     ["low", "low"],
@@ -111,7 +111,7 @@ describe("CodexAdapter effort-level mapping (SPEC §11 table)", () => {
 });
 
 describe("CodexAdapter fallback-chain ordering (SPEC §11)", () => {
-  test("default chain is gpt-5.1-codex-max first, gpt-5.1-codex second", async () => {
+  test("default chain is gpt-5.4 first, gpt-5.3-codex second", async () => {
     // Rejecting every attempt with model-not-available forces the
     // adapter to walk the chain; the spawn cmds capture the order.
     // accountDefaultFallback: false so we isolate the two-model chain.
@@ -136,9 +136,9 @@ describe("CodexAdapter fallback-chain ordering (SPEC §11)", () => {
     expect(spy.calls.length).toBe(2);
     const first = spy.calls[0]?.cmd ?? [];
     const second = spy.calls[1]?.cmd ?? [];
-    expect(first).toContain("gpt-5.1-codex-max");
-    expect(second).toContain("gpt-5.1-codex");
-    expect(second).not.toContain("gpt-5.1-codex-max");
+    expect(first).toContain("gpt-5.4");
+    expect(second).toContain("gpt-5.3-codex");
+    expect(second).not.toContain("gpt-5.4");
   });
 
   test("custom model list is respected in order, default still leads", async () => {

--- a/tests/adapter/codex.test.ts
+++ b/tests/adapter/codex.test.ts
@@ -84,15 +84,15 @@ describe("CodexAdapter — lifecycle (SPEC §7, §11)", () => {
     }
   });
 
-  test("models() returns pinned default gpt-5.1-codex-max + gpt-5.1-codex fallback; family 'codex'", async () => {
+  test("models() returns pinned default gpt-5.4 + gpt-5.3-codex fallback; family 'codex'", async () => {
     const adapter = new CodexAdapter();
     const models = await adapter.models();
     expect(models.length).toBeGreaterThanOrEqual(2);
     const ids = models.map((m) => m.id);
-    expect(ids).toContain("gpt-5.1-codex-max");
-    expect(ids).toContain("gpt-5.1-codex");
+    expect(ids).toContain("gpt-5.4");
+    expect(ids).toContain("gpt-5.3-codex");
     // Pinned default must be first in the chain.
-    expect(ids[0]).toBe("gpt-5.1-codex-max");
+    expect(ids[0]).toBe("gpt-5.4");
     for (const m of models) {
       expect(m.family).toBe("codex");
     }

--- a/tests/adapter/codex.work.test.ts
+++ b/tests/adapter/codex.work.test.ts
@@ -10,7 +10,7 @@
 // - spawn-spy: non-interactive flags (`exec`) passed on every work call
 // - spawn-spy: minimal env — only HOME, PATH, TMPDIR, OPENAI_API_KEY
 //   forwarded; no host secret leaks
-// - spawn-spy: pinned model `gpt-5.1-codex-max` passed on first attempt
+// - spawn-spy: pinned model `gpt-5.4` passed on first attempt
 // - spawn-spy: reasoning-effort flag matches the logical effort per
 //   SPEC §11 effort-level table
 // - critique(): persona system prompt + taxonomy weighting literal
@@ -257,7 +257,7 @@ describe("CodexAdapter spawn flags + minimal env (SPEC §7)", () => {
     if (workCall === undefined) return;
     expect(workCall.cmd).toContain("exec");
     expect(workCall.cmd).toContain("--model");
-    expect(workCall.cmd).toContain("gpt-5.1-codex-max");
+    expect(workCall.cmd).toContain("gpt-5.4");
   });
 
   test("ask() passes reasoning_effort flag matching logical effort (SPEC §11 table)", async () => {
@@ -640,7 +640,7 @@ describe("CodexAdapter.critique (SPEC §7)", () => {
 // ---------- model fallback chain ----------
 
 describe("CodexAdapter model fallback (SPEC §11)", () => {
-  test("pinned model rejected -> falls back to gpt-5.1-codex and succeeds", async () => {
+  test("pinned model rejected -> falls back to gpt-5.3-codex and succeeds", async () => {
     const stateDir = mkdtempSync(join(tmpdir(), "samospec-codex-fb-"));
     TMP.push(stateDir);
     const stateJson = join(stateDir, "call-state.json");
@@ -655,15 +655,15 @@ describe("CodexAdapter model fallback (SPEC §11)", () => {
 
     const out = await adapter.ask(sampleAsk());
     expect(out.answer).toBe("fallback-ok");
-    // Exactly two spawns: max (rejected), then codex.
+    // Exactly two spawns: gpt-5.4 (rejected), then gpt-5.3-codex.
     expect(spy.calls.length).toBe(2);
     // First call carried the pinned model.
     const firstCmd = spy.calls[0]?.cmd.join(" ") ?? "";
-    expect(firstCmd).toContain("gpt-5.1-codex-max");
+    expect(firstCmd).toContain("gpt-5.4");
     // Second call carried the fallback model.
     const secondCmd = spy.calls[1]?.cmd.join(" ") ?? "";
-    expect(secondCmd).toContain("gpt-5.1-codex");
-    expect(secondCmd).not.toContain("gpt-5.1-codex-max");
+    expect(secondCmd).toContain("gpt-5.3-codex");
+    expect(secondCmd).not.toContain("gpt-5.4");
   });
 
   test("all models rejected -> terminal", async () => {

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -62,8 +62,13 @@ describe("samospec init — fresh directory", () => {
 
     const reviewerA = adapters["reviewer_a"] as Record<string, unknown>;
     expect(reviewerA["adapter"]).toBe("codex");
-    expect(reviewerA["model_id"]).toBe("gpt-5.1-codex-max");
-    expect(reviewerA["effort"]).toBe("high");
+    expect(reviewerA["model_id"]).toBe("gpt-5.4");
+    expect(reviewerA["effort"]).toBe("max");
+    // Regression guard: stale 5.1-codex-max must NOT appear (#130).
+    expect(reviewerA["model_id"]).not.toContain("5.1-codex");
+    const fallback = reviewerA["fallback_chain"] as string[];
+    expect(fallback[0]).toBe("gpt-5.4");
+    expect(fallback).toContain("gpt-5.3-codex");
 
     const reviewerB = adapters["reviewer_b"] as Record<string, unknown>;
     expect(reviewerB["adapter"]).toBe("claude");

--- a/tests/cli/iterate.test.ts
+++ b/tests/cli/iterate.test.ts
@@ -448,7 +448,7 @@ describe("cli/iterate — degraded resolution prompt", () => {
       },
       resolutions: {
         lead: { adapter: "claude", model_id: "claude-sonnet-4-6" },
-        reviewer_a: { adapter: "codex", model_id: "gpt-5.1-codex-max" },
+        reviewer_a: { adapter: "codex", model_id: "gpt-5.3-codex" },
         reviewer_b: { adapter: "claude", model_id: "claude-sonnet-4-6" },
         coupled_fallback: true,
       },

--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -135,7 +135,7 @@ describe("cli/status — degraded resolution (SPEC §11)", () => {
       ],
       resolutions: {
         lead: { adapter: "claude", model_id: "claude-sonnet-4-6" },
-        reviewer_a: { adapter: "codex", model_id: "gpt-5.1-codex-max" },
+        reviewer_a: { adapter: "codex", model_id: "gpt-5.3-codex" },
         reviewer_b: { adapter: "claude", model_id: "claude-sonnet-4-6" },
         coupled_fallback: true,
       },

--- a/tests/fixtures/codex-fixtures/chatgpt-auth-all-fail.json
+++ b/tests/fixtures/codex-fixtures/chatgpt-auth-all-fail.json
@@ -2,7 +2,7 @@
   "script": [
     {
       "type": "stdout",
-      "text": "ERROR: {\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account.\"}}\n"
+      "text": "ERROR: {\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.\"}}\n"
     },
     { "type": "exit", "code": 0 }
   ]

--- a/tests/fixtures/codex-fixtures/chatgpt-auth-both-fail-then-default.json
+++ b/tests/fixtures/codex-fixtures/chatgpt-auth-both-fail-then-default.json
@@ -4,7 +4,7 @@
       "script": [
         {
           "type": "stdout",
-          "text": "ERROR: {\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account.\"}}\n"
+          "text": "ERROR: {\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.\"}}\n"
         },
         { "type": "exit", "code": 0 }
       ]
@@ -13,7 +13,7 @@
       "script": [
         {
           "type": "stdout",
-          "text": "ERROR: {\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5.1-codex' model is not supported when using Codex with a ChatGPT account.\"}}\n"
+          "text": "ERROR: {\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.\"}}\n"
         },
         { "type": "exit", "code": 0 }
       ]

--- a/tests/fixtures/codex-fixtures/chatgpt-auth-error-max.json
+++ b/tests/fixtures/codex-fixtures/chatgpt-auth-error-max.json
@@ -2,7 +2,7 @@
   "script": [
     {
       "type": "stdout",
-      "text": "ERROR: {\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account.\"}}\n"
+      "text": "ERROR: {\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.\"}}\n"
     },
     { "type": "exit", "code": 0 }
   ]

--- a/tests/fixtures/codex-fixtures/model-fallback.json
+++ b/tests/fixtures/codex-fixtures/model-fallback.json
@@ -4,7 +4,7 @@
       "script": [
         {
           "type": "stderr",
-          "text": "error: model 'gpt-5.1-codex-max' is not available for this account\n"
+          "text": "error: model 'gpt-5.4' is not available for this account\n"
         },
         { "type": "exit", "code": 2 }
       ]

--- a/tests/loop/degradation.test.ts
+++ b/tests/loop/degradation.test.ts
@@ -34,10 +34,10 @@ describe("loop/degradation — detectDegradedResolution (SPEC §11)", () => {
     expect(res.items.some((i) => i.includes("coupled_fallback"))).toBe(true);
   });
 
-  test("Codex fell back to gpt-5.1-codex (non-max) -> flagged", () => {
+  test("Codex fell back to gpt-5.3-codex (non-default) -> flagged", () => {
     const res = detectDegradedResolution({
       lead: { adapter: "claude", model_id: DEFAULT_LEAD_MODEL },
-      reviewer_a: { adapter: "codex", model_id: "gpt-5.1-codex" },
+      reviewer_a: { adapter: "codex", model_id: "gpt-5.3-codex" },
       reviewer_b: { adapter: "claude", model_id: DEFAULT_LEAD_MODEL },
       coupled_fallback: false,
     });
@@ -50,12 +50,12 @@ describe("loop/degradation — detectDegradedResolution (SPEC §11)", () => {
       degraded: true,
       items: [
         "lead fell back to claude-sonnet-4-6",
-        "reviewer_a fell back to gpt-5.1-codex",
+        "reviewer_a fell back to gpt-5.3-codex",
       ],
     });
     expect(text).toContain("degraded model resolution");
     expect(text).toContain("lead fell back to claude-sonnet-4-6");
-    expect(text).toContain("reviewer_a fell back to gpt-5.1-codex");
+    expect(text).toContain("reviewer_a fell back to gpt-5.3-codex");
   });
 
   test("formatStatusDegradedLine empty when no degradation", () => {

--- a/tests/publish/lint.test.ts
+++ b/tests/publish/lint.test.ts
@@ -276,7 +276,7 @@ describe("publishLint — soft warnings: adapter/model drift", () => {
       spec,
       baseRepoState({
         repoRoot: fx.dir,
-        adapterModels: ["claude-opus-4-7", "gpt-5.1-codex-max"],
+        adapterModels: ["claude-opus-4-7", "gpt-5.4"],
       }),
     );
     const soft = report.softWarnings.filter((w) => w.kind === "adapter-drift");


### PR DESCRIPTION
## Summary

- Updates `reviewer_a` default model from stale `gpt-5.1-codex-max` (absent in codex CLI 0.120.0) to `gpt-5.4` — the current flagship model
- Bumps effort from `high` to `max` (maps `max → xhigh` in the codex adapter's `EFFORT_TO_REASONING` table, which is the highest reasoning level `gpt-5.4` supports)
- Updates the fallback chain from `gpt-5.1-codex-max → gpt-5.1-codex → terminal` to `gpt-5.4 → gpt-5.3-codex → terminal`
- Updates all stale `gpt-5.1-*` references across src, tests, fixtures, SPEC.md, and docs/troubleshooting.md

## Test plan

- [ ] `bun test` — 1457 tests pass (regression test added to `tests/cli/init.test.ts` asserting `model_id: "gpt-5.4"` and NOT `"5.1-codex"`)
- [ ] `bun run lint` passes
- [ ] `bun run format:check` passes
- [ ] `bun run typecheck` passes

Fixes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)