### PR TITLE
fix(persona): pass idea to askForPersona to prevent schema conflict

### DIFF
--- a/src/cli/persona.ts
+++ b/src/cli/persona.ts
@@ -201,7 +201,13 @@ export async function proposePersona(
   });
 
   // First attempt.
-  const rawFirst = await askForPersona(adapter, prompt, effort, timeoutMs, input.idea);
+  const rawFirst = await askForPersona(
+    adapter,
+    prompt,
+    effort,
+    timeoutMs,
+    input.idea,
+  );
   let validated = parsePersonaAnswer(rawFirst);
 
   // One repair retry if the first attempt failed the schema.

--- a/src/cli/persona.ts
+++ b/src/cli/persona.ts
@@ -154,11 +154,13 @@ async function askForPersona(
   prompt: string,
   effort: EffortLevel,
   timeoutMs: number,
+  idea?: string,
 ): Promise<string> {
   const askInput: AskInput = {
     prompt,
     context: "",
     opts: { effort, timeout: timeoutMs },
+    ...(typeof idea === "string" && idea.length > 0 ? { idea } : {}),
   };
   let output;
   try {
@@ -199,7 +201,7 @@ export async function proposePersona(
   });
 
   // First attempt.
-  const rawFirst = await askForPersona(adapter, prompt, effort, timeoutMs);
+  const rawFirst = await askForPersona(adapter, prompt, effort, timeoutMs, input.idea);
   let validated = parsePersonaAnswer(rawFirst);
 
   // One repair retry if the first attempt failed the schema.
@@ -210,6 +212,7 @@ export async function proposePersona(
       repairPrompt,
       effort,
       timeoutMs,
+      input.idea,
     );
     validated = parsePersonaAnswer(rawSecond);
   }

--- a/tests/cli/persona.test.ts
+++ b/tests/cli/persona.test.ts
@@ -126,6 +126,7 @@ describe("proposePersona — happy path", () => {
   });
 
   test("ask() is invoked with a system prompt mentioning the persona form", async () => {
+    const idea = "some idea";
     const adapter = makeScriptedAskAdapter([
       JSON.stringify({
         persona: 'Veteran "platform engineer" expert',
@@ -134,7 +135,7 @@ describe("proposePersona — happy path", () => {
     ]);
     await proposePersona(
       {
-        idea: "some idea",
+        idea,
         explain: false,
         subscriptionAuth: false,
         choice: { kind: "accept" },
@@ -146,6 +147,7 @@ describe("proposePersona — happy path", () => {
     const first = adapter.asks[0];
     expect(first.prompt).toContain("Veteran");
     expect(first.prompt).toContain("expert");
+    expect(first.idea).toBe(idea);
     expect(first.opts.effort).toBe("max");
   });
 });
@@ -232,6 +234,7 @@ describe("proposePersona — confirm / edit / replace", () => {
 
 describe("proposePersona — schema repair + lead_terminal", () => {
   test("first response malformed, second response valid: accepts second", async () => {
+    const idea = "idea";
     const adapter = makeScriptedAskAdapter([
       // Malformed: missing quotes around skill.
       JSON.stringify({
@@ -246,7 +249,7 @@ describe("proposePersona — schema repair + lead_terminal", () => {
     ]);
     const result = await proposePersona(
       {
-        idea: "idea",
+        idea,
         explain: false,
         subscriptionAuth: false,
         choice: { kind: "accept" },
@@ -256,6 +259,8 @@ describe("proposePersona — schema repair + lead_terminal", () => {
     expect(result.persona).toBe('Veteran "CLI software engineer" expert');
     // Exactly one repair attempt was made (so 2 total ask calls).
     expect(adapter.asks.length).toBe(2);
+    expect(adapter.asks[0].idea).toBe(idea);
+    expect(adapter.asks[1].idea).toBe(idea);
   });
 
   test("two malformed responses in a row => throws PersonaTerminalError", async () => {


### PR DESCRIPTION
## Bug

When `askForPersona` creates `AskInput` without the `idea` field, `buildAskPrompt` omits the idea-precedence block. Without it, the outer `{"answer": ...}` schema instruction conflicts with the inner persona prompt's `{"persona": ..., "rationale": ...}` schema. Claude follows the inner format, causing `AskOutputSchema.parse` to fail with "expected string, received undefined" at path `["answer"]` — manifesting as exit 4 / `lead_terminal at persona`.

## Fix

Thread `input.idea` into `askForPersona` and include it in `AskInput`. This causes `buildAskPrompt` to emit the idea-precedence block, which makes the outer `{"answer": ...}` format authoritative.

## Changes

- Added optional `idea?: string` parameter to `askForPersona`
- Spread `idea` into `AskInput` when present (non-empty string)
- Pass `input.idea` to both `askForPersona` calls in `proposePersona` (first attempt + repair retry)

## Reproduction

Run `samospec new <slug> --idea "..." --accept-persona --answers-file <path>` when stdin is not a TTY. The persona phase fails every time.