### PR TITLE
docs: describe GitHub<->GitLab mirror topology

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,17 @@ samospec — git-native CLI (`samospec`) that turns a rough idea into a reviewed
 
 See `.samo/blueprints/SPEC.md` for the full specification.
 
+## Repo mirroring (GitHub ↔ GitLab)
+
+This project is mirrored between GitHub (`NikolayS/samospec`) and GitLab (`postgres-ai/samospec`). The mirror is **asymmetric by branch**:
+
+- `main` — mirrored **GitLab → GitHub**. GitLab is the source of truth; do not push directly to `main` on GitHub (it will be overwritten on the next sync).
+- Dev branches (`claude/*`, feature branches, etc.) — mirrored **GitHub → GitLab**. Push dev work to GitHub from a Claude Code session, then continue review and merge on GitLab.
+
+Workflow implication: a typical change is *started* on GitHub (Claude Code drafts and pushes the dev branch, opens a draft PR for visibility), then *continued and merged* on GitLab (final review, MR merge into `main`). After the GitLab merge, `main` syncs back down to GitHub on the next mirror tick.
+
+Do not rebase or force-push `main` from either side — the mirror will fight it.
+
 ## Naming
 
 - `samospec` — always lowercase (binary name, repo/package name, config keys, prose)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This project is mirrored between GitHub (`NikolayS/samospec`) and GitLab (`postg
 - `main` — mirrored **GitLab → GitHub**. GitLab is the source of truth; do not push directly to `main` on GitHub (it will be overwritten on the next sync).
 - Dev branches (`claude/*`, feature branches, etc.) — mirrored **GitHub → GitLab**. Push dev work to GitHub from a Claude Code session, then continue review and merge on GitLab.
 
-Workflow implication: a typical change is *started* on GitHub (Claude Code drafts and pushes the dev branch, opens a draft PR for visibility), then *continued and merged* on GitLab (final review, MR merge into `main`). After the GitLab merge, `main` syncs back down to GitHub on the next mirror tick.
+Workflow implication: a typical change is _started_ on GitHub (Claude Code drafts and pushes the dev branch, opens a draft PR for visibility), then _continued and merged_ on GitLab (final review, MR merge into `main`). After the GitLab merge, `main` syncs back down to GitHub on the next mirror tick.
 
 Do not rebase or force-push `main` from either side — the mirror will fight it.
 


### PR DESCRIPTION
## Summary

- Document the asymmetric GitHub ↔ GitLab mirror in `CLAUDE.md`:
  - `main` flows GitLab → GitHub (GitLab is source of truth).
  - Dev branches flow GitHub → GitLab (start in Claude Code on GitHub, continue and merge on GitLab).
- Note that direct pushes to `main` on GitHub will be overwritten, and that `main` must not be force-pushed from either side.

## Test plan

- [ ] Markdown renders correctly on GitHub (heading hierarchy, list bullets).
- [ ] No other content in `CLAUDE.md` changed.

Note: per the new section itself, this is started on GitHub but expected to be merged on GitLab.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGW1PZsJ9Tc6fjnntLjupV)_