### PR TITLE
fix(interview): focus on project substance, cap tech-stack at 1

### DIFF
--- a/src/cli/interview.ts
+++ b/src/cli/interview.ts
@@ -184,27 +184,49 @@ function buildInterviewPrompt(input: {
       "jargon in prose fields. (Non-technical ICP.)\n\n"
     : "";
 
-  const langGuardrail =
+  // Tech-stack guardrail (#NEW-INTERVIEW): the interview is about
+  // PROJECT SUBSTANCE, not implementation tech. At most ONE question
+  // total may concern the tech stack (language, database, framework,
+  // hosting, etc.). When the brief already names a language, do not
+  // re-open it. When it doesn't, you MAY ask one language question —
+  // but only if it is genuinely strategic for this brief; otherwise
+  // skip it and let the spec/engine choose later.
+  const stackGuardrail =
     input.idea !== undefined
       ? ideaHasOpenLanguage(input.idea)
-        ? "Language guardrail: the brief does not specify a language (or " +
-          "says the language is open/flexible/any). Your FIRST question " +
-          "MUST be about language choice. Downstream questions must not " +
-          "presuppose any specific language.\n\n"
-        : "Language guardrail: the brief has already specified a language. " +
-          "Anchor your questions on that specified language choice; do not " +
-          "re-open it unless the user's brief explicitly invites it.\n\n"
-      : "";
+        ? "Tech-stack guardrail: the brief does not name a language. You " +
+          "MAY include AT MOST ONE tech-stack question total (covering " +
+          "language, database, framework, hosting, or similar) — and only " +
+          "if it is genuinely strategic for this brief. Prefer skipping it " +
+          "entirely; the spec/engine can choose downstream. Downstream " +
+          "questions must not presuppose any specific language.\n\n"
+        : "Tech-stack guardrail: the brief already names a language. Do " +
+          "NOT re-open language choice. Across all questions, include AT " +
+          "MOST ONE tech-stack question (language, database, framework, " +
+          "hosting, or similar) — and only if it is genuinely strategic " +
+          "for this brief.\n\n"
+      : "Tech-stack guardrail: include AT MOST ONE tech-stack question " +
+        "(language, database, framework, hosting, or similar) across all " +
+        "questions, and only if it is genuinely strategic for this " +
+        "brief.\n\n";
 
   return (
     explainPreamble +
-    langGuardrail +
+    stackGuardrail +
     `You are the samospec lead, playing the persona: ${input.persona}. ` +
     "Propose up to FIVE (5) high-signal strategic questions that the " +
     "user must answer to produce a v0.1 spec. Fewer is fine; more than 5 " +
-    "will be truncated by the tool. Each question has an `id` (slug), " +
-    "`text` (one sentence), and `options` (2-6 concrete choices the " +
-    "persona thinks are the most likely answers).\n\n" +
+    "will be truncated by the tool.\n\n" +
+    "Focus on PROJECT SUBSTANCE — questions a product owner cares about, " +
+    "not implementation choices. Cover topics like: who the target users " +
+    "are, what jobs they need done, the most important features for v0.1, " +
+    "what success looks like, key edge cases or failure modes, " +
+    "constraints (budget, timeline, compliance), and what's explicitly " +
+    "out of scope. Avoid tech-stack questions beyond the one allowed by " +
+    "the guardrail above.\n\n" +
+    "Each question has an `id` (slug), `text` (one sentence), and " +
+    "`options` (2-6 concrete choices the persona thinks are the most " +
+    "likely answers).\n\n" +
     "Respond ONLY with a JSON object:\n" +
     '  { "questions": [ { "id": "...", "text": "...", "options": ' +
     '["...", "..."] }, ... ] }\n' +

--- a/tests/cli/interview.test.ts
+++ b/tests/cli/interview.test.ts
@@ -327,7 +327,16 @@ describe("runInterview — persona + explain wiring (SPEC §7)", () => {
     );
   });
 
-  test("idea with open language -> prompt includes language-first guardrail", async () => {
+  // ---------- project-substance + ≤1 tech-stack guardrail (#NEW-INTERVIEW)
+  //
+  // The interview is for product-owner-shaped questions: target users,
+  // jobs-to-be-done, v0.1 features, success criteria, edge cases,
+  // constraints, out-of-scope. Tech-stack questions (language, DB,
+  // framework, hosting) are capped at ONE total. The previous "language
+  // FIRST question MUST" guardrail biased the entire interview toward
+  // tech and was reported by users as the regression.
+
+  test("idea with open language -> prompt does NOT mandate language-first; caps tech-stack at 1", async () => {
     const qs = [{ id: "q1", text: "something?" }];
     const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
     await runInterview(
@@ -342,12 +351,17 @@ describe("runInterview — persona + explain wiring (SPEC §7)", () => {
       adapter,
     );
     const first = adapter.asks[0];
-    expect(first.prompt).toMatch(
-      /language.*open|open.*language|first question.*language|language.*first question/i,
+    // No "FIRST question MUST be language" mandate.
+    expect(first.prompt).not.toMatch(
+      /first question.*MUST.*language|language.*MUST.*first question/i,
+    );
+    // Tech-stack cap is present.
+    expect(first.prompt.toLowerCase()).toMatch(
+      /at most one tech-stack question|at most 1 tech-stack question/,
     );
   });
 
-  test("idea with no language -> prompt includes language-first guardrail", async () => {
+  test("idea with no explicit language -> prompt caps tech-stack at 1, focuses on substance", async () => {
     const qs = [{ id: "q1", text: "something?" }];
     const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
     await runInterview(
@@ -362,12 +376,18 @@ describe("runInterview — persona + explain wiring (SPEC §7)", () => {
       adapter,
     );
     const first = adapter.asks[0];
-    expect(first.prompt).toMatch(
-      /first question.*language|language.*first question/i,
+    expect(first.prompt).not.toMatch(
+      /first question.*MUST.*language|language.*MUST.*first question/i,
     );
+    expect(first.prompt.toLowerCase()).toMatch(
+      /at most one tech-stack question|at most 1 tech-stack question/,
+    );
+    // Project-substance focus must be explicit.
+    expect(first.prompt.toLowerCase()).toMatch(/project substance/);
+    expect(first.prompt.toLowerCase()).toMatch(/target users|users/);
   });
 
-  test("idea specifying a language -> guardrail anchors on it, no lang-first mandate", async () => {
+  test("idea specifying a language -> tech-stack capped, language not re-opened", async () => {
     const qs = [{ id: "q1", text: "something?" }];
     const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
     await runInterview(
@@ -382,8 +402,31 @@ describe("runInterview — persona + explain wiring (SPEC §7)", () => {
       adapter,
     );
     const first = adapter.asks[0];
-    // Should NOT mandate language as first question; should anchor on Rust
-    expect(first.prompt).toMatch(/anchor|specified/i);
+    // Do not re-open language choice.
+    expect(first.prompt.toLowerCase()).toMatch(/do not re-open|not re-open/);
+    expect(first.prompt.toLowerCase()).toMatch(
+      /at most one tech-stack question|at most 1 tech-stack question/,
+    );
+  });
+
+  test("no idea provided -> still caps tech-stack at 1 and focuses on substance", async () => {
+    const qs = [{ id: "q1", text: "something?" }];
+    const adapter = makeScriptedAskAdapter([makeQuestionsJson(qs)]);
+    await runInterview(
+      {
+        slug: "test",
+        persona: 'Veteran "CLI engineer" expert',
+        explain: false,
+        subscriptionAuth: false,
+        onQuestion: (_q) => Promise.resolve({ choice: "decide for me" }),
+      },
+      adapter,
+    );
+    const first = adapter.asks[0];
+    expect(first.prompt.toLowerCase()).toMatch(
+      /at most one tech-stack question|at most 1 tech-stack question/,
+    );
+    expect(first.prompt.toLowerCase()).toMatch(/project substance/);
   });
 });
 


### PR DESCRIPTION
## Summary

User-reported regression on samo.team (downstream wrapper of samospec): the interview now asks ~5 tech-stack questions (language, DB, framework) instead of project-substance questions (target users, features, success criteria, edge cases). Verbatim:

> "interview: it used to ask questions about the project substance not it's just the tech stack (like language, db, etc). user doesn't care about these things!! i wanna answer questions about the project. and even if i care 1 question is enough"

## Root cause

`src/cli/interview.ts` `buildInterviewPrompt`, introduced in #134 (closes #129):

- When the brief does not name a language, the prompt instructed: *"Your FIRST question MUST be about language choice."*
- When the brief named a language, the prompt instructed: *"Anchor your questions on that specified language choice."*

Both nudged the lead toward spending the 5-question budget on implementation choices.

## Fix

1. Replace the language-first mandate with a **tech-stack guardrail** that caps tech-stack questions (language, DB, framework, hosting) at **AT MOST ONE** total, and only when genuinely strategic for the brief.
2. Add an explicit **"PROJECT SUBSTANCE"** focus paragraph listing the expected topics: target users, jobs-to-be-done, v0.1 features, success criteria, edge cases, constraints, out-of-scope.
3. Keep the "do not re-open language when the brief specifies one" safeguard.
4. Emit the cap even when no idea is provided.

`ideaHasOpenLanguage` is preserved (still exported, still tested) — only the prompt-builder branches changed.

## Tests

- 4 prompt-shape tests rewritten in `tests/cli/interview.test.ts` to assert the new contract (≤1 tech-stack, project-substance focus, no "language MUST be FIRST") + a new test for the no-idea case.
- All 1502 tests pass; lint, typecheck, format all clean.

## Test plan

- [x] `bun test tests/cli/interview.test.ts` — 28 pass
- [x] `bun test` (full suite) — 1502 pass
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run format:check` — clean
- [ ] Once merged: bump samo.team's `samospec` pin to the new commit and verify in production that interview questions cover project substance.

Downstream tracking: samo.team#165.