### PR TITLE
docs(readme): lead with bunx, drop global install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bunx samospec doctor
 bunx samospec --version   # 0.8.0
 ```
 
-`npx` is not supported — use `bunx`.
+`npx` won't work — the CLI ships as TypeScript and depends on the Bun runtime (`Bun.spawn`, etc.). Use `bunx`.
 
 For brevity, the rest of this README writes `samospec` — read it as `bunx samospec`.
 

--- a/README.md
+++ b/README.md
@@ -28,22 +28,18 @@ SamoSpec treats spec authoring like code review:
 
 ---
 
-## Install
+## Run
 
-Requires [Bun](https://bun.sh) ≥ 1.2.0.
-
-```bash
-bun install -g samospec
-samospec --version   # 0.8.0
-```
-
-Or one-shot:
+No install step. Requires [Bun](https://bun.sh) ≥ 1.2.0; `bunx` fetches and caches `samospec` on first use.
 
 ```bash
 bunx samospec doctor
+bunx samospec --version   # 0.8.0
 ```
 
-`npx` is not supported — use `bunx` or a global Bun install.
+`npx` is not supported — use `bunx`.
+
+For brevity, the rest of this README writes `samospec` — read it as `bunx samospec`.
 
 ---
 
@@ -52,13 +48,13 @@ bunx samospec doctor
 Three commands, from idea to reviewed spec:
 
 ```bash
-samospec init                                       # scaffolds .samo/ in the current git repo
-samospec new linkrot --idea "Detect dead links in Markdown files"
-samospec iterate linkrot                            # lead drafts → 2 reviewers critique → lead revises → repeat
-samospec publish linkrot                            # promote, commit, push, open PR via gh
+bunx samospec init                                       # scaffolds .samo/ in the current git repo
+bunx samospec new linkrot --idea "Detect dead links in Markdown files"
+bunx samospec iterate linkrot                            # lead drafts → 2 reviewers critique → lead revises → repeat
+bunx samospec publish linkrot                            # promote, commit, push, open PR via gh
 ```
 
-At every step: `samospec status <slug>` prints phase, current version, next-step hint, and last-round summary.
+At every step: `bunx samospec status <slug>` prints phase, current version, next-step hint, and last-round summary.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace the `## Install` section with `## Run`, leading with `bunx samospec` (install-less, no global step required).
- Update the Quickstart commands to use `bunx samospec ...` so a new reader can copy-paste and go without first installing anything.
- Note once that the rest of the README writes `samospec` as shorthand for `bunx samospec`, so command listings stay readable.

## Why

`bunx` already fetches and caches the package on first use, so the global `bun install -g samospec` step was extra friction we were recommending by default. The README now matches the actual happy path. Global install is no longer mentioned — happy to add a one-line "or install globally" pointer if you'd prefer to keep that option visible.

## Test plan

- [ ] Skim rendered README on GitHub: Run section, Quickstart, and Auth blocks read cleanly with `bunx samospec ...` invocations.
- [ ] Confirm no stale `bun install -g samospec` references remain.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CzuaCF9pmT2rTho4fZVaS7)_