### PR TITLE
[codex] stabilize revise timeout clamp

### DIFF
--- a/src/loop/round.ts
+++ b/src/loop/round.ts
@@ -793,13 +793,15 @@ export async function runRound(input: RunRoundInput): Promise<RunRoundOutcome> {
  * the inner `ReviseTimeoutError` fires strictly BEFORE the outer
  * `SessionWallClockError`, preserving the diagnostic distinction.
  *
- * The margin must exceed CI scheduler jitter, otherwise the post-merge
- * iterate test for #92 REV flakes (observed ~766ms overrun on
- * ubuntu-latest in run 25085910538). 500ms gives 5x headroom over the
- * worst sample we've seen and is still negligible vs typical session
- * budgets measured in minutes.
+ * The margin must exceed CI scheduler jitter and leave enough room for
+ * the required whole-round retry after a first revise timeout. Smaller
+ * margins let the first timeout consume almost all of a tiny injected
+ * session budget, after which the sibling session-deadline wrapper can
+ * win the race and classify the same hang as `wall_clock`. 2s remains
+ * negligible vs typical user session budgets measured in minutes, while
+ * keeping the regression test stable under Ubuntu coverage jitter.
  */
-const CLAMP_SAFETY_MARGIN_MS = 500 as const;
+const CLAMP_SAFETY_MARGIN_MS = 2_000 as const;
 
 function resolveEffectiveReviseTimeout(
   configured: number,


### PR DESCRIPTION
## Summary

Stabilizes the #92 revise-timeout clamp so the inner `ReviseTimeoutError` keeps precedence over the sibling session wall-clock timer under Ubuntu coverage jitter.

Root cause: the previous 500 ms clamp margin let the first revise timeout consume nearly all of the tiny injected session budget in `tests/loop/revise-timeout.test.ts`. On the failing Ubuntu run for `246580c`, the required whole-round retry did not have enough timing headroom, so the outer session-wall-clock wrapper won and persisted `lead-terminal:wall_clock` instead of `lead-terminal:revise_timeout`.

This keeps the existing behavior but widens the safety margin to 2 seconds. That is still negligible for normal minute-scale session budgets, while giving the retry path room to finish before the outer wall-clock timer in the small regression test budget.

## Evidence

CI failure investigated:

- `ci / build (ubuntu-latest)` failed on push commit `246580c1e3a3d6f3e67f695990b838a8a653ab6e`
- GitHub Actions run: https://github.com/NikolayS/samospec/actions/runs/25529811800
- Failed assertion: `tests/loop/revise-timeout.test.ts:481`
- Expected `lead-terminal:revise_timeout`, received `lead-terminal:wall_clock`
- Failing test duration in CI: `3127.05ms`

Local verification:

- Before fix, focused test passed locally but took about `1576ms`, so the failure was not locally reproducible here.
- After fix, focused failing test: `bun test tests/loop/revise-timeout.test.ts -t "session cap smaller than configured revise"` -> `1 pass`, about `89ms` without coverage and `70ms` under coverage.
- `bun test tests/loop/revise-timeout.test.ts` -> `11 pass`, `0 fail`.
- `bun test --coverage tests` -> `1529 pass`, `0 fail`, `9605 expect() calls`.
- `bun run format:check` -> pass.
- `bun run typecheck` -> pass.
- `bunx eslint $(git ls-files '*.ts' '*.js')` -> pass.

Note: exact local `bun run lint` is blocked by a pre-existing untracked `app/` directory in this checkout; it is not part of this PR or a clean CI checkout. The PR commit stages only `src/loop/round.ts`.
