### PR TITLE
chore: bump version to 0.6.2 (#137-#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.6.2] - 2026-04-23
+
+### Added
+
+- **`--verbose` now listed in `samospec iterate --help`** (#137). The
+  flag was accepted (as a no-op alias for default-verbose behavior)
+  since v0.6.1, but the help block didn't document it. Now
+  discoverable.
+
+### Fixed
+
+- **Claude adapter: invalid-key detection now covers the repair-retry
+  path too** (#138). Previously, if the Anthropic API key became
+  invalid between the first spawn and the repair-retry spawn (rare but
+  possible), the error fell through to `schema_violation` instead of
+  the actionable `claude_cli_auth_failed` reason. The check now fires
+  only when JSON parsing has already failed, so valid spec JSON
+  containing the phrase as body text cannot false-positive.
+- **Protected-branch refusal in `samospec iterate`** (#139). The
+  commit path was still using the pre-#126 bare wording; now matches
+  `src/cli/new.ts` — names the "built-in default" source and
+  recommends the `samospec/<slug>` branch convention.
+
+### Changed
+
+- **Codex `effort: "max"` now maps to `xhigh` reasoning** (was
+  `high`) (#140). Matches CLAUDE.md's "strongest latest" product
+  thesis. Users with `effort: "max"` in `.samo/config.json` will see
+  higher reasoning cost and higher review quality. To pin the previous
+  behavior, set `"effort": "high"` explicitly. Closes #140.
+
+### CI
+
+- **CI release path verified with rotated NPM_TOKEN.** This release
+  exercises the publish workflow end-to-end after NPM_TOKEN was
+  rotated to a granular token with explicit "all unscoped" packages.
+  Closes #121 if the publish lands cleanly.
+
+---
+
 ## [Unreleased]
 
 ---

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Requires [Bun](https://bun.sh) ≥ 1.2.0.
 
 ```bash
 bun install -g samospec
-samospec --version   # 0.6.1
+samospec --version   # 0.6.2
 ```
 
 Or one-shot:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samospec",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Git-native CLI that turns a rough idea into a reviewed, versioned specification document.",
   "type": "module",
   "bin": {

--- a/src/adapter/claude.ts
+++ b/src/adapter/claude.ts
@@ -471,6 +471,17 @@ export class ClaudeAdapter implements Adapter {
 
     const parsedRepair = preParseJson(repair.stdout);
     if (!parsedRepair.ok) {
+      // Issue #138: before falling through to schema_violation, check
+      // whether the raw stdout is an auth-failure signal. We only do
+      // this when JSON parsing has already failed — valid spec JSON
+      // containing the phrase in a field value must not false-positive.
+      if (isInvalidApiKeyStdout(repair.stdout)) {
+        return {
+          ok: false,
+          reason: "other",
+          detail: INVALID_API_KEY_DETAIL,
+        };
+      }
       return {
         ok: false,
         reason: "schema_violation",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -123,6 +123,8 @@ const USAGE =
   "      Git remote name (default: origin).\n" +
   "  --quiet\n" +
   "      Suppress per-phase progress + heartbeat (default: verbose on stderr).\n" +
+  "  --verbose\n" +
+  "      Alias / no-op — iterate is verbose by default (see --quiet).\n" +
   "  --max-session-wall-clock-ms <ms>\n" +
   "      Cap the review-loop session wall-clock (positive integer ms). On cap:\n" +
   "      exit 4 with reason `session-wall-clock`.\n" +

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -38,7 +38,7 @@ import type { Adapter, Finding } from "../adapter/types.ts";
 import { currentBranch } from "../git/branch.ts";
 import { specCommit } from "../git/commit.ts";
 import { ProtectedBranchError } from "../git/errors.ts";
-import { isProtected } from "../git/protected.ts";
+import { HARDCODED_PROTECTED_BRANCHES, isProtected } from "../git/protected.ts";
 import {
   applyManualEdit,
   detectManualEdits,
@@ -1009,8 +1009,14 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
             }
           } catch (err) {
             if (err instanceof ProtectedBranchError) {
+              // Issue #139: match the wording from src/cli/new.ts —
+              // name the source and recommend samospec/<slug>.
+              const src = HARDCODED_PROTECTED_BRANCHES.includes(err.branchName)
+                ? "built-in default"
+                : "config";
               error(
-                `samospec: cannot commit on protected branch '${err.branchName}'. ` +
+                `samospec: refusing to commit on protected branch ` +
+                  `'${err.branchName}' (${src}). ` +
                   `Check out samospec/${input.slug} and re-run.`,
               );
               return {

--- a/tests/adapter/claude-invalid-api-key.test.ts
+++ b/tests/adapter/claude-invalid-api-key.test.ts
@@ -13,6 +13,11 @@
 //   - have reason "claude_cli_auth_failed"
 //   - have detail containing "unset ANTHROPIC_API_KEY"
 //   - have detail containing "https://console.anthropic.com/settings/keys"
+//
+// Issue #138: the same detection must also apply on the repair-retry
+// path (second spawn). If auth becomes invalid between the first spawn
+// and the repair call, the error should still surface as
+// "claude_cli_auth_failed", not "schema_violation".
 
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync, chmodSync } from "node:fs";
@@ -167,6 +172,122 @@ describe("ClaudeAdapter — Invalid API key stdout detection (issue #127)", () =
       expect(err).toBeInstanceOf(ClaudeAdapterError);
       if (err instanceof ClaudeAdapterError) {
         // Must NOT be misclassified as an auth failure.
+        expect(err.payload.reason).not.toBe("claude_cli_auth_failed");
+      }
+    },
+  );
+});
+
+// ---------- Issue #138: repair-retry path ----------
+
+/**
+ * Spawn spy that returns invalid JSON on the first call (triggers
+ * repair) and "Invalid API key" stdout on the second call (simulates
+ * auth failure during repair).
+ */
+function makeInvalidKeyOnRepairSpawn(): (
+  input: SpawnCliInput,
+) => Promise<SpawnCliResult> {
+  let callCount = 0;
+  return (_input: SpawnCliInput): Promise<SpawnCliResult> => {
+    callCount += 1;
+    if (callCount === 1) {
+      // First spawn: return malformed JSON to trigger repair retry.
+      return Promise.resolve({
+        ok: true,
+        exitCode: 0,
+        stdout: "not valid json {{{",
+        stderr: "",
+      });
+    }
+    // Repair spawn: auth failure.
+    return Promise.resolve({
+      ok: true,
+      exitCode: 0,
+      stdout: "Invalid API key · Fix external API key\n",
+      stderr: "",
+    });
+  };
+}
+
+describe("ClaudeAdapter — Invalid API key on repair-retry path (issue #138)", () => {
+  test(
+    "repair spawn with 'Invalid API key' stdout → " +
+      "reason=claude_cli_auth_failed, not schema_violation",
+    async () => {
+      const host = makeInstalledHost();
+      const adapter = new ClaudeAdapter({
+        host,
+        spawn: makeInvalidKeyOnRepairSpawn(),
+      });
+
+      let err: unknown;
+      try {
+        await adapter.ask({
+          prompt: "ping",
+          context: "",
+          opts: { effort: "max", timeout: 5_000 },
+        });
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toBeInstanceOf(ClaudeAdapterError);
+      if (err instanceof ClaudeAdapterError) {
+        expect(err.payload.reason).toBe("claude_cli_auth_failed");
+        expect(err.payload.reason).not.toBe("schema_violation");
+      }
+    },
+  );
+
+  test(
+    "spec-content JSON containing 'Invalid API key' as body text " +
+      "does not false-positive on the repair path",
+    async () => {
+      // Build a valid JSON payload whose body happens to contain the
+      // auth-error phrase — this guards the most plausible false-positive.
+      // ask() expects AskOutputSchema shape.
+      const bodyWithPhrase = JSON.stringify({
+        ready: false,
+        rationale: "Invalid API key is a common auth error message.",
+        spec_md: "# Test\n\nInvalid API key warning section.\n",
+      });
+      const host = makeInstalledHost();
+      let callCount = 0;
+      const safeSpawn = (_input: SpawnCliInput): Promise<SpawnCliResult> => {
+        callCount += 1;
+        if (callCount === 1) {
+          // First spawn: invalid JSON to force repair.
+          return Promise.resolve({
+            ok: true,
+            exitCode: 0,
+            stdout: "not valid json {{{",
+            stderr: "",
+          });
+        }
+        // Repair spawn: valid JSON whose body contains the phrase.
+        return Promise.resolve({
+          ok: true,
+          exitCode: 0,
+          stdout: bodyWithPhrase,
+          stderr: "",
+        });
+      };
+      const adapter = new ClaudeAdapter({ host, spawn: safeSpawn });
+
+      let err: unknown;
+      try {
+        await adapter.ask({
+          prompt: "ping",
+          context: "",
+          opts: { effort: "max", timeout: 5_000 },
+        });
+      } catch (e) {
+        err = e;
+      }
+
+      // Should throw (schema_violation or similar), but NOT auth failure.
+      if (err instanceof ClaudeAdapterError) {
         expect(err.payload.reason).not.toBe("claude_cli_auth_failed");
       }
     },

--- a/tests/cli/iterate-protected-branch.test.ts
+++ b/tests/cli/iterate-protected-branch.test.ts
@@ -1,0 +1,174 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #139: the protected-branch refusal in runIterate should use
+// the same wording as src/cli/new.ts — naming the "built-in default"
+// source and recommending `samospec/<slug>`.
+//
+// Before the fix, the iterate commit path emitted:
+//   "samospec: cannot commit on protected branch 'main'.
+//    Check out samospec/... and re-run."
+//
+// After the fix it must also contain "built-in default".
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type { Adapter, CritiqueOutput } from "../../src/adapter/types.ts";
+import { runIterate, type IterateResolvers } from "../../src/cli/iterate.ts";
+import { writeState } from "../../src/state/store.ts";
+import type { State } from "../../src/state/types.ts";
+
+const ACCEPT_RESOLVERS: IterateResolvers = {
+  onManualEdit: () => Promise.resolve("incorporate"),
+  onDegraded: () => Promise.resolve("accept"),
+  onReviewerExhausted: () => Promise.resolve("abort"),
+};
+
+const DEFAULT_TIME_INPUTS = {
+  sessionStartedAtMs: 0,
+  nowMs: 0,
+  maxWallClockMs: 60 * 60 * 1000,
+};
+
+const SAMPLE_CRITIQUE: CritiqueOutput = {
+  findings: [
+    {
+      category: "ambiguity",
+      text: "spec is ambiguous",
+      severity: "minor",
+    },
+  ],
+  summary: "one ambiguity",
+  suggested_next_version: "0.2",
+  usage: null,
+  effort_used: "max",
+};
+
+function initProtectedRepo(cwd: string): void {
+  spawnSync("git", ["init", "-q", "--initial-branch=main"], { cwd });
+  spawnSync("git", ["config", "user.email", "test@example.com"], { cwd });
+  spawnSync("git", ["config", "user.name", "Test"], { cwd });
+  spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd });
+  writeFileSync(path.join(cwd, "README.md"), "seed\n", "utf8");
+  spawnSync("git", ["add", "README.md"], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", "seed"], { cwd });
+}
+
+function seedSpec(cwd: string, slug: string): void {
+  const slugDir = path.join(cwd, ".samo", "spec", slug);
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(
+    path.join(slugDir, "SPEC.md"),
+    "# SPEC\n\ncontent v0.1\n",
+    "utf8",
+  );
+  writeFileSync(path.join(slugDir, "TLDR.md"), "# TLDR\n\n- old\n", "utf8");
+  writeFileSync(
+    path.join(slugDir, "decisions.md"),
+    "# decisions\n\n- No review-loop decisions yet.\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "changelog.md"),
+    "# changelog\n\n## v0.1 — seed\n\n- initial\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "interview.json"),
+    JSON.stringify({
+      slug,
+      persona: `Veteran "${slug}" expert`,
+      generated_at: "2026-04-19T12:00:00Z",
+      questions: [],
+      answers: [],
+    }),
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "context.json"),
+    JSON.stringify({
+      phase: "draft",
+      files: [],
+      risk_flags: [],
+      budget: { phase: "draft", tokens_used: 0, tokens_budget: 0 },
+    }),
+    "utf8",
+  );
+  const state: State = {
+    slug,
+    phase: "review_loop",
+    round_index: 0,
+    version: "0.1.0",
+    persona: { skill: slug, accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: "2026-04-19T12:00:00Z",
+    updated_at: "2026-04-19T12:00:00Z",
+  };
+  writeState(path.join(slugDir, "state.json"), state);
+  spawnSync("git", ["add", "."], { cwd });
+  spawnSync("git", ["commit", "-q", "-m", `spec(${slug}): draft v0.1`], {
+    cwd,
+  });
+}
+
+describe("cli/iterate — protected-branch refusal uses #126 wording (issue #139)", () => {
+  test(
+    "commit on built-in-protected branch 'main' → " +
+      "stderr contains 'built-in default' and 'samospec/'",
+    async () => {
+      const tmp = mkdtempSync(
+        path.join(tmpdir(), "samospec-iterate-protected-"),
+      );
+      try {
+        initProtectedRepo(tmp);
+        seedSpec(tmp, "myfeature");
+
+        const lead: Adapter = {
+          ...createFakeAdapter({
+            revise: {
+              spec: "# SPEC\n\ncontent v0.2\n",
+              ready: true,
+              rationale: JSON.stringify([
+                {
+                  finding_ref: "codex#1",
+                  decision: "accepted",
+                  rationale: "yes",
+                },
+              ]),
+              usage: null,
+              effort_used: "max",
+            },
+          }),
+        };
+        const revA = createFakeAdapter({ critique: SAMPLE_CRITIQUE });
+        const revB = createFakeAdapter({ critique: SAMPLE_CRITIQUE });
+
+        const res = await runIterate({
+          cwd: tmp,
+          slug: "myfeature",
+          now: "2026-04-19T12:00:00Z",
+          resolvers: ACCEPT_RESOLVERS,
+          adapters: { lead, reviewerA: revA, reviewerB: revB },
+          maxRounds: 1,
+          ...DEFAULT_TIME_INPUTS,
+        });
+
+        expect(res.exitCode).toBe(2);
+        expect(res.stderr).toContain("built-in default");
+        expect(res.stderr).toContain("samospec/");
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/tests/cli/iterate-verbose-flag.test.ts
+++ b/tests/cli/iterate-verbose-flag.test.ts
@@ -4,6 +4,9 @@
 // "unknown flag '--verbose'" because ITERATE_ALLOWED_FLAGS lacked
 // the entry. `samospec new` has --verbose; iterate is verbose by default
 // but should accept the flag as a no-op alias so muscle-memory works.
+//
+// Issue #137 — the --help block should also document --verbose so
+// users can discover it without reading the source.
 
 import { describe, expect, test } from "bun:test";
 
@@ -29,5 +32,19 @@ describe("iterate parser — --verbose accepted as no-op (#128)", () => {
     expect(res.stderr.toLowerCase()).not.toContain("unknown flag");
     expect(res.stderr.toLowerCase()).toContain("no spec found");
     expect(res.exitCode).toBe(1);
+  });
+});
+
+describe("iterate help — --verbose documented (#137)", () => {
+  test("help text contains '--verbose'", async () => {
+    const res = await runCli([]);
+    expect(res.stderr).toContain("--verbose");
+  });
+
+  test("help text contains alias description for iterate --verbose", async () => {
+    const res = await runCli([]);
+    expect(res.stderr).toContain(
+      "Alias / no-op — iterate is verbose by default",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- **#137** — `--verbose` added to `samospec iterate --help` block; the flag was accepted since v0.6.1 but not documented.
- **#138** — Claude adapter invalid-key detection now covers the repair-retry path (second spawn). Check fires only after JSON parsing fails so spec content containing the phrase cannot false-positive.
- **#139** — `samospec iterate` protected-branch refusal now uses the same wording as `src/cli/new.ts` (#126): names the "built-in default" source and recommends `samospec/<slug>`.
- **#140** — CHANGELOG entry for the codex `effort: "max"` → `xhigh` mapping change from PR #135.

Version bump to 0.6.2 via `bun run scripts/bump-version.ts 0.6.2`. README `0.6.1` → `0.6.2` reference updated.

## Test plan

- [ ] `bun run lint` — passes
- [ ] `bun run format:check` — passes
- [ ] `bun run typecheck` — passes
- [ ] `bun test` — 1481 pass, 0 fail (was 1476; +5 new tests)
- [ ] `tests/cli/iterate-verbose-flag.test.ts` — 2 new cases verify `--verbose` appears in help text
- [ ] `tests/adapter/claude-invalid-api-key.test.ts` — 2 new cases: repair-path auth detection + no-false-positive with spec JSON
- [ ] `tests/cli/iterate-protected-branch.test.ts` — new file: verify refusal stderr contains "built-in default" and "samospec/"

Closes #137.
Closes #138.
Closes #139.
Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)