### PR TITLE
[codex] add PR lifecycle gates

### DIFF
--- a/src/publish/lifecycle-gates.ts
+++ b/src/publish/lifecycle-gates.ts
@@ -1,0 +1,219 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+export type CiState = "missing" | "pending" | "failure" | "success";
+
+export interface GithubCiStatus {
+  readonly state: CiState;
+  readonly source: "github";
+  readonly detailsUrl?: string;
+}
+
+export type RevFindingSeverity =
+  | "blocking"
+  | "non-blocking"
+  | "potential"
+  | "info";
+
+export interface RevFinding {
+  readonly id: string;
+  readonly severity: RevFindingSeverity;
+  readonly category: string;
+  readonly message: string;
+}
+
+export type RevGate =
+  | {
+      readonly state: "missing";
+    }
+  | {
+      readonly state: "recorded";
+      readonly commentPosted: boolean;
+      readonly findings: readonly RevFinding[];
+      readonly reportUrl?: string;
+    };
+
+export type ManualTestingGate =
+  | {
+      readonly state: "missing";
+    }
+  | {
+      readonly state: "not-meaningful";
+      readonly rationale: string;
+    }
+  | {
+      readonly state: "present";
+      readonly evidence: string;
+    };
+
+export interface LifecyclePolicy {
+  readonly mergeAllowed: boolean;
+  readonly releaseAllowed: boolean;
+  readonly reason?: string;
+}
+
+export interface PrLifecycleInput {
+  readonly prNumber: number;
+  readonly authorLogin: string;
+  readonly ci: GithubCiStatus;
+  readonly rev: RevGate;
+  readonly manualTesting: ManualTestingGate;
+  readonly policy: LifecyclePolicy;
+}
+
+export type LifecycleState = "blocked" | "needs-author-action" | "merge-ready";
+
+export interface LifecycleBlocker {
+  readonly code:
+    | "ci-not-green"
+    | "rev-missing"
+    | "rev-comment-missing"
+    | "rev-blocking-findings"
+    | "testing-evidence-missing"
+    | "merge-policy-blocked"
+    | "release-policy-blocked";
+  readonly message: string;
+  readonly action: string;
+}
+
+export interface LifecycleActions {
+  readonly assignTo?: string;
+  readonly postRevComment?: boolean;
+}
+
+export interface PrLifecycleResult {
+  readonly prNumber: number;
+  readonly lifecycleState: LifecycleState;
+  readonly canMerge: boolean;
+  readonly canRelease: boolean;
+  readonly blockers: readonly LifecycleBlocker[];
+  readonly actions: LifecycleActions;
+}
+
+export function evaluatePrLifecycle(
+  input: PrLifecycleInput,
+): PrLifecycleResult {
+  const blockers: LifecycleBlocker[] = [];
+  const actions: MutableLifecycleActions = {};
+
+  addCiBlockers(input.ci, blockers);
+  addRevBlockers(input, blockers, actions);
+  addManualTestingBlockers(input.manualTesting, blockers);
+  addPolicyBlockers(input.policy, blockers);
+
+  const hasAuthorAction = actions.assignTo !== undefined;
+  const lifecycleState =
+    blockers.length === 0
+      ? "merge-ready"
+      : hasAuthorAction
+        ? "needs-author-action"
+        : "blocked";
+
+  return {
+    prNumber: input.prNumber,
+    lifecycleState,
+    canMerge:
+      blockers.length === 0 &&
+      input.policy.mergeAllowed &&
+      input.ci.state === "success",
+    canRelease: blockers.length === 0 && input.policy.releaseAllowed,
+    blockers,
+    actions,
+  };
+}
+
+interface MutableLifecycleActions {
+  assignTo?: string;
+  postRevComment?: boolean;
+}
+
+function addCiBlockers(ci: GithubCiStatus, blockers: LifecycleBlocker[]): void {
+  if (ci.state === "success") return;
+
+  blockers.push({
+    code: "ci-not-green",
+    message: `GitHub CI must be green before merge. Current CI state: ${ci.state}.`,
+    action: "Wait for CI to pass or fix the failing checks.",
+  });
+}
+
+function addRevBlockers(
+  input: PrLifecycleInput,
+  blockers: LifecycleBlocker[],
+  actions: MutableLifecycleActions,
+): void {
+  if (input.rev.state === "missing") {
+    actions.postRevComment = true;
+    blockers.push({
+      code: "rev-missing",
+      message: "REV must run against the PR diff before merge.",
+      action:
+        "Run REV, ignore SOC2-only findings, and post the report as a PR comment.",
+    });
+    return;
+  }
+
+  if (!input.rev.commentPosted) {
+    actions.postRevComment = true;
+    blockers.push({
+      code: "rev-comment-missing",
+      message: "The REV report must be posted to the PR before merge.",
+      action: "Post the recorded REV report as a PR comment.",
+    });
+  }
+
+  const blockingFindings = input.rev.findings.filter(
+    (finding) => finding.severity === "blocking" && !isSoc2Finding(finding),
+  );
+  if (blockingFindings.length === 0) return;
+
+  actions.assignTo = input.authorLogin;
+  const noun = blockingFindings.length === 1 ? "finding" : "findings";
+  blockers.push({
+    code: "rev-blocking-findings",
+    message:
+      `REV has ${blockingFindings.length} blocking ${noun} ` +
+      `that must be fixed.`,
+    action: `Assign ${input.authorLogin} and rerun REV after fixes land.`,
+  });
+}
+
+function addManualTestingBlockers(
+  manualTesting: ManualTestingGate,
+  blockers: LifecycleBlocker[],
+): void {
+  if (manualTesting.state !== "missing") return;
+
+  blockers.push({
+    code: "testing-evidence-missing",
+    message: "Manual testing evidence must be posted before merge.",
+    action:
+      "Add a PR comment or PR body section with the focused manual testing evidence.",
+  });
+}
+
+function addPolicyBlockers(
+  policy: LifecyclePolicy,
+  blockers: LifecycleBlocker[],
+): void {
+  const reason = policy.reason ?? "policy does not allow it";
+
+  if (!policy.mergeAllowed) {
+    blockers.push({
+      code: "merge-policy-blocked",
+      message: `Merge is blocked because ${reason}.`,
+      action: "Wait for owner approval or update the merge policy decision.",
+    });
+  }
+
+  if (!policy.releaseAllowed) {
+    blockers.push({
+      code: "release-policy-blocked",
+      message: `Release is blocked because ${reason}.`,
+      action: "Wait for owner approval or update the release policy decision.",
+    });
+  }
+}
+
+function isSoc2Finding(finding: RevFinding): boolean {
+  return finding.category.trim().toLowerCase().startsWith("soc2");
+}

--- a/tests/publish/lifecycle-gates.test.ts
+++ b/tests/publish/lifecycle-gates.test.ts
@@ -1,0 +1,145 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  evaluatePrLifecycle,
+  type PrLifecycleInput,
+} from "../../src/publish/lifecycle-gates.ts";
+
+function mergeReadyFixture(
+  overrides: Partial<PrLifecycleInput> = {},
+): PrLifecycleInput {
+  return {
+    prNumber: 155,
+    authorLogin: "feature-author",
+    ci: {
+      state: "success",
+      source: "github",
+      detailsUrl: "https://github.com/NikolayS/samospec/actions/runs/1",
+    },
+    rev: {
+      state: "recorded",
+      commentPosted: true,
+      reportUrl: "https://github.com/NikolayS/samospec/pull/1#issuecomment-1",
+      findings: [
+        {
+          id: "rev-tests-1",
+          severity: "non-blocking",
+          category: "tests",
+          message: "Consider expanding release smoke coverage later.",
+        },
+      ],
+    },
+    manualTesting: {
+      state: "present",
+      evidence: "Ran publish dry-run against a fixture PR.",
+    },
+    policy: {
+      mergeAllowed: true,
+      releaseAllowed: true,
+    },
+    ...overrides,
+  };
+}
+
+describe("evaluatePrLifecycle", () => {
+  test("blocks merge without green GitHub CI", () => {
+    const result = evaluatePrLifecycle(
+      mergeReadyFixture({
+        ci: {
+          state: "pending",
+          source: "github",
+          detailsUrl: "https://github.com/NikolayS/samospec/actions/runs/2",
+        },
+      }),
+    );
+
+    expect(result.lifecycleState).toBe("blocked");
+    expect(result.canMerge).toBe(false);
+    expect(result.blockers).toContainEqual({
+      code: "ci-not-green",
+      message:
+        "GitHub CI must be green before merge. Current CI state: pending.",
+      action: "Wait for CI to pass or fix the failing checks.",
+    });
+  });
+
+  test("blocks merge without a posted REV result", () => {
+    const result = evaluatePrLifecycle(
+      mergeReadyFixture({
+        rev: { state: "missing" },
+      }),
+    );
+
+    expect(result.lifecycleState).toBe("blocked");
+    expect(result.canMerge).toBe(false);
+    expect(result.blockers).toContainEqual({
+      code: "rev-missing",
+      message: "REV must run against the PR diff before merge.",
+      action:
+        "Run REV, ignore SOC2-only findings, and post the report as a PR comment.",
+    });
+  });
+
+  test("blocks merge when meaningful manual testing evidence is missing", () => {
+    const result = evaluatePrLifecycle(
+      mergeReadyFixture({
+        manualTesting: { state: "missing" },
+      }),
+    );
+
+    expect(result.lifecycleState).toBe("blocked");
+    expect(result.canMerge).toBe(false);
+    expect(result.blockers).toContainEqual({
+      code: "testing-evidence-missing",
+      message: "Manual testing evidence must be posted before merge.",
+      action:
+        "Add a PR comment or PR body section with the focused manual testing evidence.",
+    });
+  });
+
+  test("routes blocking REV findings back to the PR author", () => {
+    const result = evaluatePrLifecycle(
+      mergeReadyFixture({
+        rev: {
+          state: "recorded",
+          commentPosted: true,
+          findings: [
+            {
+              id: "rev-bugs-1",
+              severity: "blocking",
+              category: "bugs",
+              message: "Merge path ignores failed checks.",
+            },
+            {
+              id: "rev-soc2-1",
+              severity: "blocking",
+              category: "soc2",
+              message: "Missing second human reviewer.",
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(result.lifecycleState).toBe("needs-author-action");
+    expect(result.canMerge).toBe(false);
+    expect(result.actions.assignTo).toBe("feature-author");
+    expect(result.blockers).toContainEqual({
+      code: "rev-blocking-findings",
+      message: "REV has 1 blocking finding that must be fixed.",
+      action: "Assign feature-author and rerun REV after fixes land.",
+    });
+  });
+
+  test("advances a passing fixture PR state to merge-ready", () => {
+    const result = evaluatePrLifecycle(mergeReadyFixture());
+
+    expect(result.lifecycleState).toBe("merge-ready");
+    expect(result.canMerge).toBe(true);
+    expect(result.canRelease).toBe(true);
+    expect(result.blockers).toEqual([]);
+    expect(result.actions).toEqual({});
+  });
+});


### PR DESCRIPTION
Refs #155.

## What changed

- Added a pure PR lifecycle gate model for publish/release decisions.
- The evaluator blocks merge when GitHub CI is not green, REV is missing or not posted, meaningful manual testing evidence is missing, or merge/release policy disallows progression.
- Blocking non-SOC2 REV findings move the lifecycle to author action and request assignment back to the PR author.
- A passing fixture PR state advances to `merge-ready` with no actions.

## Testing evidence

- RED: `bun test tests/publish/lifecycle-gates.test.ts` initially failed because `src/publish/lifecycle-gates.ts` did not exist.
- GREEN focused: `bun test tests/publish/lifecycle-gates.test.ts tests/publish/pr.test.ts` -> 18 pass, 0 fail.
- Typecheck: `bun run typecheck` -> pass.
- Lint: `bun run lint` -> pass.
- Format: `bun run format:check` -> pass.
- Full suite: `bun test` -> 1514 pass, 0 fail.

## Manual testing

Manual UI testing is not meaningful for this pure TypeScript gate model. The manual evidence for this slice is the exercised fixture matrix in `tests/publish/lifecycle-gates.test.ts`: missing CI, missing REV, missing manual testing evidence, blocking REV findings with SOC2 ignored, and merge-ready state.

## Lifecycle note

Draft PR only. Do not merge without owner approval, CI green, REV pass, blocker loop closed, and testing evidence retained.