### PR TITLE
fix(persona): require job-title-shaped 2-4 word role (samo.team #367)

### DIFF
--- a/src/cli/persona.ts
+++ b/src/cli/persona.ts
@@ -108,13 +108,44 @@ function buildPersonaPrompt(input: { idea: string; explain: boolean }): string {
     ? "Use plain English for any user-facing copy. Avoid engineer-terse " +
       "jargon in prose fields. (Non-technical ICP.)\n\n"
     : "";
+  // Issue #367: the `<skill>` slot must read like a person's job title
+  // on a business card (e.g. "Recipe Developer"), not a descriptive
+  // expertise / task / domain phrase (e.g. "Culinary recipe
+  // development and food science"). Tight shape constraints + a few
+  // good/bad few-shot examples keep the lead from emitting prose that
+  // later has to be cosmetically truncated by the consumer.
   return (
     explainPreamble +
     "You are the samospec lead. Given a rough idea, propose a single " +
-    'expert persona in the EXACT form `Veteran "<skill>" expert`. ' +
-    "Examples:\n" +
-    '  - Veteran "CLI software engineer" expert\n' +
-    '  - Veteran "distributed systems / SRE specialist" expert\n\n' +
+    'expert persona in the EXACT form `Veteran "<skill>" expert`.\n\n' +
+    "SHAPE OF `<skill>` (strict):\n" +
+    "  - 2–4 words, Title Case.\n" +
+    "  - A job title / role label — what would be printed on this " +
+    "person's business card. Answer the question 'What is this " +
+    "person's title?', NOT 'What is their area of expertise?'.\n" +
+    "  - Noun phrase ending in a person-noun such as: Developer, " +
+    "Designer, Manager, Advisor, Counselor, Strategist, Analyst, " +
+    "Architect, Engineer, Consultant, Scientist, Specialist, Editor, " +
+    "Coach, Lead.\n" +
+    "  - NEVER a descriptive expertise / task / domain phrase. Forbid " +
+    "anything ending in -planning, -development, -analysis, -science " +
+    "(when used as a field name, e.g. 'food science' is OK ONLY if " +
+    "preceded by a person-noun like 'Food Scientist'), -engineering " +
+    "(same caveat), or generic gerunds describing what the person " +
+    "does rather than who they are.\n\n" +
+    "GOOD examples (right shape):\n" +
+    '  - Veteran "Recipe Developer" expert\n' +
+    '  - Veteran "Food Scientist" expert\n' +
+    '  - Veteran "Academic Advisor" expert\n' +
+    '  - Veteran "College Counselor" expert\n' +
+    '  - Veteran "CLI Software Engineer" expert\n\n' +
+    "BAD examples (wrong shape — do NOT emit these):\n" +
+    '  - Veteran "Culinary recipe development and food science" ' +
+    "expert (too long, describes a task not a person)\n" +
+    '  - Veteran "Higher-education academic planning" expert ' +
+    "(reads as a domain/task, not a title)\n" +
+    '  - Veteran "Distributed systems and reliability" expert ' +
+    "(missing person-noun)\n\n" +
     "Respond ONLY with a JSON object:\n" +
     '  { "persona": "Veteran \\"<skill>\\" expert", "rationale": "..." }\n' +
     "Do not wrap in code fences. The skill must be non-empty and must " +

--- a/tests/cli/persona.test.ts
+++ b/tests/cli/persona.test.ts
@@ -405,6 +405,130 @@ describe("proposePersona — --explain flag (SPEC §4 secondary ICP)", () => {
   });
 });
 
+// ---------- job-title shape guidance (#367) ----------
+
+describe("proposePersona — job-title shape guidance (#367)", () => {
+  test("prompt asks for a 2-4 word job-title-shaped role", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "Recipe Developer" expert',
+        rationale: "r",
+      }),
+    ]);
+    await proposePersona(
+      {
+        idea: "idea",
+        explain: false,
+        subscriptionAuth: false,
+        choice: { kind: "accept" },
+      },
+      adapter,
+    );
+    const prompt = adapter.asks[0].prompt;
+    // Must mention the 2-4 word constraint.
+    expect(prompt).toMatch(/2[–—-]4\s+words/i);
+    // Must instruct Title Case.
+    expect(prompt.toLowerCase()).toContain("title case");
+    // Must explicitly name "job title" / "role" framing.
+    expect(prompt.toLowerCase()).toMatch(/job title|role label|business card/);
+  });
+
+  test("prompt names person-noun endings (Developer, Designer, etc.)", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "Recipe Developer" expert',
+        rationale: "r",
+      }),
+    ]);
+    await proposePersona(
+      {
+        idea: "idea",
+        explain: false,
+        subscriptionAuth: false,
+        choice: { kind: "accept" },
+      },
+      adapter,
+    );
+    const prompt = adapter.asks[0].prompt;
+    // At least three of these person-nouns should be enumerated as
+    // accepted endings.
+    const personNouns = [
+      "Developer",
+      "Designer",
+      "Manager",
+      "Advisor",
+      "Counselor",
+      "Strategist",
+      "Analyst",
+      "Architect",
+      "Engineer",
+      "Consultant",
+    ];
+    const hits = personNouns.filter((n) => prompt.includes(n));
+    expect(hits.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("prompt forbids descriptive task / domain phrases", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "Recipe Developer" expert',
+        rationale: "r",
+      }),
+    ]);
+    await proposePersona(
+      {
+        idea: "idea",
+        explain: false,
+        subscriptionAuth: false,
+        choice: { kind: "accept" },
+      },
+      adapter,
+    );
+    const prompt = adapter.asks[0].prompt;
+    const lower = prompt.toLowerCase();
+    // Must call out the forbidden -ing / -ment / -ence task-shaped
+    // suffixes by listing some of them verbatim.
+    const badEndings = [
+      "planning",
+      "development",
+      "analysis",
+      "science",
+      "engineering",
+    ];
+    const flagged = badEndings.filter((s) => lower.includes(s));
+    expect(flagged.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("prompt includes few-shot good/bad examples for shape", async () => {
+    const adapter = makeScriptedAskAdapter([
+      JSON.stringify({
+        persona: 'Veteran "Recipe Developer" expert',
+        rationale: "r",
+      }),
+    ]);
+    await proposePersona(
+      {
+        idea: "idea",
+        explain: false,
+        subscriptionAuth: false,
+        choice: { kind: "accept" },
+      },
+      adapter,
+    );
+    const prompt = adapter.asks[0].prompt;
+    // Good examples: short job-title-shaped roles (canonically wrapped
+    // in the Veteran "<skill>" expert form).
+    expect(prompt).toContain('Veteran "Recipe Developer" expert');
+    expect(prompt).toContain('Veteran "Food Scientist" expert');
+    // Bad examples: descriptive task/domain phrases that the user
+    // explicitly does NOT want.
+    expect(prompt).toContain("Culinary recipe development and food science");
+    expect(prompt.toLowerCase()).toContain(
+      "higher-education academic planning",
+    );
+  });
+});
+
 // ---------- effort max policy ----------
 
 describe("proposePersona — lead effort policy (SPEC §11)", () => {


### PR DESCRIPTION
## Summary
- Tighten the persona-proposal prompt in `src/cli/persona.ts` so the lead emits **short job-title-shaped role names** (2–4 words, Title Case, noun phrase ending in a person-noun) instead of long descriptive expertise / task / domain phrases.
- Add explicit person-noun enumeration (Developer, Designer, Manager, Advisor, Counselor, Strategist, Analyst, Architect, Engineer, Consultant, Scientist, Specialist, Editor, Coach, Lead).
- Add good/bad few-shot examples + "business card" framing ("answer 'What is this person's title?', NOT 'What is their area of expertise?'").

## Why
Reported via samo.team#367 (GitLab). On prod 2026-05-14 the lead produced things like:
- `"Culinary recipe development and food science"` → after the samo.team display truncation became `"Culinary recipe development and food"` (cosmetically fixed in samo.team!305, but the root cause is upstream — that shape should never be emitted).
- `"Higher-education academic planning"` — wrong shape, reads as a TASK/DOMAIN.

Expected post-fix: `"Recipe Developer"`, `"Food Scientist"`, `"Academic Advisor"`, `"College Counselor"` — all fit the samo.team 40-char display budget without truncation.

## Test plan
- [x] `bun test tests/cli/persona.test.ts` — 24 pass / 0 fail (+4 new tests)
- [x] `bun test` (full suite) — 1656 pass / 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx eslint src/cli/persona.ts tests/cli/persona.test.ts` — clean
- [x] `bunx prettier --check` — clean
- [ ] Manual sanity: run `samospec new` with a non-technical idea (e.g. cooking app) and confirm the proposed persona reads like a job title

## New tests added (4)
1. `prompt asks for a 2-4 word job-title-shaped role` — checks "2–4 words", "title case", and "job title | role label | business card" framing.
2. `prompt names person-noun endings` — checks ≥3 of the canonical person-nouns are listed.
3. `prompt forbids descriptive task / domain phrases` — checks ≥3 of the bad endings (planning, development, analysis, science, engineering) are explicitly called out.
4. `prompt includes few-shot good/bad examples for shape` — checks the canonical good examples (Recipe Developer, Food Scientist) and the verbatim bad examples from prod (Culinary recipe development…, Higher-education academic planning) are present.

## Notes
- No breaking API changes; only the natural-language prompt body changed.
- The PERSONA_FORM_RE / `formatPersonaString` / `extractSkill` contracts are unchanged.
- The samo.team `normalizePersonaSkill` post-processing strip stays as defense-in-depth.

Refs: samo.team#367 (https://gitlab.com/NikolayS/samo.team/-/issues/367)