### PR TITLE
fix(iterate): wire push-consent into non-TTY refusal (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`samospec iterate` no longer crashes at the first-push consent
+  prompt in non-TTY contexts** (#136). Headless / CI / background-shell
+  runs that reached a round boundary in a fresh repo crashed with
+  `ERR_USE_AFTER_CLOSE` when the push-consent readline fired after
+  round 1. The prompt now participates in the #114 non-TTY safety net:
+  new `--push-consent <yes|no>` flag answers the prompt without
+  touching stdin, `--yes` on `iterate` implies `--push-consent yes`,
+  and non-TTY runs with neither flag (nor persisted consent) fail fast
+  BEFORE round 1 with a message naming the four escape hatches
+  (`--push-consent yes`, `--push-consent no`, `--yes`, `--no-push`).
+  TTY behavior is unchanged.
+
 ---
 
 ## [0.6.1] - 2026-04-23

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,10 @@
 // Copyright 2026 Nikolay Samokhvalov.
 
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import * as readline from "node:readline/promises";
+import path from "node:path";
 
 import { ClaudeAdapter } from "./adapter/claude.ts";
 import { ClaudeResolver } from "./adapter/claude-resolver.ts";
@@ -14,10 +17,14 @@ import {
   runIterate,
   type IterateResolvers,
   type ManualEditResolver,
+  type PushConsentResolver,
   type PushOptions,
   type SeatDiagnostics,
 } from "./cli/iterate.ts";
-import { describePrCapability } from "./git/push-consent.ts";
+import {
+  describePrCapability,
+  loadPersistedConsent,
+} from "./git/push-consent.ts";
 import { runNew, type ChoiceResolvers } from "./cli/new.ts";
 import {
   buildNonInteractiveResolvers,
@@ -131,6 +138,11 @@ const USAGE =
   "  --on-dirty <incorporate|overwrite|abort>\n" +
   "      Answer the uncommitted-edits prompt without reading stdin. Required\n" +
   "      when stdin is not a TTY and `.samo/spec/<slug>/` has dirty edits (#114).\n" +
+  "  --push-consent <yes|no>\n" +
+  "      Answer the first-push consent prompt without reading stdin. Required\n" +
+  "      when stdin is not a TTY and the remote has no persisted consent (#136).\n" +
+  "  --yes\n" +
+  "      Accept everything non-interactively; implies --push-consent yes.\n" +
   "\n" +
   "Options for `publish`:\n" +
   "  --no-lint\n" +
@@ -629,6 +641,19 @@ interface IterateArgs {
    * `.samo/spec/<slug>/` has dirty edits.
    */
   readonly onDirty?: ManualEditChoice;
+  /**
+   * #136: when set, `iterate` answers the first-push consent prompt
+   * without reading stdin. Required in non-TTY contexts where no
+   * persisted consent exists for the target remote URL. `--yes`
+   * implies `pushConsent: "yes"`.
+   */
+  readonly pushConsent?: "yes" | "no";
+  /**
+   * #136: broad "accept everything non-interactively". Currently
+   * implies `pushConsent: "yes"`; future automation flags may fold in
+   * here too (mirrors the `new` precedent).
+   */
+  readonly yes: boolean;
 }
 
 const ON_DIRTY_CHOICES: readonly ManualEditChoice[] = [
@@ -654,6 +679,25 @@ function parseOnDirty(raw: string): ParseOnDirtyResult {
   };
 }
 
+type ParsePushConsentResult =
+  | { readonly ok: true; readonly value: "yes" | "no" }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * #136 — parse `--push-consent <yes|no>`. Rejects anything else with a
+ * message that names the valid token set so users can self-correct.
+ */
+function parsePushConsent(raw: string): ParsePushConsentResult {
+  const norm = raw.trim().toLowerCase();
+  if (norm === "yes" || norm === "no") {
+    return { ok: true, value: norm };
+  }
+  return {
+    ok: false,
+    error: `samospec iterate: --push-consent must be yes|no (got '${raw}')`,
+  };
+}
+
 /**
  * Centralised allow-list of long flags recognised by `samospec iterate`
  * (Issue #91). Parser compares every `--…` token against this set and
@@ -671,6 +715,9 @@ const ITERATE_ALLOWED_FLAGS: ReadonlySet<string> = new Set([
   "--max-session-wall-clock-ms",
   // #114: non-TTY automation.
   "--on-dirty",
+  // #136: non-TTY automation for first-push consent.
+  "--push-consent",
+  "--yes",
 ]);
 
 function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
@@ -681,6 +728,8 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
   let quiet = false;
   let maxSessionWallClockMs: number | undefined;
   let onDirty: ManualEditChoice | undefined;
+  let pushConsent: "yes" | "no" | undefined;
+  let yes = false;
   for (let i = 0; i < argv.length; i += 1) {
     const t = argv[i];
     if (t === undefined) continue;
@@ -726,6 +775,28 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
       const parsed = parseOnDirty(raw);
       if (!parsed.ok) return parsed.error;
       onDirty = parsed.value;
+      continue;
+    }
+    // #136: --push-consent <yes|no>
+    if (t === "--push-consent") {
+      const raw = argv[i + 1] ?? "";
+      i += 1;
+      const parsed = parsePushConsent(raw);
+      if (!parsed.ok) return parsed.error;
+      pushConsent = parsed.value;
+      continue;
+    }
+    if (t.startsWith("--push-consent=")) {
+      const raw = t.slice("--push-consent=".length);
+      const parsed = parsePushConsent(raw);
+      if (!parsed.ok) return parsed.error;
+      pushConsent = parsed.value;
+      continue;
+    }
+    // #136: --yes on iterate implies push-consent=yes (matches the
+    // `new` precedent of --yes as "accept everything non-interactively").
+    if (t === "--yes") {
+      yes = true;
       continue;
     }
     if (t === "--remote") {
@@ -779,9 +850,11 @@ function parseIterateArgs(argv: readonly string[]): IterateArgs | string {
     noPush,
     remote,
     quiet,
+    yes,
     ...(rounds !== undefined ? { rounds } : {}),
     ...(maxSessionWallClockMs !== undefined ? { maxSessionWallClockMs } : {}),
     ...(onDirty !== undefined ? { onDirty } : {}),
+    ...(pushConsent !== undefined ? { pushConsent } : {}),
   };
 }
 
@@ -861,8 +934,59 @@ function buildManualEditResolver(
   };
 }
 
+/**
+ * #136 — build the push-consent resolver.
+ *
+ *   - `pushConsent` flag set (`yes` / `no`): return a resolver that
+ *     answers without any readline call, so `iterate` never touches
+ *     stdin for push consent.
+ *   - stdin is NOT a TTY and no flag set: return a resolver that
+ *     rejects with a clear error string. `runIterateCommand` preflights
+ *     the non-TTY + unresolved-consent case BEFORE round 1 to avoid
+ *     wasting a round on a run that would die at the round boundary;
+ *     this resolver is a defence-in-depth backstop for the unusual
+ *     case where the preflight missed (e.g., remote URL probe failed).
+ *   - default: the legacy interactive readline prompt.
+ */
+function buildPushConsentResolver(
+  rl: readline.Interface,
+  pushConsent: "yes" | "no" | undefined,
+): PushConsentResolver {
+  if (pushConsent === "yes") return () => Promise.resolve("accept");
+  if (pushConsent === "no") return () => Promise.resolve("refuse");
+  const stdinIsTty = process.stdin.isTTY === true;
+  if (!stdinIsTty) {
+    return () =>
+      Promise.reject(
+        new Error(
+          "samospec iterate: push consent is required and stdin is not a TTY. " +
+            "Pass one of --push-consent yes, --push-consent no, --yes, or --no-push " +
+            "to run non-interactively.",
+        ),
+      );
+  }
+  return async (payload) => {
+    process.stdout.write(`\nFirst push in this repo — consent required.\n`);
+    process.stdout.write(`  remote: ${payload.remoteName}\n`);
+    process.stdout.write(`  remote URL: ${payload.remoteUrl}\n`);
+    process.stdout.write(`  branch: ${payload.targetBranch}\n`);
+    process.stdout.write(`  default branch: ${payload.defaultBranch}\n`);
+    process.stdout.write(`  ${describePrCapability(payload.prCapability)}\n`);
+    const ans = (
+      await rl.question(
+        "[A]ccept (persist) / [R]efuse (persist) [Enter=refuse]: ",
+      )
+    )
+      .trim()
+      .toLowerCase();
+    if (ans === "a" || ans === "accept") return "accept";
+    return "refuse";
+  };
+}
+
 function interactiveIterateResolvers(
   onDirty: ManualEditChoice | undefined,
+  pushConsent: "yes" | "no" | undefined,
 ): IterateResolvers {
   const rl = readline.createInterface({
     input: process.stdin,
@@ -906,30 +1030,101 @@ function interactiveIterateResolvers(
       if (ans === "c" || ans === "continue") return "continue";
       return "abort";
     },
-    onPushConsent: async (payload) => {
-      process.stdout.write(`\nFirst push in this repo — consent required.\n`);
-      process.stdout.write(`  remote: ${payload.remoteName}\n`);
-      process.stdout.write(`  remote URL: ${payload.remoteUrl}\n`);
-      process.stdout.write(`  branch: ${payload.targetBranch}\n`);
-      process.stdout.write(`  default branch: ${payload.defaultBranch}\n`);
-      process.stdout.write(`  ${describePrCapability(payload.prCapability)}\n`);
-      const ans = (
-        await rl.question(
-          "[A]ccept (persist) / [R]efuse (persist) [Enter=refuse]: ",
-        )
-      )
-        .trim()
-        .toLowerCase();
-      if (ans === "a" || ans === "accept") return "accept";
-      return "refuse";
-    },
+    onPushConsent: buildPushConsentResolver(rl, pushConsent),
   };
+}
+
+/**
+ * #136 — resolve the effective push-consent flag, folding `--yes` in.
+ * `--yes` implies `--push-consent yes` UNLESS `--push-consent no` was
+ * explicitly set (explicit flag wins, matches `new` precedent where
+ * explicit values beat broad `--yes`).
+ */
+function effectivePushConsent(parsed: IterateArgs): "yes" | "no" | undefined {
+  if (parsed.pushConsent !== undefined) return parsed.pushConsent;
+  if (parsed.yes) return "yes";
+  return undefined;
+}
+
+/**
+ * #136 — preflight refusal for the first-push consent prompt.
+ *
+ * When stdin is not a TTY, pushOptions would fire (i.e., `--no-push` is
+ * NOT set), no automation flag is supplied, and there is no persisted
+ * consent for the target remote URL, round 1 would complete and then
+ * crash at the round-boundary readline prompt with ERR_USE_AFTER_CLOSE.
+ * Fail fast BEFORE round 1 starts so the user doesn't waste a round.
+ *
+ * Returns the error string on refusal, or `null` when the run may
+ * proceed.
+ */
+function preflightPushConsent(cwd: string, parsed: IterateArgs): string | null {
+  if (parsed.noPush) return null;
+  if (effectivePushConsent(parsed) !== undefined) return null;
+  if (process.stdin.isTTY === true) return null;
+
+  // If the spec doesn't exist, let `runIterate` surface its own
+  // "no spec found" error — don't preempt it with a push-consent
+  // message that would mislead the user.
+  const statePath = path.join(cwd, ".samo", "spec", parsed.slug, "state.json");
+  if (!existsSync(statePath)) return null;
+
+  const remoteUrl = resolveRemoteUrlForPreflight(cwd, parsed.remote);
+  if (remoteUrl === null) {
+    // No remote configured — the push path treats this as a silent
+    // local-only run (see handleRoundBoundaryPush). No refusal needed.
+    return null;
+  }
+
+  let persisted: boolean | null;
+  try {
+    persisted = loadPersistedConsent({ repoPath: cwd, remoteUrl });
+  } catch {
+    // Corrupt config.json — let the push layer surface its own error
+    // during the actual push flow. Don't double-report here.
+    return null;
+  }
+  if (persisted !== null) return null; // already decided — no prompt needed.
+
+  return (
+    "samospec iterate: push consent is required on first push and stdin " +
+    "is not a TTY. Pass one of:\n" +
+    `\n    samospec iterate ${parsed.slug} --push-consent yes\n` +
+    `    samospec iterate ${parsed.slug} --push-consent no\n` +
+    `    samospec iterate ${parsed.slug} --yes\n` +
+    `    samospec iterate ${parsed.slug} --no-push`
+  );
+}
+
+/**
+ * Return the origin remote URL for the preflight, or `null` when no
+ * such remote is configured. Kept preflight-local (not reusing
+ * iterate.ts's copy) because cli.ts is not supposed to depend on
+ * iterate internals.
+ */
+function resolveRemoteUrlForPreflight(
+  cwd: string,
+  remoteName: string,
+): string | null {
+  const res = spawnSync("git", ["remote", "get-url", remoteName], {
+    cwd,
+    encoding: "utf8",
+  });
+  if ((res.status ?? 1) !== 0) return null;
+  const url = (res.stdout ?? "").trim();
+  return url.length > 0 ? url : null;
 }
 
 async function runIterateCommand(rest: readonly string[]) {
   const parsed = parseIterateArgs(rest);
   if (typeof parsed === "string") {
     return { exitCode: 1, stdout: "", stderr: `${parsed}\n\n${USAGE}` };
+  }
+  // #136: fail-fast refusal BEFORE round 1 starts when push consent
+  // would be needed mid-loop and we can't prompt for it.
+  const refusal = preflightPushConsent(process.cwd(), parsed);
+  if (refusal !== null) {
+    return { exitCode: 1, stdout: "", stderr: `${refusal}\n` };
   }
   const adapters = buildReviewLoopAdapters();
   const pushOptions: PushOptions = {
@@ -941,7 +1136,10 @@ async function runIterateCommand(rest: readonly string[]) {
       cwd: process.cwd(),
       slug: parsed.slug,
       now: new Date().toISOString(),
-      resolvers: interactiveIterateResolvers(parsed.onDirty),
+      resolvers: interactiveIterateResolvers(
+        parsed.onDirty,
+        effectivePushConsent(parsed),
+      ),
       adapters,
       pushOptions,
       quiet: parsed.quiet,
@@ -959,8 +1157,9 @@ async function runIterateCommand(rest: readonly string[]) {
     // #114: the non-TTY manual-edit resolver rejects with an Error so
     // iterate exits cleanly instead of readline-deadlocking. Translate
     // the rejection to an exit-1 CliResult with the actionable message.
+    // #136: same translation for the push-consent backstop resolver.
     const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("--on-dirty")) {
+    if (msg.includes("--on-dirty") || msg.includes("--push-consent")) {
       return { exitCode: 1, stdout: "", stderr: `${msg}\n` };
     }
     throw err;

--- a/tests/cli/iterate-push-consent-non-tty.test.ts
+++ b/tests/cli/iterate-push-consent-non-tty.test.ts
@@ -41,6 +41,12 @@ beforeEach(() => {
     path.join(tmpdir(), "samospec-iterate-pushconsent-bin-"),
   );
 
+  // Adapter stubs that sleep on any non-version call. The "no refusal"
+  // assertions below rely on spawnSync timing out after a few seconds —
+  // by then, argv parsing and any preflight refusal have already run,
+  // so stderr is stable. `exit 1` stubs would otherwise push iterate
+  // into the `reviewer exhausted` path which has its own readline
+  // prompt unrelated to push-consent (out of scope for #136).
   const stubBody =
     '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then ' +
     "echo '0.0.0'; exit 0; fi\nsleep 60\n";
@@ -138,7 +144,10 @@ afterEach(() => {
   rmSync(fakeBin, { recursive: true, force: true });
 });
 
-function runCli(args: readonly string[]): {
+function runCli(
+  args: readonly string[],
+  opts: { timeoutMs?: number } = {},
+): {
   stdout: string;
   stderr: string;
   status: number;
@@ -158,7 +167,7 @@ function runCli(args: readonly string[]): {
     encoding: "utf8",
     env,
     stdio: [devNull, "pipe", "pipe"],
-    timeout: 15_000,
+    timeout: opts.timeoutMs ?? 15_000,
   });
   return {
     stdout: r.stdout ?? "",
@@ -183,19 +192,20 @@ describe("samospec iterate --push-consent (#136)", () => {
     expect(res.stderr.toLowerCase()).toMatch(/--push-consent|--yes|--no-push/);
   });
 
-  test("non-TTY + --no-push -> no refusal (already covered by #114 surface)", () => {
-    // With --no-push, there's no first-push consent to collect, so the
-    // new refusal must NOT fire. We still exit early because the fake
-    // adapter stubs are stubbed out; this test only asserts the
-    // refusal message is absent, i.e., the guard is not over-eager.
-    const res = runCli(["iterate", "demo", "--rounds", "1", "--no-push"]);
+  test("non-TTY + --no-push -> no refusal (guard must not over-fire)", () => {
+    // With --no-push, there's no first-push consent to collect, so
+    // the new refusal must NOT fire. The run proceeds into the loop
+    // where stubs sleep; spawnSync timeout fires at 3s. By then any
+    // refusal text would already be on stderr.
+    const res = runCli(["iterate", "demo", "--rounds", "1", "--no-push"], {
+      timeoutMs: 3_000,
+    });
     expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
-    // Must not surface the push-consent refusal since --no-push is set.
     const mentionsPushConsentRefusal = res.stderr
       .toLowerCase()
       .includes("push consent is required");
     expect(mentionsPushConsentRefusal).toBe(false);
-  });
+  }, 10_000);
 
   test("invalid --push-consent value -> exit 1 with validation error (before any work)", () => {
     const res = runCli([
@@ -216,18 +226,13 @@ describe("samospec iterate --push-consent (#136)", () => {
   });
 
   test("--push-consent yes is a known flag (not rejected by allowlist)", () => {
-    const res = runCli([
-      "iterate",
-      "demo",
-      "--rounds",
-      "1",
-      "--push-consent",
-      "yes",
-    ]);
-    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
-    // Parser must NOT reject `--push-consent` as unknown — we go past
-    // arg parsing and hit the adapter stub (test times out, stderr
-    // does not contain the allowlist rejection).
+    const res = runCli(
+      ["iterate", "demo", "--rounds", "1", "--push-consent", "yes"],
+      { timeoutMs: 3_000 },
+    );
+    // Parser must NOT reject `--push-consent` as unknown — we go
+    // past arg parsing and hit the adapter stub, which sleeps until
+    // spawnSync's 3s timeout kills the child.
     expect(res.stderr.toLowerCase()).not.toContain(
       "unknown flag '--push-consent'",
     );
@@ -235,18 +240,13 @@ describe("samospec iterate --push-consent (#136)", () => {
       .toLowerCase()
       .includes("push consent is required");
     expect(mentionsPushConsentRefusal).toBe(false);
-  });
+  }, 10_000);
 
   test("--push-consent no is a known flag (not rejected by allowlist)", () => {
-    const res = runCli([
-      "iterate",
-      "demo",
-      "--rounds",
-      "1",
-      "--push-consent",
-      "no",
-    ]);
-    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    const res = runCli(
+      ["iterate", "demo", "--rounds", "1", "--push-consent", "no"],
+      { timeoutMs: 3_000 },
+    );
     expect(res.stderr.toLowerCase()).not.toContain(
       "unknown flag '--push-consent'",
     );
@@ -254,17 +254,18 @@ describe("samospec iterate --push-consent (#136)", () => {
       .toLowerCase()
       .includes("push consent is required");
     expect(mentionsPushConsentRefusal).toBe(false);
-  });
+  }, 10_000);
 
   test("--yes is a known flag on iterate (not rejected by allowlist)", () => {
-    const res = runCli(["iterate", "demo", "--rounds", "1", "--yes"]);
-    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    const res = runCli(["iterate", "demo", "--rounds", "1", "--yes"], {
+      timeoutMs: 3_000,
+    });
     expect(res.stderr.toLowerCase()).not.toContain("unknown flag '--yes'");
     const mentionsPushConsentRefusal = res.stderr
       .toLowerCase()
       .includes("push consent is required");
     expect(mentionsPushConsentRefusal).toBe(false);
-  });
+  }, 10_000);
 
   test("non-TTY + persisted consent (yes) -> no refusal (already decided)", () => {
     // Pre-persist consent=true so the resolver would silently
@@ -280,11 +281,12 @@ describe("samospec iterate --push-consent (#136)", () => {
       JSON.stringify(cfg, null, 2) + "\n",
       "utf8",
     );
-    const res = runCli(["iterate", "demo", "--rounds", "1"]);
-    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    const res = runCli(["iterate", "demo", "--rounds", "1"], {
+      timeoutMs: 3_000,
+    });
     const mentionsPushConsentRefusal = res.stderr
       .toLowerCase()
       .includes("push consent is required");
     expect(mentionsPushConsentRefusal).toBe(false);
-  });
+  }, 10_000);
 });

--- a/tests/cli/iterate-push-consent-non-tty.test.ts
+++ b/tests/cli/iterate-push-consent-non-tty.test.ts
@@ -1,0 +1,290 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Issue #136 — `samospec iterate --push-consent <yes|no>` (and `--yes`
+// which implies `--push-consent yes`) wires the first-push consent
+// prompt into the non-TTY safety net introduced in #114.
+//
+// Without the flag and with stdin not a TTY, iterate must fail-fast
+// BEFORE round 1 starts with an actionable error — never readline-
+// deadlock at the end of round 1 with ERR_USE_AFTER_CLOSE.
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { writeState } from "../../src/state/store.ts";
+import type { State } from "../../src/state/types.ts";
+
+const CLI_PATH = path.resolve(import.meta.dir, "..", "..", "src", "main.ts");
+
+let tmp: string;
+let bare: string;
+let fakeHome: string;
+let fakeBin: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-iterate-pushconsent-"));
+  bare = mkdtempSync(path.join(tmpdir(), "samospec-iterate-pushconsent-bare-"));
+  fakeHome = mkdtempSync(
+    path.join(tmpdir(), "samospec-iterate-pushconsent-home-"),
+  );
+  fakeBin = mkdtempSync(
+    path.join(tmpdir(), "samospec-iterate-pushconsent-bin-"),
+  );
+
+  const stubBody =
+    '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then ' +
+    "echo '0.0.0'; exit 0; fi\nsleep 60\n";
+  for (const name of ["claude", "codex"]) {
+    const p = path.join(fakeBin, name);
+    writeFileSync(p, stubBody);
+    chmodSync(p, 0o755);
+  }
+
+  // Bare remote so push attempts have somewhere to land (not exercised
+  // in the fast-refusal tests, but needed so the preflight check sees
+  // a configured remote URL).
+  spawnSync("git", ["init", "--bare", "-q", "--initial-branch", "main"], {
+    cwd: bare,
+  });
+
+  // Real git repo with a samospec/<slug> branch + origin pointed at bare.
+  spawnSync("git", ["init", "-q", "--initial-branch", "main"], { cwd: tmp });
+  spawnSync("git", ["config", "user.email", "t@example.invalid"], { cwd: tmp });
+  spawnSync("git", ["config", "user.name", "t"], { cwd: tmp });
+  spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: tmp });
+  writeFileSync(path.join(tmp, "README.md"), "seed\n");
+  spawnSync("git", ["add", "README.md"], { cwd: tmp });
+  spawnSync("git", ["commit", "-q", "-m", "seed"], { cwd: tmp });
+  spawnSync("git", ["remote", "add", "origin", bare], { cwd: tmp });
+  spawnSync("git", ["checkout", "-q", "-b", "samospec/demo"], { cwd: tmp });
+
+  // Seed a complete .samo/spec/demo/ — clean (no dirty edits, so the
+  // #114 on-dirty path does NOT fire).
+  const slugDir = path.join(tmp, ".samo", "spec", "demo");
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(
+    path.join(slugDir, "SPEC.md"),
+    "# SPEC\n\ncontent v0.1\n",
+    "utf8",
+  );
+  writeFileSync(path.join(slugDir, "TLDR.md"), "# TLDR\n\n- old\n", "utf8");
+  writeFileSync(
+    path.join(slugDir, "decisions.md"),
+    "# decisions\n\n- none.\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "changelog.md"),
+    "# changelog\n\n## v0.1 — seed\n\n- initial\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "interview.json"),
+    JSON.stringify({
+      slug: "demo",
+      persona: 'Veteran "demo" expert',
+      generated_at: "2026-04-19T12:00:00Z",
+      questions: [],
+      answers: [],
+    }),
+    "utf8",
+  );
+  writeFileSync(
+    path.join(slugDir, "context.json"),
+    JSON.stringify({
+      phase: "draft",
+      files: [],
+      risk_flags: [],
+      budget: { phase: "draft", tokens_used: 0, tokens_budget: 0 },
+    }),
+    "utf8",
+  );
+  const state: State = {
+    slug: "demo",
+    phase: "review_loop",
+    round_index: 0,
+    version: "0.1.0",
+    persona: { skill: "demo", accepted: true },
+    push_consent: null,
+    calibration: null,
+    remote_stale: false,
+    coupled_fallback: false,
+    head_sha: null,
+    round_state: "committed",
+    exit: null,
+    created_at: "2026-04-19T12:00:00Z",
+    updated_at: "2026-04-19T12:00:00Z",
+  };
+  writeState(path.join(slugDir, "state.json"), state);
+  spawnSync("git", ["add", "."], { cwd: tmp });
+  spawnSync("git", ["commit", "-q", "-m", "spec(demo): draft v0.1"], {
+    cwd: tmp,
+  });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  rmSync(bare, { recursive: true, force: true });
+  rmSync(fakeHome, { recursive: true, force: true });
+  rmSync(fakeBin, { recursive: true, force: true });
+});
+
+function runCli(args: readonly string[]): {
+  stdout: string;
+  stderr: string;
+  status: number;
+  elapsedMs: number;
+} {
+  const bun = Bun.argv[0];
+  const env: Record<string, string> = {
+    PATH: `${fakeBin}:/usr/bin:/bin:/usr/local/bin`,
+    HOME: fakeHome,
+    NO_COLOR: "1",
+    ANTHROPIC_API_KEY: "sk-fake-test-key",
+  };
+  const devNull = openSync("/dev/null", "r");
+  const started = Date.now();
+  const r = spawnSync(bun, ["run", CLI_PATH, ...(args as string[])], {
+    cwd: tmp,
+    encoding: "utf8",
+    env,
+    stdio: [devNull, "pipe", "pipe"],
+    timeout: 15_000,
+  });
+  return {
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? "",
+    status: r.status ?? 1,
+    elapsedMs: Date.now() - started,
+  };
+}
+
+describe("samospec iterate --push-consent (#136)", () => {
+  test("non-TTY + no flag + no --no-push -> fast exit 1 BEFORE round 1 with actionable message", () => {
+    const res = runCli(["iterate", "demo", "--rounds", "1"]);
+    // Must fail fast — well under the stubbed adapter's 60s sleep. The
+    // refusal fires before any adapter spawn.
+    expect(res.elapsedMs).toBeLessThan(5_000);
+    expect(res.status).not.toBe(0);
+    // Must not readline-deadlock / crash with ERR_USE_AFTER_CLOSE.
+    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    expect(res.stderr).not.toContain("readline");
+    // Error names the offending concept + at least one fix.
+    expect(res.stderr.toLowerCase()).toContain("push-consent");
+    expect(res.stderr.toLowerCase()).toMatch(/--push-consent|--yes|--no-push/);
+  });
+
+  test("non-TTY + --no-push -> no refusal (already covered by #114 surface)", () => {
+    // With --no-push, there's no first-push consent to collect, so the
+    // new refusal must NOT fire. We still exit early because the fake
+    // adapter stubs are stubbed out; this test only asserts the
+    // refusal message is absent, i.e., the guard is not over-eager.
+    const res = runCli(["iterate", "demo", "--rounds", "1", "--no-push"]);
+    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    // Must not surface the push-consent refusal since --no-push is set.
+    const mentionsPushConsentRefusal = res.stderr
+      .toLowerCase()
+      .includes("push consent is required");
+    expect(mentionsPushConsentRefusal).toBe(false);
+  });
+
+  test("invalid --push-consent value -> exit 1 with validation error (before any work)", () => {
+    const res = runCli([
+      "iterate",
+      "demo",
+      "--rounds",
+      "1",
+      "--push-consent",
+      "maybe",
+    ]);
+    expect(res.elapsedMs).toBeLessThan(5_000);
+    expect(res.status).toBe(1);
+    // The validator's own error (NOT the allowlist "unknown flag" message)
+    // — must name the valid values yes/no.
+    expect(res.stderr.toLowerCase()).toContain("--push-consent");
+    expect(res.stderr.toLowerCase()).toContain("yes|no");
+    expect(res.stderr.toLowerCase()).not.toContain("unknown flag");
+  });
+
+  test("--push-consent yes is a known flag (not rejected by allowlist)", () => {
+    const res = runCli([
+      "iterate",
+      "demo",
+      "--rounds",
+      "1",
+      "--push-consent",
+      "yes",
+    ]);
+    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    // Parser must NOT reject `--push-consent` as unknown — we go past
+    // arg parsing and hit the adapter stub (test times out, stderr
+    // does not contain the allowlist rejection).
+    expect(res.stderr.toLowerCase()).not.toContain(
+      "unknown flag '--push-consent'",
+    );
+    const mentionsPushConsentRefusal = res.stderr
+      .toLowerCase()
+      .includes("push consent is required");
+    expect(mentionsPushConsentRefusal).toBe(false);
+  });
+
+  test("--push-consent no is a known flag (not rejected by allowlist)", () => {
+    const res = runCli([
+      "iterate",
+      "demo",
+      "--rounds",
+      "1",
+      "--push-consent",
+      "no",
+    ]);
+    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    expect(res.stderr.toLowerCase()).not.toContain(
+      "unknown flag '--push-consent'",
+    );
+    const mentionsPushConsentRefusal = res.stderr
+      .toLowerCase()
+      .includes("push consent is required");
+    expect(mentionsPushConsentRefusal).toBe(false);
+  });
+
+  test("--yes is a known flag on iterate (not rejected by allowlist)", () => {
+    const res = runCli(["iterate", "demo", "--rounds", "1", "--yes"]);
+    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    expect(res.stderr.toLowerCase()).not.toContain("unknown flag '--yes'");
+    const mentionsPushConsentRefusal = res.stderr
+      .toLowerCase()
+      .includes("push consent is required");
+    expect(mentionsPushConsentRefusal).toBe(false);
+  });
+
+  test("non-TTY + persisted consent (yes) -> no refusal (already decided)", () => {
+    // Pre-persist consent=true so the resolver would silently
+    // short-circuit at the push-consent layer. The CLI preflight
+    // SHOULD honor this and not refuse.
+    const cfg = {
+      schema_version: 1,
+      git: { push_consent: { [bare]: true } },
+    };
+    mkdirSync(path.join(tmp, ".samo"), { recursive: true });
+    writeFileSync(
+      path.join(tmp, ".samo", "config.json"),
+      JSON.stringify(cfg, null, 2) + "\n",
+      "utf8",
+    );
+    const res = runCli(["iterate", "demo", "--rounds", "1"]);
+    expect(res.stderr).not.toContain("ERR_USE_AFTER_CLOSE");
+    const mentionsPushConsentRefusal = res.stderr
+      .toLowerCase()
+      .includes("push consent is required");
+    expect(mentionsPushConsentRefusal).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`samospec iterate` running in non-TTY (background shell, CI, piped stdin) crashes with `ERR_USE_AFTER_CLOSE` when it hits the first-push consent readline at the end of round 1 in a fresh repo. Same bug class as the persona / uncommitted-edits prompts solved in #114, but the push-consent prompt wasn't wired into the non-TTY safety net.

This PR wires it in, mirroring the #114 flag-shape convention.

Fixes #136.

## Design

- New `--push-consent <yes|no>` flag on `iterate` answers the prompt without stdin (explicit; matches `--on-dirty`).
- `--yes` on `iterate` implies `--push-consent yes` (matches the `new` precedent where `--yes` is a broad "accept everything" opt-in).
- Non-TTY + pushing + no flag + no persisted consent: fail-fast **BEFORE round 1 starts** with a message naming all four escape hatches (`--push-consent yes`, `--push-consent no`, `--yes`, `--no-push`). Users don't waste a round on a run that would die at the boundary.
- TTY behavior unchanged — the existing readline prompt still fires.
- Preflight refusal skips when `.samo/spec/<slug>/state.json` is missing so `runIterate` can surface its own `"no spec found"` error first instead of being preempted by a misleading push-consent message.
- `buildPushConsentResolver` keeps a non-TTY `Promise.reject` backstop for the edge case where preflight missed (e.g., remote-URL probe transiently failed) — defence-in-depth against the original crash.

## Flag shape precedents matched

| Prompt                         | Flag (non-TTY)                          | Introduced |
| ------------------------------ | --------------------------------------- | ---------- |
| Persona acceptance             | `--yes` / `--accept-persona`            | #114       |
| Interview 5Q                   | `--answers-file <path>` / `--yes` fallback | #114    |
| Uncommitted edits              | `--on-dirty <incorporate\|overwrite\|abort>` | #114  |
| **First-push consent (this PR)** | **`--push-consent <yes\|no>` / `--yes`** | **#136** |

## Back-compat

- TTY runs unchanged (readline prompt wording, persistence behavior, `.samo/config.json` schema all untouched).
- No behavior change for runs with persisted consent (`--push-consent` not needed; the consent layer short-circuits like before).
- Existing `--no-push` remains the broadest escape hatch and suppresses the new preflight refusal.
- New flags are additive to `ITERATE_ALLOWED_FLAGS`; unknown-flag rejection behavior preserved.

## Test plan

- [x] `tests/cli/iterate-push-consent-non-tty.test.ts` (7 cases):
  - non-TTY + no flag + no `--no-push`: exit 1 fast (< 5s), stderr names `push-consent` + one fix, no `ERR_USE_AFTER_CLOSE`
  - non-TTY + `--no-push`: no refusal (guard doesn't over-fire)
  - invalid `--push-consent bogus`: exit 1 with `yes|no` validator hint, not rejected as unknown flag
  - `--push-consent yes` / `--push-consent no` / `--yes`: known flags, pass argv parsing
  - non-TTY + persisted consent (yes): no refusal (preflight honors on-disk decision)
- [x] Existing `tests/loop/push-round-boundary.test.ts` still green (the programmatic `onPushConsent` resolver path is untouched).
- [x] Existing `tests/cli/iterate-on-dirty.test.ts` still green (no regression on #114 surface).
- [x] Full suite: **1488 pass, 0 fail**.
- [x] `bun run lint`, `bun run typecheck`, `bun run format:check` all clean.

## Changelog

Added an `Unreleased` entry pending the next patch bump.