### PR TITLE
refactor: extract formatProtectedBranchError helper (#142)

### DIFF
--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -38,7 +38,11 @@ import type { Adapter, Finding } from "../adapter/types.ts";
 import { currentBranch } from "../git/branch.ts";
 import { specCommit } from "../git/commit.ts";
 import { ProtectedBranchError } from "../git/errors.ts";
-import { HARDCODED_PROTECTED_BRANCHES, isProtected } from "../git/protected.ts";
+import {
+  formatProtectedBranchError,
+  isProtected,
+  protectedBranchSource,
+} from "../git/protected.ts";
 import {
   applyManualEdit,
   detectManualEdits,
@@ -1009,15 +1013,14 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
             }
           } catch (err) {
             if (err instanceof ProtectedBranchError) {
-              // Issue #139: match the wording from src/cli/new.ts —
-              // name the source and recommend samospec/<slug>.
-              const src = HARDCODED_PROTECTED_BRANCHES.includes(err.branchName)
-                ? "built-in default"
-                : "config";
+              // Issue #139 / #142: shared canonical post-#126 wording —
+              // names the source and recommends samospec/<slug>.
               error(
-                `samospec: refusing to commit on protected branch ` +
-                  `'${err.branchName}' (${src}). ` +
-                  `Check out samospec/${input.slug} and re-run.`,
+                formatProtectedBranchError(
+                  err.branchName,
+                  input.slug,
+                  protectedBranchSource(err.branchName),
+                ),
               );
               return {
                 exitCode: 2,

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -41,7 +41,10 @@ import {
 import { specCommit } from "../git/commit.ts";
 import { ensureHasCommit } from "../git/ensure-has-commit.ts";
 import { ProtectedBranchError, GitLayerUsageError } from "../git/errors.ts";
-import { HARDCODED_PROTECTED_BRANCHES } from "../git/protected.ts";
+import {
+  formatProtectedBranchError,
+  protectedBranchSource,
+} from "../git/protected.ts";
 import { writeCalibrationSample } from "../policy/calibration.ts";
 import {
   CONSENT_ABORT_EXIT_CODE,
@@ -433,9 +436,12 @@ export async function runNew(
     //     so legacy tests that don't initialize a git repo still run.
     let branchResult = createBranch(input);
     if (branchResult.kind === "protected") {
-      const source = HARDCODED_PROTECTED_BRANCHES.includes(branchResult.branch)
-        ? "built-in default"
-        : "config";
+      // Note: this is the 'refusing to branch' path (branch creation
+      // blocked). It has a different remedy than the 'refusing to
+      // commit' helper (formatProtectedBranchError) — we suggest
+      // `git checkout -b samospec/<slug>` because no feature branch
+      // exists yet. Source classification is shared.
+      const source = protectedBranchSource(branchResult.branch);
       errors.push(
         `samospec: refusing to branch on protected branch ` +
           `'${branchResult.branch}' (${source}). ` +
@@ -877,9 +883,14 @@ export async function runNew(
           state = { ...state, round_state: "lead_revised" };
           state.updated_at = input.now;
           writeState(statePath, state);
+          // Issue #142: use the canonical post-#126 refusal (source
+          // label + samospec/<slug> hint) via the shared helper.
           errors.push(
-            `samospec: refusing to commit on protected branch '${err.branchName}'. ` +
-              `Check out a feature branch and run \`samospec resume ${input.slug}\`.`,
+            formatProtectedBranchError(
+              err.branchName,
+              input.slug,
+              protectedBranchSource(err.branchName),
+            ),
           );
           return {
             exitCode: 2,

--- a/src/cli/resume.ts
+++ b/src/cli/resume.ts
@@ -28,6 +28,10 @@ import { discoverContext } from "../context/discover.ts";
 import { contextJsonPath, writeContextJson } from "../context/provenance.ts";
 import { specCommit } from "../git/commit.ts";
 import { ProtectedBranchError } from "../git/errors.ts";
+import {
+  formatProtectedBranchError,
+  protectedBranchSource,
+} from "../git/protected.ts";
 import { writeCalibrationSample } from "../policy/calibration.ts";
 import { injectArchitectureBlock } from "../render/architecture-spec.ts";
 import { renderTldr } from "../render/tldr.ts";
@@ -442,9 +446,14 @@ export async function runResume(
               updated_at: input.now,
             };
             writeState(paths.statePath, lr);
+            // Issue #142: use the shared canonical post-#126 refusal
+            // string (names source, recommends samospec/<slug>).
             errors.push(
-              `samospec: cannot commit v0.1 on protected branch '${err.branchName}'. ` +
-                `Check out samospec/${input.slug} and resume.`,
+              formatProtectedBranchError(
+                err.branchName,
+                input.slug,
+                protectedBranchSource(err.branchName),
+              ),
             );
             return {
               exitCode: 2,

--- a/src/git/protected.ts
+++ b/src/git/protected.ts
@@ -77,3 +77,51 @@ function readGitConfigBranchProtected(
   const value = (result.stdout ?? "").trim().toLowerCase();
   return value === "true" || value === "1" || value === "yes" || value === "on";
 }
+
+/**
+ * Source label used in the canonical protected-branch refusal string.
+ * Matches the vocabulary introduced by PR #132 (issue #126):
+ *   - `"built-in default"` when the branch is in
+ *     {@link HARDCODED_PROTECTED_BRANCHES}.
+ *   - `"config"` when the branch is only protected via user config
+ *     (`.samo/config.json → git.protected_branches`) or git's
+ *     `branch.<name>.protected` setting.
+ */
+export type ProtectedBranchSource = "built-in default" | "config";
+
+/**
+ * Returns the source label for a branch that is known to be protected.
+ *
+ * Call sites typically already know the branch is protected (they are
+ * formatting a refusal); this helper only classifies the source.
+ */
+export function protectedBranchSource(
+  branchName: string,
+): ProtectedBranchSource {
+  return HARDCODED_PROTECTED_BRANCHES.includes(branchName)
+    ? "built-in default"
+    : "config";
+}
+
+/**
+ * Formats the canonical post-#126 / #132 refusal string emitted when a
+ * `samospec` commit (from `new`, `iterate`, or `resume`) would otherwise
+ * land on a protected branch.
+ *
+ * Extracted per issue #142 to dedupe three call sites that were drifting
+ * on wording (pre-#126 bare form vs post-#126 sourced form).
+ *
+ * Shape: `samospec: refusing to commit on protected branch '<branch>'
+ * (<source>). Check out samospec/<slug> and re-run.`
+ */
+export function formatProtectedBranchError(
+  branch: string,
+  slug: string,
+  source: ProtectedBranchSource,
+): string {
+  return (
+    `samospec: refusing to commit on protected branch ` +
+    `'${branch}' (${source}). ` +
+    `Check out samospec/${slug} and re-run.`
+  );
+}

--- a/tests/git/format-protected-branch-error.test.ts
+++ b/tests/git/format-protected-branch-error.test.ts
@@ -13,7 +13,11 @@ import { formatProtectedBranchError } from "../../src/git/protected.ts";
 
 describe("formatProtectedBranchError — canonical post-#126 refusal string", () => {
   test("names the source and recommends the samospec/<slug> branch", () => {
-    const out = formatProtectedBranchError("main", "myfeature", "built-in default");
+    const out = formatProtectedBranchError(
+      "main",
+      "myfeature",
+      "built-in default",
+    );
     expect(out).toBe(
       "samospec: refusing to commit on protected branch 'main' " +
         "(built-in default). Check out samospec/myfeature and re-run.",
@@ -48,7 +52,11 @@ describe("formatProtectedBranchError — canonical post-#126 refusal string", ()
     // 'built-in default' + 'samospec/'. Guard that contract here so
     // any refactor that changes the wording fails this helper test
     // first, before tripping the e2e tests.
-    const out = formatProtectedBranchError("master", "demo", "built-in default");
+    const out = formatProtectedBranchError(
+      "master",
+      "demo",
+      "built-in default",
+    );
     expect(out).toContain("built-in default");
     expect(out).toContain("samospec/");
   });

--- a/tests/git/format-protected-branch-error.test.ts
+++ b/tests/git/format-protected-branch-error.test.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #142: unit tests for `formatProtectedBranchError(branch, slug, source)`.
+//
+// The helper produces the canonical post-#126 / #132 refusal string
+// emitted when `samospec iterate` / `samospec new` / `samospec resume`
+// would otherwise commit on a protected branch. All three call sites
+// share this exact wording.
+
+import { describe, expect, test } from "bun:test";
+
+import { formatProtectedBranchError } from "../../src/git/protected.ts";
+
+describe("formatProtectedBranchError — canonical post-#126 refusal string", () => {
+  test("names the source and recommends the samospec/<slug> branch", () => {
+    const out = formatProtectedBranchError("main", "myfeature", "built-in default");
+    expect(out).toBe(
+      "samospec: refusing to commit on protected branch 'main' " +
+        "(built-in default). Check out samospec/myfeature and re-run.",
+    );
+  });
+
+  test("accepts 'config' as the source label for user-configured protection", () => {
+    const out = formatProtectedBranchError("staging", "refunds", "config");
+    expect(out).toBe(
+      "samospec: refusing to commit on protected branch 'staging' " +
+        "(config). Check out samospec/refunds and re-run.",
+    );
+  });
+
+  test("interpolates slug literally (supports hyphens, digits, slashes)", () => {
+    const out = formatProtectedBranchError(
+      "trunk",
+      "checkout-flow-2",
+      "built-in default",
+    );
+    expect(out).toContain("samospec/checkout-flow-2");
+    expect(out).toContain("'trunk' (built-in default)");
+  });
+
+  test("includes the 'samospec:' prefix so it matches other samospec error lines", () => {
+    const out = formatProtectedBranchError("main", "x", "built-in default");
+    expect(out.startsWith("samospec: ")).toBe(true);
+  });
+
+  test("preserves the canonical ' (built-in default)' substring for test matchers", () => {
+    // The existing iterate / new e2e tests assert on the substring
+    // 'built-in default' + 'samospec/'. Guard that contract here so
+    // any refactor that changes the wording fails this helper test
+    // first, before tripping the e2e tests.
+    const out = formatProtectedBranchError("master", "demo", "built-in default");
+    expect(out).toContain("built-in default");
+    expect(out).toContain("samospec/");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up from REV review of PR #141. PR #139 updated the `iterate`
commit-refusal wording to match the post-#126 / #132 form (names the
protection source, recommends `samospec/<slug>`), but left two other
sites emitting pre-#126 bare wording. The template itself was now
duplicated across call sites.

This PR extracts a shared helper and dedupes the call sites.

### What changed

- `src/git/protected.ts` — new exports:
  - `formatProtectedBranchError(branch, slug, source)` — returns the
    canonical post-#126 refusal string.
  - `protectedBranchSource(branchName)` — classifies a protected
    branch as `"built-in default"` (hardcoded list) or `"config"`.
  - `ProtectedBranchSource` — the source label union.

### Sites deduped (3)

| File | Prior wording | After |
| --- | --- | --- |
| `src/cli/new.ts` (first-commit, ~L881) | pre-#126 bare: "Check out a feature branch and run `samospec resume …`." | canonical: names source + "Check out samospec/<slug> and re-run." |
| `src/cli/iterate.ts` (~L1015) | post-#126 (from #139) | identical string, now produced by the helper |
| `src/cli/resume.ts` (~L446) | pre-#126 bare with "v0.1" qualifier | canonical: names source + "Check out samospec/<slug> and re-run." |

The 'refusing to *branch*' path in `src/cli/new.ts` (~L440) keeps its
distinct remedy text (branch creation blocked — user has no feature
branch yet, so we suggest `git checkout -b samospec/<slug>`), but now
shares the `protectedBranchSource()` classifier instead of duplicating
the `HARDCODED_PROTECTED_BRANCHES.includes(…) ? … : …` ternary.

### Rationale

- Single source of truth for the refusal wording means future edits
  (e.g. adding a link to docs, tweaking punctuation) touch one place.
- The unit test on the helper (`tests/git/format-protected-branch-error.test.ts`)
  locks in the exact canonical string. Any drift fails the unit test
  before tripping the existing iterate / new e2e substring checks.
- Addresses the root cause of #139 (template duplication → drift).

## Test plan

- [x] RED commit: unit test asserting exact canonical string shape (fails — helper not yet exported).
- [x] GREEN commit: helper + 3 call-site migrations → 5 new unit tests pass.
- [x] `bun test` — 1486 pass, 0 fail (was 1481 on `main`; +5 new helper tests).
- [x] `bun run lint` — clean.
- [x] `bun run typecheck` — clean.
- [x] `bun run format:check` — clean.
- [x] Existing `tests/cli/iterate-protected-branch.test.ts` (PR #141) and `tests/cli/new.test.ts` protected-branch describe (PR #132) continue to pass — they assert the `"built-in default"` and `"samospec/"` substrings, both preserved by the helper.

Closes #142.