### PR TITLE
[codex] add autonomy policy model

### DIFF
--- a/src/adapter/claude.ts
+++ b/src/adapter/claude.ts
@@ -36,6 +36,7 @@ import {
   type SpawnCliResult,
 } from "./spawn.ts";
 import { runWithCappedRetry, type AttemptResult } from "./timeout.ts";
+import { renderAutonomyPolicySnapshotPromptBlock } from "../policy/autonomy.ts";
 import {
   type Adapter,
   type AskInput,
@@ -649,23 +650,31 @@ export function buildAskPrompt(input: AskInput): string {
   if (typeof input.slug === "string" && input.slug.length > 0)
     ideaOpts.slug = input.slug;
   const ideaBlock = buildIdeaPrecedenceBlock(ideaOpts);
+  const autonomyBlock = renderAutonomyPolicySnapshotPromptBlock(
+    input.autonomy_policy,
+  );
   return (
     "You are the samospec lead. Respond ONLY with a JSON object matching " +
     'the schema { "answer": string, "usage": null, "effort_used": ' +
     `"${input.opts.effort}" }. Do not wrap in code fences.` +
     ideaBlock +
+    autonomyBlock +
     ctx +
     `\n\nQuestion:\n${input.prompt}\n`
   );
 }
 
 export function buildCritiquePrompt(input: CritiqueInput): string {
+  const autonomyBlock = renderAutonomyPolicySnapshotPromptBlock(
+    input.autonomy_policy,
+  );
   return (
     "You are the samospec reviewer. Return ONLY a JSON object matching " +
     'the review-taxonomy schema: { "findings": Array<{ "category": ' +
     'string, "text": string, "severity": "major"|"minor" }>, "summary":' +
     ' string, "suggested_next_version": string, "usage": null, ' +
     `"effort_used": "${input.opts.effort}" }. Do not wrap in code fences.` +
+    autonomyBlock +
     `\n\nGuidelines:\n${input.guidelines}\n\nSpec:\n${input.spec}\n`
   );
 }
@@ -678,6 +687,9 @@ export function buildRevisePrompt(input: ReviseInput): string {
   if (typeof input.slug === "string" && input.slug.length > 0)
     reviseIdeaOpts.slug = input.slug;
   const ideaBlock = buildIdeaPrecedenceBlock(reviseIdeaOpts);
+  const autonomyBlock = renderAutonomyPolicySnapshotPromptBlock(
+    input.autonomy_policy,
+  );
   return (
     "You are the samospec lead. Emit the FULL revised SPEC.md text — " +
     'not a patch. Return ONLY a JSON object: { "spec": <full text>, ' +
@@ -691,6 +703,7 @@ export function buildRevisePrompt(input: ReviseInput): string {
     "Verdict options: accepted (applied to the spec), rejected " +
     "(did not apply, with reason), deferred (punted to a later version)." +
     ideaBlock +
+    autonomyBlock +
     baselineSections +
     `\n\nCurrent spec:\n${input.spec}\n\nReviews (JSON):\n` +
     `${JSON.stringify(input.reviews)}\n\nDecisions so far (JSON):\n` +

--- a/src/adapter/codex.ts
+++ b/src/adapter/codex.ts
@@ -49,6 +49,7 @@ import {
   type SpawnCliResult,
 } from "./spawn.ts";
 import { computeAttemptTimeouts } from "./timeout.ts";
+import { renderAutonomyPolicySnapshotPromptBlock } from "../policy/autonomy.ts";
 
 // Internal fail reason covering the Codex fallback sentinel plus the
 // standard failure classes. The adapter-level CodexAdapterError
@@ -639,11 +640,15 @@ export class CodexAdapter implements Adapter {
 
 function buildAskPrompt(input: AskInput): string {
   const ctx = input.context === "" ? "" : `\n\nContext:\n${input.context}\n`;
+  const autonomyBlock = renderAutonomyPolicySnapshotPromptBlock(
+    input.autonomy_policy,
+  );
   return (
     "You are the samospec Reviewer A (Codex). Respond ONLY with a JSON " +
     'object matching the schema { "answer": string, "usage": null, ' +
     `"effort_used": "${input.opts.effort}" }. Do not wrap in code ` +
     "fences." +
+    autonomyBlock +
     ctx +
     `\n\nQuestion:\n${input.prompt}\n`
   );
@@ -653,6 +658,9 @@ function buildCritiquePrompt(input: CritiqueInput): string {
   // Persona prefix + taxonomy weighting (SPEC §7 Model roles).
   // Advisory, not a hard filter — reviewer may still surface other
   // categories.
+  const autonomyBlock = renderAutonomyPolicySnapshotPromptBlock(
+    input.autonomy_policy,
+  );
   return (
     `${CODEX_CRITIQUE_PERSONA_PREFIX}\n\n` +
     "You are the samospec reviewer. Return ONLY a JSON object matching " +
@@ -660,6 +668,7 @@ function buildCritiquePrompt(input: CritiqueInput): string {
     'string, "text": string, "severity": "major"|"minor" }>, "summary":' +
     ' string, "suggested_next_version": string, "usage": null, ' +
     `"effort_used": "${input.opts.effort}" }. Do not wrap in code fences.` +
+    autonomyBlock +
     `\n\nGuidelines:\n${input.guidelines}\n\nSpec:\n${input.spec}\n`
   );
 }
@@ -667,13 +676,18 @@ function buildCritiquePrompt(input: CritiqueInput): string {
 function buildRevisePrompt(input: ReviseInput): string {
   // Reviewer seats rarely call revise(); the method is exposed for
   // adapter-contract parity with the lead seat.
+  const autonomyBlock = renderAutonomyPolicySnapshotPromptBlock(
+    input.autonomy_policy,
+  );
   return (
     "You are the samospec reviewer operating in revise mode. Emit the " +
     "FULL revised SPEC.md text — not a patch. Return ONLY a JSON " +
     'object: { "spec": <full text>, "ready": boolean, "rationale": ' +
     'string, "usage": null, ' +
     `"effort_used": "${input.opts.effort}" }. Do not wrap in code ` +
-    `fences.\n\nCurrent spec:\n${input.spec}\n\nReviews (JSON):\n` +
+    "fences." +
+    autonomyBlock +
+    `\n\nCurrent spec:\n${input.spec}\n\nReviews (JSON):\n` +
     `${JSON.stringify(input.reviews)}\n\nDecisions so far (JSON):\n` +
     `${JSON.stringify(input.decisions_history)}\n`
   );

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -2,6 +2,8 @@
 
 import { z } from "zod";
 
+import { autonomyPolicySnapshotSchema } from "../policy/autonomy.ts";
+
 // SPEC §7: adapter contract. Effort ladder per SPEC §11.
 export const EffortLevelSchema = z.enum([
   "max",
@@ -90,6 +92,12 @@ export const AskInputSchema = z.object({
    * a non-semantic identifier.
    */
   slug: z.string().optional(),
+  /**
+   * #153: implementation-run autonomy policy snapshot. When present,
+   * prompt builders render `rendered_policy` verbatim so issue/PR agent
+   * prompts carry the chosen authority limits.
+   */
+  autonomy_policy: autonomyPolicySnapshotSchema.optional(),
 });
 export type AskInput = z.infer<typeof AskInputSchema>;
 
@@ -134,6 +142,7 @@ export const CritiqueInputSchema = z.object({
    * contradiction findings when the spec reintroduces a disclaimed class.
    */
   idea: z.string().optional(),
+  autonomy_policy: autonomyPolicySnapshotSchema.optional(),
 });
 export type CritiqueInput = z.infer<typeof CritiqueInputSchema>;
 
@@ -187,6 +196,7 @@ export const ReviseInputSchema = z.object({
    * #85: filesystem-safe slug (non-authoritative identifier only).
    */
   slug: z.string().optional(),
+  autonomy_policy: autonomyPolicySnapshotSchema.optional(),
 });
 export type ReviseInput = z.infer<typeof ReviseInputSchema>;
 

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -94,8 +94,8 @@ export const AskInputSchema = z.object({
   slug: z.string().optional(),
   /**
    * #153: implementation-run autonomy policy snapshot. When present,
-   * prompt builders render `rendered_policy` verbatim so issue/PR agent
-   * prompts carry the chosen authority limits.
+   * prompt builders validate the persisted snapshot and render policy text
+   * derived from the structured authority limits.
    */
   autonomy_policy: autonomyPolicySnapshotSchema.optional(),
 });

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -22,6 +22,11 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
+import {
+  DEFAULT_AUTONOMY_POLICY,
+  type AutonomyPolicy,
+} from "../policy/autonomy.ts";
+
 export const CONFIG_SCHEMA_VERSION = 1 as const;
 
 export interface LeadAdapterDefaults {
@@ -95,6 +100,7 @@ export interface DefaultConfig {
   readonly context: ContextDefaults;
   readonly convergence: ConvergenceDefaults;
   readonly publish_lint: PublishLintDefaults;
+  readonly autonomy_policy: AutonomyPolicy;
 }
 
 /**
@@ -149,6 +155,7 @@ export const DEFAULT_CONFIG: DefaultConfig = {
   publish_lint: {
     allowed_commands: [],
   },
+  autonomy_policy: DEFAULT_AUTONOMY_POLICY,
 };
 
 const GITIGNORE_BODY = [

--- a/src/policy/autonomy.ts
+++ b/src/policy/autonomy.ts
@@ -51,7 +51,17 @@ export const autonomyPolicySnapshotSchema = z
     recorded_at: isoTimestampSchema,
     source: z.enum(["config", "cli", "api"]),
   })
-  .strict();
+  .strict()
+  .superRefine((snapshot, ctx) => {
+    const expected = renderAutonomyPolicyPromptBlock(snapshot.policy);
+    if (snapshot.rendered_policy !== expected) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "must match rendered autonomy policy derived from policy",
+        path: ["rendered_policy"],
+      });
+    }
+  });
 export type AutonomyPolicySnapshot = z.infer<
   typeof autonomyPolicySnapshotSchema
 >;
@@ -190,7 +200,7 @@ export function renderAutonomyPolicySnapshotPromptBlock(
 ): string {
   if (snapshot === undefined) return "";
   const parsed = autonomyPolicySnapshotSchema.parse(snapshot);
-  return `\n\n${parsed.rendered_policy}\n`;
+  return `\n\n${renderAutonomyPolicyPromptBlock(parsed.policy)}\n`;
 }
 
 function parseChoice<const T extends string>(

--- a/src/policy/autonomy.ts
+++ b/src/policy/autonomy.ts
@@ -1,0 +1,211 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+import { z } from "zod";
+
+export const AUTONOMY_POLICY_SCHEMA_VERSION = 1 as const;
+
+export const mergeAuthoritySchema = z.enum([
+  "cannot_merge",
+  "can_merge_after_gates",
+  "can_tag_release_after_gates",
+]);
+export type MergeAuthority = z.infer<typeof mergeAuthoritySchema>;
+
+export const workScopeSchema = z.enum(["issue_only", "full_dev_sprint"]);
+export type WorkScope = z.infer<typeof workScopeSchema>;
+
+export const followUpIssueAuthoritySchema = z.enum([
+  "cannot_create",
+  "can_propose",
+  "can_create",
+]);
+export type FollowUpIssueAuthority = z.infer<
+  typeof followUpIssueAuthoritySchema
+>;
+
+export const reviewAuthoritySchema = z.enum(["request_review_only"]);
+export type ReviewAuthority = z.infer<typeof reviewAuthoritySchema>;
+
+export const autonomyPolicySchema = z
+  .object({
+    merge_authority: mergeAuthoritySchema,
+    work_scope: workScopeSchema,
+    follow_up_issue_authority: followUpIssueAuthoritySchema,
+    review_authority: reviewAuthoritySchema,
+  })
+  .strict();
+export type AutonomyPolicy = z.infer<typeof autonomyPolicySchema>;
+
+const isoTimestampSchema = z
+  .string()
+  .regex(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/,
+    "must be an ISO 8601 UTC timestamp ending in 'Z'",
+  );
+
+export const autonomyPolicySnapshotSchema = z
+  .object({
+    schema_version: z.literal(AUTONOMY_POLICY_SCHEMA_VERSION),
+    policy: autonomyPolicySchema,
+    rendered_policy: z.string().min(1),
+    recorded_at: isoTimestampSchema,
+    source: z.enum(["config", "cli", "api"]),
+  })
+  .strict();
+export type AutonomyPolicySnapshot = z.infer<
+  typeof autonomyPolicySnapshotSchema
+>;
+
+export const DEFAULT_AUTONOMY_POLICY: AutonomyPolicy = {
+  merge_authority: "cannot_merge",
+  work_scope: "issue_only",
+  follow_up_issue_authority: "cannot_create",
+  review_authority: "request_review_only",
+};
+
+const MERGE_TEXT: Readonly<Record<MergeAuthority, string>> = {
+  cannot_merge: "cannot merge; manager/project-owner approval required.",
+  can_merge_after_gates: "can merge after required gates pass.",
+  can_tag_release_after_gates: "can tag/release after required gates pass.",
+};
+
+const SCOPE_TEXT: Readonly<Record<WorkScope, string>> = {
+  issue_only: "issue-level only.",
+  full_dev_sprint: "full-dev mode across the sprint.",
+};
+
+const FOLLOW_UP_TEXT: Readonly<Record<FollowUpIssueAuthority, string>> = {
+  cannot_create: "cannot create follow-up issues.",
+  can_propose:
+    "may propose follow-up issues for manager/project-owner approval.",
+  can_create: "may create follow-up issues directly.",
+};
+
+const REVIEW_TEXT: Readonly<Record<ReviewAuthority, string>> = {
+  request_review_only:
+    "may request REV/reviewer agents; cannot approve own PR.",
+};
+
+export interface AutonomyPolicyChoiceInput {
+  readonly mergeAuthority?: string;
+  readonly workScope?: string;
+  readonly followUpIssueAuthority?: string;
+  readonly reviewAuthority?: string;
+}
+
+export type ParseAutonomyPolicyChoicesResult =
+  | { readonly ok: true; readonly policy: AutonomyPolicy }
+  | { readonly ok: false; readonly error: string };
+
+export function readAutonomyPolicyFromConfig(config: unknown): AutonomyPolicy {
+  if (
+    typeof config !== "object" ||
+    config === null ||
+    Array.isArray(config) ||
+    !("autonomy_policy" in config)
+  ) {
+    return DEFAULT_AUTONOMY_POLICY;
+  }
+  const raw = (config as Record<string, unknown>)["autonomy_policy"];
+  if (raw === undefined || raw === null) return DEFAULT_AUTONOMY_POLICY;
+  return autonomyPolicySchema.parse(raw);
+}
+
+export function parseAutonomyPolicyChoices(
+  input: AutonomyPolicyChoiceInput,
+): ParseAutonomyPolicyChoicesResult {
+  const errors: string[] = [];
+  const merge_authority = parseChoice(
+    "merge authority",
+    input.mergeAuthority,
+    mergeAuthoritySchema.options,
+    DEFAULT_AUTONOMY_POLICY.merge_authority,
+    errors,
+  );
+  const work_scope = parseChoice(
+    "work scope",
+    input.workScope,
+    workScopeSchema.options,
+    DEFAULT_AUTONOMY_POLICY.work_scope,
+    errors,
+  );
+  const follow_up_issue_authority = parseChoice(
+    "follow-up issue authority",
+    input.followUpIssueAuthority,
+    followUpIssueAuthoritySchema.options,
+    DEFAULT_AUTONOMY_POLICY.follow_up_issue_authority,
+    errors,
+  );
+  const review_authority = parseChoice(
+    "review authority",
+    input.reviewAuthority,
+    reviewAuthoritySchema.options,
+    DEFAULT_AUTONOMY_POLICY.review_authority,
+    errors,
+  );
+  if (errors.length > 0) {
+    return { ok: false, error: errors.join(" ") };
+  }
+  return {
+    ok: true,
+    policy: {
+      merge_authority,
+      work_scope,
+      follow_up_issue_authority,
+      review_authority,
+    },
+  };
+}
+
+export function createAutonomyPolicySnapshot(args: {
+  readonly policy: AutonomyPolicy;
+  readonly recordedAt: string;
+  readonly source: AutonomyPolicySnapshot["source"];
+}): AutonomyPolicySnapshot {
+  return autonomyPolicySnapshotSchema.parse({
+    schema_version: AUTONOMY_POLICY_SCHEMA_VERSION,
+    policy: args.policy,
+    rendered_policy: renderAutonomyPolicyPromptBlock(args.policy),
+    recorded_at: args.recordedAt,
+    source: args.source,
+  });
+}
+
+export function renderAutonomyPolicyPromptBlock(
+  policy: AutonomyPolicy,
+): string {
+  const parsed = autonomyPolicySchema.parse(policy);
+  return [
+    "## Autonomy policy",
+    "",
+    `- Merge authority: ${MERGE_TEXT[parsed.merge_authority]}`,
+    `- Work scope: ${SCOPE_TEXT[parsed.work_scope]}`,
+    `- Follow-up issue authority: ${FOLLOW_UP_TEXT[parsed.follow_up_issue_authority]}`,
+    `- Review authority: ${REVIEW_TEXT[parsed.review_authority]}`,
+  ].join("\n");
+}
+
+export function renderAutonomyPolicySnapshotPromptBlock(
+  snapshot?: AutonomyPolicySnapshot,
+): string {
+  if (snapshot === undefined) return "";
+  const parsed = autonomyPolicySnapshotSchema.parse(snapshot);
+  return `\n\n${parsed.rendered_policy}\n`;
+}
+
+function parseChoice<const T extends string>(
+  label: string,
+  raw: string | undefined,
+  allowed: readonly T[],
+  fallback: T,
+  errors: string[],
+): T {
+  if (raw === undefined || raw.trim().length === 0) return fallback;
+  if (allowed.includes(raw as T)) return raw as T;
+  errors.push(
+    `Invalid ${label}: ${JSON.stringify(raw)}. Use one of: ${allowed.join(
+      ", ",
+    )}.`,
+  );
+  return fallback;
+}

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -2,6 +2,8 @@
 
 import { z } from "zod";
 
+import { autonomyPolicySnapshotSchema } from "../policy/autonomy.ts";
+
 // SPEC §5 — eight phases in canonical order.
 export const PHASES = [
   "detect",
@@ -148,6 +150,11 @@ export const stateSchema = z
     /** Absent when neither `gh` nor `glab` was authenticated; set from
      * the tool's stdout URL when the PR was opened successfully. */
     published_pr_url: z.string().min(1).optional(),
+    /**
+     * #153: auditable autonomy-policy snapshot for the implementation
+     * run that turns reviewed specs into issue/PR prompts.
+     */
+    implementation_autonomy: autonomyPolicySnapshotSchema.optional(),
     created_at: isoTimestampSchema,
     updated_at: isoTimestampSchema,
     /**

--- a/tests/adapter/autonomy-policy-prompt.test.ts
+++ b/tests/adapter/autonomy-policy-prompt.test.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED tests for #153: issue/PR agent prompts must include the chosen
+// autonomy policy verbatim.
+
+import { describe, expect, test } from "bun:test";
+
+import { buildAskPrompt, buildRevisePrompt } from "../../src/adapter/claude.ts";
+import {
+  createAutonomyPolicySnapshot,
+  renderAutonomyPolicyPromptBlock,
+} from "../../src/policy/autonomy.ts";
+import type { AskInput, ReviseInput } from "../../src/adapter/types.ts";
+
+const policy = {
+  merge_authority: "can_merge_after_gates",
+  work_scope: "full_dev_sprint",
+  follow_up_issue_authority: "can_create",
+  review_authority: "request_review_only",
+} as const;
+
+const snapshot = createAutonomyPolicySnapshot({
+  policy,
+  recordedAt: "2026-05-08T12:00:00.000Z",
+  source: "api",
+});
+
+describe("agent prompt rendering — autonomy policy (#153)", () => {
+  test("ask prompt includes the rendered autonomy policy verbatim", () => {
+    const input: AskInput = {
+      prompt: "Create the implementation issue prompt.",
+      context: "Issue #153",
+      opts: { effort: "max", timeout: 120_000 },
+      autonomy_policy: snapshot,
+    };
+    const prompt = buildAskPrompt(input);
+    expect(prompt).toContain(renderAutonomyPolicyPromptBlock(policy));
+    expect(prompt).toContain(snapshot.rendered_policy);
+  });
+
+  test("revise prompt includes the rendered autonomy policy verbatim", () => {
+    const input: ReviseInput = {
+      spec: "# SPEC\n\n## Implementation plan\n\nCreate issue prompts.",
+      reviews: [],
+      decisions_history: [],
+      opts: { effort: "max", timeout: 600_000 },
+      autonomy_policy: snapshot,
+    };
+    const prompt = buildRevisePrompt(input);
+    expect(prompt).toContain(snapshot.rendered_policy);
+    expect(prompt).toContain(
+      "Follow-up issue authority: may create follow-up issues directly.",
+    );
+  });
+});

--- a/tests/policy/autonomy.test.ts
+++ b/tests/policy/autonomy.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../src/cli/init.ts";
 import {
   DEFAULT_AUTONOMY_POLICY,
+  autonomyPolicySnapshotSchema,
   createAutonomyPolicySnapshot,
   parseAutonomyPolicyChoices,
   readAutonomyPolicyFromConfig,
@@ -102,5 +103,23 @@ describe("autonomy policy — explicit choices (#153)", () => {
     expect(snapshot.rendered_policy).toContain(
       "Follow-up issue authority: may propose follow-up issues for manager/project-owner approval.",
     );
+  });
+
+  test("snapshot rejects rendered policy text that contradicts structured policy", () => {
+    const parsed = autonomyPolicySnapshotSchema.safeParse({
+      schema_version: 1,
+      policy: DEFAULT_AUTONOMY_POLICY,
+      rendered_policy: renderAutonomyPolicyPromptBlock({
+        merge_authority: "can_merge_after_gates",
+        work_scope: "full_dev_sprint",
+        follow_up_issue_authority: "can_create",
+        review_authority: "request_review_only",
+      }),
+      recorded_at: "2026-05-08T12:00:00.000Z",
+      source: "api",
+    });
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.error.issues[0]?.path).toEqual(["rendered_policy"]);
   });
 });

--- a/tests/policy/autonomy.test.ts
+++ b/tests/policy/autonomy.test.ts
@@ -1,0 +1,106 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED tests for #153: implementation runs must carry an explicit
+// autonomy policy for merge, scope, follow-up issues, and review
+// authority. Defaults are conservative; explicit autonomous choices are
+// auditable and render verbatim into prompts.
+
+import { describe, expect, test } from "bun:test";
+
+import { DEFAULT_CONFIG } from "../../src/cli/init.ts";
+import {
+  DEFAULT_AUTONOMY_POLICY,
+  createAutonomyPolicySnapshot,
+  parseAutonomyPolicyChoices,
+  readAutonomyPolicyFromConfig,
+  renderAutonomyPolicyPromptBlock,
+} from "../../src/policy/autonomy.ts";
+
+describe("autonomy policy — defaults (#153)", () => {
+  test("DEFAULT_CONFIG carries the conservative autonomy policy", () => {
+    expect(DEFAULT_CONFIG.autonomy_policy).toEqual(DEFAULT_AUTONOMY_POLICY);
+  });
+
+  test("missing config policy resolves to conservative defaults", () => {
+    const policy = readAutonomyPolicyFromConfig({ schema_version: 1 });
+    expect(policy).toEqual(DEFAULT_AUTONOMY_POLICY);
+    expect(policy.merge_authority).toBe("cannot_merge");
+    expect(policy.work_scope).toBe("issue_only");
+    expect(policy.follow_up_issue_authority).toBe("cannot_create");
+    expect(policy.review_authority).toBe("request_review_only");
+  });
+
+  test("conservative render says manager/project-owner approval is required", () => {
+    const text = renderAutonomyPolicyPromptBlock(DEFAULT_AUTONOMY_POLICY);
+    expect(text).toContain(
+      "Merge authority: cannot merge; manager/project-owner approval required.",
+    );
+    expect(text).toContain("Work scope: issue-level only.");
+    expect(text).toContain(
+      "Follow-up issue authority: cannot create follow-up issues.",
+    );
+    expect(text).toContain(
+      "Review authority: may request REV/reviewer agents; cannot approve own PR.",
+    );
+  });
+});
+
+describe("autonomy policy — explicit choices (#153)", () => {
+  test("explicit autonomous policy parses from unambiguous CLI/API ids", () => {
+    const parsed = parseAutonomyPolicyChoices({
+      mergeAuthority: "can_tag_release_after_gates",
+      workScope: "full_dev_sprint",
+      followUpIssueAuthority: "can_create",
+      reviewAuthority: "request_review_only",
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.policy).toEqual({
+      merge_authority: "can_tag_release_after_gates",
+      work_scope: "full_dev_sprint",
+      follow_up_issue_authority: "can_create",
+      review_authority: "request_review_only",
+    });
+  });
+
+  test("ambiguous shorthand is rejected", () => {
+    const parsed = parseAutonomyPolicyChoices({
+      mergeAuthority: "auto",
+      workScope: "full",
+      followUpIssueAuthority: "yes",
+      reviewAuthority: "approve",
+    });
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.error).toContain("merge authority");
+    expect(parsed.error).toContain("can_merge_after_gates");
+    expect(parsed.error).toContain("can_tag_release_after_gates");
+  });
+
+  test("snapshot is auditable and includes the rendered policy verbatim", () => {
+    const policy = {
+      merge_authority: "can_merge_after_gates",
+      work_scope: "full_dev_sprint",
+      follow_up_issue_authority: "can_propose",
+      review_authority: "request_review_only",
+    } as const;
+    const snapshot = createAutonomyPolicySnapshot({
+      policy,
+      recordedAt: "2026-05-08T12:00:00.000Z",
+      source: "cli",
+    });
+    expect(snapshot.schema_version).toBe(1);
+    expect(snapshot.recorded_at).toBe("2026-05-08T12:00:00.000Z");
+    expect(snapshot.source).toBe("cli");
+    expect(snapshot.policy).toEqual(policy);
+    expect(snapshot.rendered_policy).toBe(
+      renderAutonomyPolicyPromptBlock(policy),
+    );
+    expect(snapshot.rendered_policy).toContain(
+      "Merge authority: can merge after required gates pass.",
+    );
+    expect(snapshot.rendered_policy).toContain(
+      "Follow-up issue authority: may propose follow-up issues for manager/project-owner approval.",
+    );
+  });
+});

--- a/tests/state/autonomy-policy.test.ts
+++ b/tests/state/autonomy-policy.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED tests for #153: state.json must be able to persist an auditable
+// autonomy policy snapshot per implementation run.
+
+import { describe, expect, test } from "bun:test";
+
+import { createAutonomyPolicySnapshot } from "../../src/policy/autonomy.ts";
+import { newState } from "../../src/state/store.ts";
+import { stateSchema } from "../../src/state/types.ts";
+
+describe("state.json — implementation autonomy policy snapshot (#153)", () => {
+  test("fresh state has no implementation-run autonomy snapshot", () => {
+    const state = newState({
+      slug: "demo",
+      now: "2026-05-08T12:00:00.000Z",
+    });
+    expect(state.implementation_autonomy).toBeUndefined();
+  });
+
+  test("state schema accepts an auditable implementation autonomy snapshot", () => {
+    const base = newState({
+      slug: "demo",
+      now: "2026-05-08T12:00:00.000Z",
+    });
+    const snapshot = createAutonomyPolicySnapshot({
+      policy: {
+        merge_authority: "can_merge_after_gates",
+        work_scope: "issue_only",
+        follow_up_issue_authority: "can_create",
+        review_authority: "request_review_only",
+      },
+      recordedAt: "2026-05-08T12:01:00.000Z",
+      source: "config",
+    });
+    const parsed = stateSchema.parse({
+      ...base,
+      implementation_autonomy: snapshot,
+    });
+    expect(parsed.implementation_autonomy).toEqual(snapshot);
+    expect(parsed.implementation_autonomy?.rendered_policy).toContain(
+      "Review authority: may request REV/reviewer agents; cannot approve own PR.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Refs #153.

Adds the autonomy policy model slice for implementation runs:

- Conservative default policy in `.samo/config.json` defaults.
- Explicit merge authority, work scope, follow-up issue authority, and review authority schemas.
- Auditable implementation-run snapshot shape for `state.json`.
- Prompt rendering helpers that inject the chosen policy verbatim into agent ask/revise/critique prompts.
- CLI/API-facing parser for unambiguous policy choice ids, rejecting ambiguous shorthand.

## Testing evidence

- RED first: `bun test tests/policy/autonomy.test.ts tests/state/autonomy-policy.test.ts tests/adapter/autonomy-policy-prompt.test.ts` initially failed because `src/policy/autonomy.ts` did not exist.
- Focused green: `bun test tests/policy/autonomy.test.ts tests/state/autonomy-policy.test.ts tests/adapter/autonomy-policy-prompt.test.ts` -> 10 pass, 0 fail.
- Nearby suites: `bun test tests/cli/init.test.ts tests/state/store.test.ts tests/adapter/lead-prompt-baseline.test.ts tests/adapter/lead-prompt-idea-precedence.test.ts tests/adapter/claude-reviewer-b.test.ts tests/adapter/codex.work.test.ts` -> 78 pass, 0 fail.
- Relevant schema/contract suites: `bun test tests/policy tests/state tests/adapter/types.test.ts tests/adapter/contract.test.ts tests/adapter/claude.contract.test.ts tests/adapter/codex.contract.test.ts` -> 243 pass, 0 fail.
- `bun run typecheck` -> pass.
- `bun run format:check` -> pass.
- `bun run lint` -> pass.
- `bun test` -> 1519 pass, 0 fail.

## Out-of-scope / follow-ups

- This PR intentionally does not implement a future implementation-stage command or agent workflow. It owns only the policy model/config/state snapshot/prompt-rendering slice requested for #153.
- REV review and CI are not completed yet; this PR is draft and must not be merged by the author.