### PR TITLE
fix(cli): remove session wall-clock kill (samo.team #415, #424)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,9 +114,11 @@ const USAGE =
   wrapList(BASELINE_SECTION_NAMES, "      ", 78) +
   ".\n" +
   "  --max-session-wall-clock-ms <ms>\n" +
-  "      Cap total session wall-clock (positive integer ms). Defaults to\n" +
-  "      budget.max_session_wall_clock_minutes in config.json, or 600000\n" +
-  "      (10 min). On cap: exit 4 with reason `session-wall-clock`.\n" +
+  "      Deprecated no-op. The session wall-clock kill was removed per\n" +
+  "      Rule 10 (no wall-clock kill of dev LLM runs) and samo.team\n" +
+  "      #415 + #424. The flag is still accepted (positive integer ms)\n" +
+  "      for backward compatibility with existing scripts; the value is\n" +
+  "      ignored. Allowed stop signals: inactivity heartbeat + SIGTERM.\n" +
   "  --verbose\n" +
   "      Emit per-phase and per-file diagnostics on stderr (stdout stays concise).\n" +
   "  --yes, --accept-persona\n" +
@@ -146,8 +148,10 @@ const USAGE =
   "  --verbose\n" +
   "      Alias / no-op — iterate is verbose by default (see --quiet).\n" +
   "  --max-session-wall-clock-ms <ms>\n" +
-  "      Cap the review-loop session wall-clock (positive integer ms). On cap:\n" +
-  "      exit 4 with reason `session-wall-clock`.\n" +
+  "      Deprecated no-op. The session wall-clock kill was removed per\n" +
+  "      Rule 10 (no wall-clock kill of dev LLM runs) and samo.team\n" +
+  "      #415 + #424. The flag is still accepted (positive integer ms)\n" +
+  "      for backward compatibility; the value is ignored.\n" +
   "  --on-dirty <incorporate|overwrite|abort>\n" +
   "      Answer the uncommitted-edits prompt without reading stdin. Required\n" +
   "      when stdin is not a TTY and `.samo/spec/<slug>/` has dirty edits (#114).\n" +

--- a/src/cli/iterate.ts
+++ b/src/cli/iterate.ts
@@ -119,11 +119,17 @@ import {
 const DEFAULT_MAX_ROUNDS = 10 as const;
 const DEFAULT_WALL_CLOCK_MS = 240 * 60 * 1000; // 240 minutes
 const DEFAULT_MAX_WALL_CLOCK_MIN = 240;
-// Issue #91: session wall-clock cap default for `samospec iterate`,
-// mirroring `samospec new`. Configurable via
-// `budget.max_session_wall_clock_minutes` in `.samo/config.json` or
-// overridden per-call via `IterateInput.maxSessionWallClockMs`.
-const DEFAULT_SESSION_WALL_CLOCK_MS = 10 * 60 * 1_000;
+// NOTE: the session wall-clock cap (#91 /
+// DEFAULT_SESSION_WALL_CLOCK_MS) was removed per Rule 10 ("nothing
+// kills a dev LLM run on the wall clock"). It produced exit code 4 +
+// a `session-wall-clock` reason which the samo.team UI rendered as an
+// alarming "Run ended / timed out" banner even while the underlying
+// LLM was still making progress (samo.team #415, #424). The
+// `maxSessionWallClockMs` field on `IterateInput` and the
+// `--max-session-wall-clock-ms` CLI flag are retained as ignored
+// no-ops for backward compatibility. The SPEC §11 "one more round
+// fits" gate (`maxWallClockMs`) is unaffected — that's a
+// between-round boundary check, not a mid-call kill.
 
 // ---------- types ----------
 
@@ -223,15 +229,15 @@ export interface IterateInput {
    */
   readonly progress?: ProgressOptions;
   /**
-   * Issue #91: session wall-clock cap in milliseconds. Mirrors the
-   * `--max-session-wall-clock-ms` semantics in `samospec new`: when the
-   * total elapsed time since `runIterate()` entry exceeds this value,
-   * the current round / seat call is preempted and `runIterate` returns
-   * exit 4 with a `session-wall-clock` message in stderr. Falls back to
-   * `budget.max_session_wall_clock_minutes` in `.samo/config.json`, then
-   * to `DEFAULT_SESSION_WALL_CLOCK_MS` (10 min). Independent of the
-   * SPEC §11 "one more round fits" guard (`maxWallClockMs`) — the two
-   * caps compose: whichever is tighter fires first.
+   * Deprecated no-op (#91 / samo.team #415, #424). The session
+   * wall-clock cap was removed per Rule 10 ("nothing kills a dev LLM
+   * run on the wall clock"). The field is retained on the input type
+   * so existing callers keep type-checking, but the value is ignored
+   * — the CLI no longer kills a run on its own wall clock. Allowed
+   * stop signals from here on: inactivity heartbeat + parent SIGTERM
+   * (user cancel). The SPEC §11 "one more round fits" gate
+   * (`maxWallClockMs`) remains: it's a between-round boundary check,
+   * not a mid-call kill.
    */
   readonly maxSessionWallClockMs?: number;
 }
@@ -373,14 +379,14 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
     const sessionStartedMs = input.sessionStartedAtMs ?? Date.parse(input.now);
     const nowMsFn = (): number => input.nowMs ?? Date.now();
 
-    // Issue #91: session wall-clock guard. The live-repro showed a
-    // stuck revise at round 7 running 1h 41m under a 40-min cap; this
-    // deadline preempts any round (or seat call) that runs past the
-    // cap. Uses a real wall clock (`Date.now()`) — cannot be silenced
-    // by tests that freeze `input.nowMs`, so the hanging-adapter tests
-    // in `tests/cli/iterate-wall-clock.test.ts` actually preempt.
-    const sessionWallClockStartMs = Date.now();
-    const sessionWallClockLimitMs = resolveSessionWallClockMs(input);
+    // Wall-clock kill removed (Rule 10 / samo.team #415, #424). The
+    // previous #91 guard (`sessionWallClockStartMs` /
+    // `sessionWallClockLimitMs` + `withSessionDeadline` wrapper) killed
+    // mid-round on a real wall clock and produced exit 4 with a
+    // `session-wall-clock` reason. The CLI no longer enforces that
+    // cap — adapter calls run to completion; the only legitimate stop
+    // signals are inactivity heartbeat (handled by the progress
+    // reporter, non-killing) and parent SIGTERM (user cancel).
 
     // Initial state tracking.
     let currentState: State = state;
@@ -452,47 +458,14 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
           });
         }
 
-        // Issue #91: session wall-clock guard BEFORE each round starts.
-        // Independent from the SPEC §11 "one more round fits" gate above
-        // — this cap is the user-facing `--max-session-wall-clock-ms`
-        // (or config-derived) budget, and must fire even if per-call
-        // timeouts would also let another round fit.
-        const sessionElapsedMs = Date.now() - sessionWallClockStartMs;
-        if (sessionElapsedMs >= sessionWallClockLimitMs) {
-          const leadTerm: State = {
-            ...currentState,
-            round_state: "lead_terminal",
-            updated_at: nowIso(),
-            exit: {
-              code: 4,
-              reason: "lead-terminal:wall_clock",
-              round_index: currentState.round_index,
-            },
-          };
-          writeState(paths.statePath, leadTerm);
-          error(
-            `samospec: session-wall-clock exceeded before round ` +
-              `${String(roundIndex)} (${String(sessionElapsedMs)}ms ` +
-              `elapsed, limit ${String(sessionWallClockLimitMs)}ms). ` +
-              `Restart with a larger --max-session-wall-clock-ms or ` +
-              `increase budget.max_session_wall_clock_minutes.`,
-          );
-          finalizeBookkeeping({
-            cwd: input.cwd,
-            slug: input.slug,
-            statePath: paths.statePath,
-            tldrPath: paths.tldrPath,
-            roundIndex: leadTerm.round_index,
-          });
-          return {
-            exitCode: 4,
-            stdout: lines.join("\n"),
-            stderr: `${errLines.join("\n")}\n`,
-            roundsRun: Math.max(0, roundsRun - 1),
-            finalVersion: currentState.version,
-            stopReason: "lead-terminal",
-          };
-        }
+        // Pre-round session-wall-clock kill removed (Rule 10 /
+        // samo.team #415, #424). Was a hard `Date.now()` deadline
+        // check that wrote `lead-terminal:wall_clock` and exited 4 —
+        // now intentionally absent. The SPEC §11
+        // `shouldStartNextRound` gate above (between-round budget
+        // boundary check) is preserved; this section only removes the
+        // separate user-facing session cap that hard-killed runs in
+        // progress.
 
         // Manual-edit detection BEFORE each round.
         const report = detectManualEdits(input.slug, {
@@ -616,81 +589,34 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
         // the outer `SessionWallClockError`, collapsing the two into
         // the same `wall_clock` exit reason and losing the specific
         // `revise_timeout` diagnostic.
-        let roundOutcome: Awaited<ReturnType<typeof runRound>>;
-        try {
-          roundOutcome = await withSessionDeadline(
-            runRound({
-              now: input.now,
-              nowFn: (): string => new Date(nowMsFn()).toISOString(),
-              roundNumber: roundIndex,
-              dirs,
-              specText: currentSpec,
-              decisionsHistory,
-              adapters: wrappedAdapters,
-              critiqueTimeoutMs: callTimeouts.criticA_ms,
-              reviseTimeoutMs: callTimeouts.revise_ms,
-              remainingSessionMsFn: (): number =>
-                sessionWallClockLimitMs -
-                (Date.now() - sessionWallClockStartMs),
-              ...(manualEditDirective !== undefined
-                ? { manualEditDirective }
-                : {}),
-              ...(ideaForRound !== undefined
-                ? { idea: ideaForRound, slug: input.slug }
-                : {}),
-            }),
-            `round_${String(roundIndex)}`,
-            sessionWallClockStartMs,
-            sessionWallClockLimitMs,
-          );
-        } catch (err) {
-          if (err instanceof SessionWallClockError) {
-            // #91: the cap fired mid-round. Persist a lead_terminal
-            // state with a wall-clock sub-reason, scoop any untracked
-            // round artefacts into a finalize commit, and surface the
-            // `session-wall-clock` token in stderr so scripts can
-            // pattern-match on it (matches src/cli/new.ts verbiage).
-            const leadTerm: State = {
-              ...currentState,
-              round_state: "lead_terminal",
-              round_index: roundIndex - 1,
-              updated_at: nowIso(),
-              exit: {
-                code: 4,
-                reason: "lead-terminal:wall_clock",
-                round_index: roundIndex,
-              },
-            };
-            writeState(paths.statePath, leadTerm);
-            error(
-              `samospec: session-wall-clock exceeded during round ` +
-                `${String(roundIndex)} (${String(err.elapsedMs)}ms ` +
-                `elapsed, limit ${String(err.limitMs)}ms). Restart with ` +
-                `a larger --max-session-wall-clock-ms or increase ` +
-                `budget.max_session_wall_clock_minutes.`,
-            );
-            finalizeBookkeeping({
-              cwd: input.cwd,
-              slug: input.slug,
-              statePath: paths.statePath,
-              tldrPath: paths.tldrPath,
-              roundIndex: leadTerm.round_index,
-              // Scoop any round-N artefacts (reviews/rNN/) created
-              // before the cap tripped so the tree is clean on exit.
-              // Same pattern as the existing lead_terminal branch.
-              extraPaths: [dirs.roundDir],
-            });
-            return {
-              exitCode: 4,
-              stdout: lines.join("\n"),
-              stderr: `${errLines.join("\n")}\n`,
-              roundsRun,
-              finalVersion: currentState.version,
-              stopReason: "lead-terminal",
-            };
-          }
-          throw err;
-        }
+        // Wall-clock kill removed (Rule 10 / samo.team #415, #424).
+        // The previous `withSessionDeadline(runRound(...), …)` wrapper
+        // would throw `SessionWallClockError` mid-round and exit 4 with
+        // a `session-wall-clock` reason; that path is gone. `runRound`
+        // now executes to completion (or until the per-call timeouts
+        // inside it, which are SPEC §7 retries — not a wall-clock
+        // kill of the session). `remainingSessionMsFn` is no longer
+        // threaded because there is no session budget to clamp
+        // against; `resolveEffectiveReviseTimeout` in
+        // `src/loop/round.ts` falls back to the configured value.
+        const roundOutcome: Awaited<ReturnType<typeof runRound>> =
+          await runRound({
+            now: input.now,
+            nowFn: (): string => new Date(nowMsFn()).toISOString(),
+            roundNumber: roundIndex,
+            dirs,
+            specText: currentSpec,
+            decisionsHistory,
+            adapters: wrappedAdapters,
+            critiqueTimeoutMs: callTimeouts.criticA_ms,
+            reviseTimeoutMs: callTimeouts.revise_ms,
+            ...(manualEditDirective !== undefined
+              ? { manualEditDirective }
+              : {}),
+            ...(ideaForRound !== undefined
+              ? { idea: ideaForRound, slug: input.slug }
+              : {}),
+          });
 
         // Persist state at round boundary (round_state tracking).
         // The round started in "planned" then advanced to "running" inside
@@ -1144,102 +1070,10 @@ export async function runIterate(input: IterateInput): Promise<IterateResult> {
 
 // ---------- helpers ----------
 
-// ---------- session wall-clock guard (#91) ----------
-
-/**
- * Thrown by `withSessionDeadline()` when the iterate session wall-clock
- * cap is exceeded. Mirrors `SessionWallClockError` in `src/cli/new.ts`
- * so both subcommands surface the same `session-wall-clock` token in
- * stderr and exit with code 4.
- */
-class SessionWallClockError extends Error {
-  readonly phase: string;
-  readonly elapsedMs: number;
-  readonly limitMs: number;
-  constructor(phase: string, elapsedMs: number, limitMs: number) {
-    super(
-      `session-wall-clock: ${phase} exceeded ${String(limitMs)}ms limit ` +
-        `(elapsed ${String(elapsedMs)}ms)`,
-    );
-    this.name = "SessionWallClockError";
-    this.phase = phase;
-    this.elapsedMs = elapsedMs;
-    this.limitMs = limitMs;
-  }
-}
-
-/**
- * Race `promise` against a deadline derived from `startMs + limitMs`.
- * If the deadline fires first, throws `SessionWallClockError`. Used at
- * every seat call and between rounds so a hanging reviewer cannot run
- * past the cap (see #91 live-repro: 40 min cap, 1h 41m runtime).
- */
-async function withSessionDeadline<T>(
-  promise: Promise<T>,
-  phase: string,
-  startMs: number,
-  limitMs: number,
-): Promise<T> {
-  const remaining = limitMs - (Date.now() - startMs);
-  if (remaining <= 0) {
-    throw new SessionWallClockError(phase, Date.now() - startMs, limitMs);
-  }
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new SessionWallClockError(phase, Date.now() - startMs, limitMs));
-    }, remaining);
-    promise.then(
-      (v) => {
-        clearTimeout(timer);
-        resolve(v);
-      },
-      (e: unknown) => {
-        clearTimeout(timer);
-        reject(e instanceof Error ? e : new Error(String(e)));
-      },
-    );
-  });
-}
-
-/**
- * Resolve the session wall-clock limit (ms) for `runIterate`:
- *   1. `input.maxSessionWallClockMs` (explicit override, e.g. from
- *      `--max-session-wall-clock-ms <ms>` on the CLI).
- *   2. `budget.max_session_wall_clock_minutes` in `.samo/config.json`.
- *   3. `DEFAULT_SESSION_WALL_CLOCK_MS` (10 min).
- *
- * Kept local to `iterate.ts` so changes to `new.ts`'s config layout
- * cannot silently mutate iterate's cap; the two subcommands share the
- * same schema but resolve it independently.
- */
-function resolveSessionWallClockMs(input: IterateInput): number {
-  if (typeof input.maxSessionWallClockMs === "number") {
-    return input.maxSessionWallClockMs;
-  }
-  try {
-    const configPath = path.join(input.cwd, ".samo", "config.json");
-    if (existsSync(configPath)) {
-      const raw = readFileSync(configPath, "utf8");
-      const cfg = JSON.parse(raw) as Record<string, unknown>;
-      const budget = cfg["budget"];
-      if (
-        typeof budget === "object" &&
-        budget !== null &&
-        !Array.isArray(budget)
-      ) {
-        const minutes = (budget as Record<string, unknown>)[
-          "max_session_wall_clock_minutes"
-        ];
-        if (typeof minutes === "number" && minutes > 0) {
-          return Math.round(minutes * 60 * 1_000);
-        }
-      }
-    }
-  } catch {
-    // config unreadable — fall through to default.
-  }
-  return DEFAULT_SESSION_WALL_CLOCK_MS;
-}
+// NOTE: The session wall-clock guard (#91 — `SessionWallClockError`,
+// `withSessionDeadline`, `resolveSessionWallClockMs`) was removed per
+// Rule 10 / samo.team #415, #424. See header constants comment for
+// rationale.
 
 function ensureTrailingNewline(s: string): string {
   return s.endsWith("\n") ? s : `${s}\n`;

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -98,10 +98,16 @@ import {
 
 const DEFAULT_MAX_WALL_CLOCK_MIN = 240;
 
-// Session wall-clock cap: 10 minutes by default (#81).
-// Configurable via budget.max_session_wall_clock_minutes in config.json,
-// or overridden per-call via RunNewInput.maxSessionWallClockMs.
-const DEFAULT_SESSION_WALL_CLOCK_MS = 10 * 60 * 1_000;
+// NOTE: the session wall-clock cap (#81 / DEFAULT_SESSION_WALL_CLOCK_MS)
+// was removed per Rule 10 ("nothing kills a dev LLM run on the wall
+// clock"). It produced exit code 4 + a `session-wall-clock` reason which
+// the samo.team UI rendered as an alarming "Run ended / timed out"
+// banner even while the underlying LLM was still making progress
+// (samo.team #415, #424). The `maxSessionWallClockMs` field on
+// `RunNewInput` and the `--max-session-wall-clock-ms` CLI flag are
+// retained as ignored no-ops for backward compatibility with existing
+// callers. Allowed stop signals from here on: inactivity heartbeat +
+// user-cancel (SIGTERM from the parent).
 
 const V01_VERSION = "0.1.0" as const;
 
@@ -169,11 +175,11 @@ export interface RunNewInput {
    */
   readonly reviewerAAdapter?: Adapter;
   /**
-   * Session wall-clock cap in milliseconds (#81). When the total elapsed
-   * time since runNew() entry exceeds this value, the current phase is
-   * preempted and runNew() returns exit 4 with a "session-wall-clock"
-   * message. Falls back to budget.max_session_wall_clock_minutes from
-   * config.json, then to DEFAULT_SESSION_WALL_CLOCK_MS (10 min).
+   * Deprecated no-op (#81 / samo.team #415, #424). The session
+   * wall-clock cap was removed per Rule 10. The field is retained on
+   * the input type so existing callers (samo.team, scripts, tests)
+   * keep type-checking, but the value is ignored — the CLI no longer
+   * kills a run on the wall clock for any reason.
    */
   readonly maxSessionWallClockMs?: number;
   /**
@@ -184,91 +190,6 @@ export interface RunNewInput {
    * Default (false/omitted) preserves the legacy stdout-as-summary shape.
    */
   readonly suppressStdout?: boolean;
-}
-
-// ---------- session wall-clock guard (#81) ----------
-
-/** Thrown by withDeadline() when the session wall-clock cap is exceeded. */
-class SessionWallClockError extends Error {
-  readonly phase: string;
-  readonly elapsedMs: number;
-  readonly limitMs: number;
-  constructor(phase: string, elapsedMs: number, limitMs: number) {
-    super(
-      `session-wall-clock: ${phase} exceeded ${String(limitMs)}ms limit ` +
-        `(elapsed ${String(elapsedMs)}ms)`,
-    );
-    this.name = "SessionWallClockError";
-    this.phase = phase;
-    this.elapsedMs = elapsedMs;
-    this.limitMs = limitMs;
-  }
-}
-
-/**
- * Race `promise` against a deadline derived from `startMs + limitMs`.
- * If the deadline fires first, throws `SessionWallClockError`.
- */
-async function withDeadline<T>(
-  promise: Promise<T>,
-  phase: string,
-  startMs: number,
-  limitMs: number,
-): Promise<T> {
-  const remaining = limitMs - (Date.now() - startMs);
-  if (remaining <= 0) {
-    throw new SessionWallClockError(phase, Date.now() - startMs, limitMs);
-  }
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new SessionWallClockError(phase, Date.now() - startMs, limitMs));
-    }, remaining);
-    promise.then(
-      (v) => {
-        clearTimeout(timer);
-        resolve(v);
-      },
-      (e: unknown) => {
-        clearTimeout(timer);
-        reject(e instanceof Error ? e : new Error(String(e)));
-      },
-    );
-  });
-}
-
-/**
- * Resolve the session wall-clock limit (ms) from:
- * 1. input.maxSessionWallClockMs (explicit override)
- * 2. budget.max_session_wall_clock_minutes in config.json
- * 3. DEFAULT_SESSION_WALL_CLOCK_MS (10 min)
- */
-function resolveSessionWallClockMs(input: RunNewInput): number {
-  if (typeof input.maxSessionWallClockMs === "number") {
-    return input.maxSessionWallClockMs;
-  }
-  try {
-    const configPath = path.join(input.cwd, ".samo", "config.json");
-    if (existsSync(configPath)) {
-      const raw = readFileSync(configPath, "utf8");
-      const cfg = JSON.parse(raw) as Record<string, unknown>;
-      const budget = cfg["budget"];
-      if (
-        typeof budget === "object" &&
-        budget !== null &&
-        !Array.isArray(budget)
-      ) {
-        const minutes = (budget as Record<string, unknown>)[
-          "max_session_wall_clock_minutes"
-        ];
-        if (typeof minutes === "number" && minutes > 0) {
-          return Math.round(minutes * 60 * 1_000);
-        }
-      }
-    }
-  } catch {
-    // config unreadable — fall through to default.
-  }
-  return DEFAULT_SESSION_WALL_CLOCK_MS;
 }
 
 // ---------- CLI entry ----------
@@ -290,9 +211,11 @@ export async function runNew(
     noticeSink.push(line);
   };
 
-  // Session wall-clock guard (#81): track start time and cap.
+  // Wall-clock kill removed (Rule 10 / samo.team #415, #424). The
+  // `sessionStartMs` timestamp is retained for `--verbose` elapsed-time
+  // bookkeeping only; nothing checks it against a deadline. Inactivity
+  // heartbeat + parent SIGTERM are the only legitimate stop signals.
   const sessionStartMs = Date.now();
-  const sessionLimitMs = resolveSessionWallClockMs(input);
 
   // Issue #77: `--verbose` — when on, emit targeted diagnostic lines to
   // **stderr** (matching `iterate`'s progress-stream convention). stdout
@@ -545,37 +468,20 @@ export async function runNew(
     const subAuth = await resolveSubscriptionAuth(adapter);
     let persona: PersonaProposal;
     try {
-      persona = await withDeadline(
-        proposePersonaInteractive(
-          {
-            idea: input.idea,
-            explain: input.explain,
-            subscriptionAuth: subAuth,
-            onNotice: notice,
-            resolver: input.resolvers.persona,
-          },
-          adapter,
-        ),
-        "persona",
-        sessionStartMs,
-        sessionLimitMs,
+      // Wall-clock deadline removed (Rule 10 / samo.team #415, #424).
+      // The adapter call runs to completion; only legitimate stops are
+      // an inactivity heartbeat or parent SIGTERM (handled outside).
+      persona = await proposePersonaInteractive(
+        {
+          idea: input.idea,
+          explain: input.explain,
+          subscriptionAuth: subAuth,
+          onNotice: notice,
+          resolver: input.resolvers.persona,
+        },
+        adapter,
       );
     } catch (err) {
-      if (err instanceof SessionWallClockError) {
-        state = { ...state, round_state: "lead_terminal" };
-        state.updated_at = input.now;
-        writeState(statePath, state);
-        errors.push(
-          `samospec: session-wall-clock exceeded at persona phase ` +
-            `(${String(err.elapsedMs)}ms elapsed, limit ${String(err.limitMs)}ms). ` +
-            `Restart with --force or increase budget.max_session_wall_clock_minutes.`,
-        );
-        return {
-          exitCode: 4,
-          stdout: lines.join("\n"),
-          stderr: buildStderr(),
-        };
-      }
       if (err instanceof PersonaTerminalError) {
         state = { ...state, round_state: "lead_terminal" };
         state.updated_at = input.now;
@@ -651,41 +557,22 @@ export async function runNew(
     const interviewPath = path.join(slugDir, "interview.json");
     let interview: InterviewResult;
     try {
-      interview = await withDeadline(
-        runInterview(
-          {
-            slug: input.slug,
-            persona: persona.persona,
-            explain: input.explain,
-            subscriptionAuth: subAuth,
-            onQuestion: input.resolvers.question,
-            onNotice: notice,
-            outputPath: interviewPath,
-            now: input.now,
-            idea: input.idea,
-          },
-          adapter,
-        ),
-        "interview",
-        sessionStartMs,
-        sessionLimitMs,
+      // Wall-clock deadline removed (Rule 10 / samo.team #415, #424).
+      interview = await runInterview(
+        {
+          slug: input.slug,
+          persona: persona.persona,
+          explain: input.explain,
+          subscriptionAuth: subAuth,
+          onQuestion: input.resolvers.question,
+          onNotice: notice,
+          outputPath: interviewPath,
+          now: input.now,
+          idea: input.idea,
+        },
+        adapter,
       );
     } catch (err) {
-      if (err instanceof SessionWallClockError) {
-        state = { ...state, round_state: "lead_terminal" };
-        state.updated_at = input.now;
-        writeState(statePath, state);
-        errors.push(
-          `samospec: session-wall-clock exceeded at interview phase ` +
-            `(${String(err.elapsedMs)}ms elapsed, limit ${String(err.limitMs)}ms). ` +
-            `Restart with --force or increase budget.max_session_wall_clock_minutes.`,
-        );
-        return {
-          exitCode: 4,
-          stdout: lines.join("\n"),
-          stderr: buildStderr(),
-        };
-      }
       if (err instanceof InterviewTerminalError) {
         state = { ...state, round_state: "lead_terminal" };
         state.updated_at = input.now;
@@ -724,41 +611,22 @@ export async function runNew(
 
     let draft;
     try {
-      draft = await withDeadline(
-        authorDraft(
-          {
-            slug: input.slug,
-            idea: input.idea,
-            persona: persona.persona,
-            interview,
-            contextChunks: chunks,
-            explain: input.explain,
-            ...(input.skipSections !== undefined
-              ? { skipSections: input.skipSections }
-              : {}),
-          },
-          adapter,
-        ),
-        "draft",
-        sessionStartMs,
-        sessionLimitMs,
+      // Wall-clock deadline removed (Rule 10 / samo.team #415, #424).
+      draft = await authorDraft(
+        {
+          slug: input.slug,
+          idea: input.idea,
+          persona: persona.persona,
+          interview,
+          contextChunks: chunks,
+          explain: input.explain,
+          ...(input.skipSections !== undefined
+            ? { skipSections: input.skipSections }
+            : {}),
+        },
+        adapter,
       );
     } catch (err) {
-      if (err instanceof SessionWallClockError) {
-        state = { ...state, round_state: "lead_terminal" };
-        state.updated_at = input.now;
-        writeState(statePath, state);
-        errors.push(
-          `samospec: session-wall-clock exceeded at draft phase ` +
-            `(${String(err.elapsedMs)}ms elapsed, limit ${String(err.limitMs)}ms). ` +
-            `Restart with --force or increase budget.max_session_wall_clock_minutes.`,
-        );
-        return {
-          exitCode: 4,
-          stdout: lines.join("\n"),
-          stderr: buildStderr(),
-        };
-      }
       if (err instanceof DraftTerminalError) {
         state = { ...state, round_state: "lead_terminal" };
         state.updated_at = input.now;

--- a/tests/cli/iterate-wall-clock.test.ts
+++ b/tests/cli/iterate-wall-clock.test.ts
@@ -203,7 +203,11 @@ describe("iterate parser — unknown --flag rejected (#91)", () => {
   });
 });
 
-// ---------- 3. Runtime: hanging reviewer honors the cap ----------
+// ---------- 3. Runtime: hanging reviewer is NOT preempted ----------
+
+// Pre-#415 this section asserted that `runIterate` killed a hanging
+// reviewer on the session wall-clock cap. That kill was removed per
+// Rule 10 and samo.team #415 + #424; the assertion shape is inverted.
 
 function makeHangingCritiqueAdapter(): Adapter {
   const base = createFakeAdapter({});
@@ -216,8 +220,30 @@ function makeHangingCritiqueAdapter(): Adapter {
   };
 }
 
-describe("runIterate — maxSessionWallClockMs caps a hanging round (#91)", () => {
-  test("hanging critique is preempted; exit 4 within ~2x cap; stderr contains session-wall-clock", async () => {
+/** Race a promise against a real-time deadline. */
+async function raceDeadline<T>(
+  p: Promise<T>,
+  deadlineMs: number,
+): Promise<{ resolved: true; value: T } | { resolved: false }> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolve({ resolved: false });
+    }, deadlineMs);
+    p.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve({ resolved: true, value });
+      },
+      () => {
+        clearTimeout(timer);
+        resolve({ resolved: false });
+      },
+    );
+  });
+}
+
+describe("runIterate — maxSessionWallClockMs is a deprecated no-op (#91 / samo.team #415, #424)", () => {
+  test("hanging critique is NOT preempted by maxSessionWallClockMs", async () => {
     const slug = "wc-slug";
     seedSpec(tmp, slug);
 
@@ -233,35 +259,25 @@ describe("runIterate — maxSessionWallClockMs caps a hanging round (#91)", () =
     const reviewerA = makeHangingCritiqueAdapter();
     const reviewerB = makeHangingCritiqueAdapter();
 
-    const capMs = 2_000;
-    const startMs = Date.now();
-    const res = await runIterate({
+    const capMs = 1_500;
+    const runPromise = runIterate({
       cwd: tmp,
       slug,
       now: "2026-04-19T12:00:00Z",
       resolvers: ACCEPT_RESOLVERS,
       adapters: { lead, reviewerA, reviewerB },
       maxRounds: 1,
-      // The hanging reviewer must be preempted by the session
-      // wall-clock guard, not by the per-call CRITIQUE_TIMEOUT_MS
-      // (which defaults to 300s — way past test timeout).
+      // Pre-fix this would have preempted at ~capMs and produced exit
+      // 4 + session-wall-clock. Post-fix the flag is a no-op.
       maxSessionWallClockMs: capMs,
-      // Pin SPEC §11's "one more round fits" gate to a neutral state
-      // so the new session-wall-clock cap (not the §11 gate) is what
-      // preempts. Without these, `now_ms - session_started_at_ms` runs
-      // off the `now` string vs real wall-clock and can trip §11 first.
       sessionStartedAtMs: 0,
       nowMs: 0,
       maxWallClockMs: 60 * 60 * 1000,
     });
-    const elapsedMs = Date.now() - startMs;
 
-    // Must terminate within ~2x the cap (generous allowance for
-    // cleanup + finalize commit + subprocess overhead).
-    expect(elapsedMs).toBeLessThan(capMs * 2 + 4_000);
-    expect(res.exitCode).toBe(4);
-    expect(res.stderr.toLowerCase()).toContain("session-wall-clock");
-  }, 15_000);
+    const outcome = await raceDeadline(runPromise, capMs * 3);
+    expect(outcome.resolved).toBe(false);
+  }, 10_000);
 
   test("runIterate accepts maxSessionWallClockMs without throwing when all calls complete fast", async () => {
     const slug = "wc-slug";

--- a/tests/cli/new-hang-recovery.test.ts
+++ b/tests/cli/new-hang-recovery.test.ts
@@ -1,12 +1,15 @@
 // Copyright 2026 Nikolay Samokhvalov.
 
-// RED test for #81: `samospec new <slug>` with a mock adapter that hangs
-// on the first `ask` call must exit within configurable timeout (5s in
-// this test) with `lead_terminal` reason and a specific `timeout` message.
+// Historically (#81) this test asserted that `samospec new <slug>` with
+// a hanging adapter exited within ~5s with `lead_terminal` exit 4 and a
+// `session-wall-clock` reason. That kill was removed per Rule 10 and
+// samo.team #415 + #424. The test below now fences the NEW behavior:
+// the CLI must NOT exit on a wall-clock timer; the run keeps going
+// until the parent sends SIGTERM or the inactivity heartbeat decides
+// to surface a warning (non-killing).
 //
-// The adapter hangs forever on ask(). With the session wall-clock guard
-// in place, runNew must kill the hanging phase and return exit 4 with
-// a message containing "timeout" and "session-wall-clock".
+// See `tests/cli/no-wall-clock-kill.test.ts` for the primary behavior
+// fence.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -29,7 +32,6 @@ import type {
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { runInit } from "../../src/cli/init.ts";
 
-// Adapter that hangs on ask() indefinitely.
 function makeHangingAdapter(): Adapter {
   const auth: AuthStatus = { authenticated: true, subscription_auth: false };
   return {
@@ -41,22 +43,18 @@ function makeHangingAdapter(): Adapter {
     supports_effort: (_level: EffortLevel) => true,
     models: (): Promise<readonly ModelInfo[]> =>
       Promise.resolve([{ id: "fake", family: "fake" }]),
-    ask: (_input: AskInput): Promise<AskOutput> => {
-      // Hangs forever — the session wall-clock guard must preempt this.
-      return new Promise(() => {
+    ask: (_input: AskInput): Promise<AskOutput> =>
+      new Promise(() => {
         /* never resolves */
-      });
-    },
-    critique: (_input: CritiqueInput): Promise<CritiqueOutput> => {
-      return new Promise(() => {
+      }),
+    critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
+      new Promise(() => {
         /* never resolves */
-      });
-    },
-    revise: (_input: ReviseInput): Promise<ReviseOutput> => {
-      return new Promise(() => {
+      }),
+    revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+      new Promise(() => {
         /* never resolves */
-      });
-    },
+      }),
   };
 }
 
@@ -65,6 +63,28 @@ function acceptResolvers(): ChoiceResolvers {
     persona: () => Promise.resolve({ kind: "accept" }),
     question: (_q) => Promise.resolve({ choice: "decide for me" }),
   };
+}
+
+/** Race a promise against a real-time deadline. */
+async function raceDeadline<T>(
+  p: Promise<T>,
+  deadlineMs: number,
+): Promise<{ resolved: true; value: T } | { resolved: false }> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolve({ resolved: false });
+    }, deadlineMs);
+    p.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve({ resolved: true, value });
+      },
+      () => {
+        clearTimeout(timer);
+        resolve({ resolved: false });
+      },
+    );
+  });
 }
 
 let tmp: string;
@@ -76,14 +96,12 @@ afterEach(() => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
-describe("samospec new hang recovery (#81)", () => {
-  test("runNew with hanging adapter exits within 10s with exit 4 + session-wall-clock reason", async () => {
+describe("samospec new hang behavior (#81 / samo.team #415, #424)", () => {
+  test("runNew with hanging adapter does NOT exit on the wall clock", async () => {
     const adapter = makeHangingAdapter();
-    const startMs = Date.now();
+    const capMs = 1_500;
 
-    // maxWallClockMinutes: use a config-file based cap.
-    // The test sets max_session_wall_clock_minutes=0.08 (≈5s) via RunNewInput.
-    const result = await runNew(
+    const runPromise = runNew(
       {
         cwd: tmp,
         slug: "demo",
@@ -91,20 +109,14 @@ describe("samospec new hang recovery (#81)", () => {
         explain: false,
         resolvers: acceptResolvers(),
         now: "2026-04-19T10:00:00Z",
-        // 5-second session wall-clock cap via new field.
-        maxSessionWallClockMs: 5_000,
+        // Old kill would have triggered exit 4 within capMs.
+        maxSessionWallClockMs: capMs,
       },
       adapter,
     );
-    const elapsedMs = Date.now() - startMs;
 
-    // Must terminate within 10s.
-    expect(elapsedMs).toBeLessThan(10_000);
-
-    // Must exit with exit code 4 (lead_terminal).
-    expect(result.exitCode).toBe(4);
-
-    // stderr must contain "session-wall-clock" reason (not a generic "adapter error").
-    expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
-  }, 12_000); // Bun test timeout: 12s
+    // Run must still be in-flight past 3x the cap.
+    const outcome = await raceDeadline(runPromise, capMs * 3);
+    expect(outcome.resolved).toBe(false);
+  }, 8_000);
 });

--- a/tests/cli/new-max-session-wall-clock-ms-flag.test.ts
+++ b/tests/cli/new-max-session-wall-clock-ms-flag.test.ts
@@ -1,20 +1,23 @@
 // Copyright 2026 Nikolay Samokhvalov.
 
-// CLI-level e2e for `--max-session-wall-clock-ms` (#81, PR #83 review).
+// Historically (#81) this test asserted that
+// `samospec new --max-session-wall-clock-ms <ms>` capped a hanging
+// session and exited within ~ms with `session-wall-clock` in stderr.
+// That kill was removed per Rule 10 and samo.team #415 + #424. The
+// flag remains parseable for backward compatibility but is a no-op.
 //
-// The runtime plumbing in src/cli/new.ts already honors
-// `RunNewInput.maxSessionWallClockMs`, but the CLI parser in src/cli.ts
-// must also accept `--max-session-wall-clock-ms <ms>` (or `=ms`) and
-// thread the value into `runNew`. Without the parser change users
-// running `samospec new demo --max-session-wall-clock-ms 5000` would
-// fall back to the 10-minute default — the exact "unit tests pass, CLI
-// never invokes" pattern that bit #79/#80.
-//
-// Strategy: spawn a real `bun run src/main.ts new <slug>` in a tmpdir
-// with a stub `claude` binary on PATH that hangs forever. With a 5s
-// cap, the command MUST terminate within ~7s and stderr MUST contain
-// `session-wall-clock`. The pre-fix CLI ignores the flag; the hang
-// would fall back to the 10-min default → test times out.
+// Tests below assert:
+//   1. USAGE still documents the flag (so existing scripts that grep
+//      for it on `--help` don't break).
+//   2. With the flag set and a hanging stub `claude` binary on PATH,
+//      the CLI does NOT exit cleanly within the cap — it only exits
+//      because the spawnSync subprocess timeout kills it (status null
+//      or the spawned bun runtime got SIGTERM). stderr does NOT
+//      contain `session-wall-clock`.
+//   3. The equals form `--max-session-wall-clock-ms=<ms>` parses the
+//      same way (same behavior assertion).
+//   4. Non-integer value still rejected with exit 1 (the parser
+//      validation didn't change).
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
@@ -59,7 +62,12 @@ afterEach(() => {
 function runSamospec(
   args: readonly string[],
   opts: { cwd: string; timeoutMs?: number } = { cwd: tmp },
-): { stdout: string; stderr: string; status: number; elapsedMs: number } {
+): {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+  elapsedMs: number;
+} {
   const env: Record<string, string> = {
     PATH: `${fakeBin}:/bin:/usr/bin:/usr/local/bin`,
     HOME: fakeHome,
@@ -78,18 +86,18 @@ function runSamospec(
   return {
     stdout: result.stdout ?? "",
     stderr: result.stderr ?? "",
-    status: result.status ?? 1,
+    status: result.status,
     elapsedMs,
   };
 }
 
-describe("samospec new --max-session-wall-clock-ms (CLI flag, #81)", () => {
-  test("USAGE string documents --max-session-wall-clock-ms", () => {
+describe("samospec new --max-session-wall-clock-ms (CLI flag, #81 / samo.team #415, #424)", () => {
+  test("USAGE string still documents --max-session-wall-clock-ms", () => {
     const res = runSamospec([], { cwd: tmp, timeoutMs: 8_000 });
     expect(res.stderr.toLowerCase()).toContain("--max-session-wall-clock-ms");
   });
 
-  test("--max-session-wall-clock-ms 5000 caps a hanging session to ~5s", () => {
+  test("--max-session-wall-clock-ms 1500 does NOT preempt a hanging session", () => {
     // Init the repo (git + .samo/).
     spawnSync("git", ["init", "--initial-branch", "feature/wc-e2e", tmp], {
       cwd: tmpdir(),
@@ -98,32 +106,44 @@ describe("samospec new --max-session-wall-clock-ms (CLI flag, #81)", () => {
     const initRes = runSamospec(["init"], { cwd: tmp, timeoutMs: 8_000 });
     expect(initRes.status).toBe(0);
 
-    // Now run `samospec new demo --max-session-wall-clock-ms 5000`
-    // with the hanging `claude` stub on PATH. Must exit within ~7s.
-    const startMs = Date.now();
+    // Run `samospec new demo --max-session-wall-clock-ms 1500` with
+    // the hanging `claude` stub on PATH and `--yes` so we pass the
+    // non-TTY gate. Pre-fix this would exit ~1.5s with a
+    // `session-wall-clock exceeded` error in stderr. Post-fix the CLI
+    // keeps running until the spawnSync subprocess timeout kills the
+    // whole bun process tree (status === null, the
+    // subprocess-timeout signal).
     const res = runSamospec(
       [
         "new",
         "demo",
         "--idea",
         "cli flag test",
+        "--yes",
         "--max-session-wall-clock-ms",
-        "5000",
+        "1500",
       ],
-      { cwd: tmp, timeoutMs: 12_000 },
+      { cwd: tmp, timeoutMs: 5_000 },
     );
-    const elapsedMs = Date.now() - startMs;
 
-    // Must terminate within 10s (gives ~5s cap + overhead).
-    expect(elapsedMs).toBeLessThan(10_000);
-
-    // Must exit with non-zero (4 from runNew, or 1 from parser) and
-    // stderr must mention session-wall-clock.
-    expect(res.status).not.toBe(0);
-    expect(res.stderr.toLowerCase()).toContain("session-wall-clock");
+    // The CLI must NOT have produced the kill-error message. The USAGE
+    // text DOES mention `--max-session-wall-clock-ms` as a deprecated
+    // flag, so we look for the distinctive runtime kill phrase
+    // ("session-wall-clock exceeded") rather than a substring of the
+    // flag name.
+    expect(res.stderr.toLowerCase()).not.toContain(
+      "session-wall-clock exceeded",
+    );
+    // Subprocess was killed by spawnSync timeout (status === null) or
+    // exited with a non-zero non-4 status — either way, NOT a
+    // wall-clock self-kill.
+    expect(res.status).not.toBe(4);
+    // It must have run for at least the subprocess timeout (the cap
+    // is a no-op, so the run does not self-terminate).
+    expect(res.elapsedMs).toBeGreaterThanOrEqual(4_500);
   }, 20_000);
 
-  test("--max-session-wall-clock-ms=5000 (equals form) also caps a hanging session", () => {
+  test("--max-session-wall-clock-ms=1500 (equals form) is also a no-op", () => {
     spawnSync("git", ["init", "--initial-branch", "feature/wc-eq", tmp], {
       cwd: tmpdir(),
       encoding: "utf8",
@@ -131,22 +151,23 @@ describe("samospec new --max-session-wall-clock-ms (CLI flag, #81)", () => {
     const initRes = runSamospec(["init"], { cwd: tmp, timeoutMs: 8_000 });
     expect(initRes.status).toBe(0);
 
-    const startMs = Date.now();
     const res = runSamospec(
       [
         "new",
         "demo-eq",
         "--idea",
         "eq form test",
-        "--max-session-wall-clock-ms=5000",
+        "--yes",
+        "--max-session-wall-clock-ms=1500",
       ],
-      { cwd: tmp, timeoutMs: 12_000 },
+      { cwd: tmp, timeoutMs: 5_000 },
     );
-    const elapsedMs = Date.now() - startMs;
 
-    expect(elapsedMs).toBeLessThan(10_000);
-    expect(res.status).not.toBe(0);
-    expect(res.stderr.toLowerCase()).toContain("session-wall-clock");
+    expect(res.stderr.toLowerCase()).not.toContain(
+      "session-wall-clock exceeded",
+    );
+    expect(res.status).not.toBe(4);
+    expect(res.elapsedMs).toBeGreaterThanOrEqual(4_500);
   }, 20_000);
 
   test("--max-session-wall-clock-ms with non-integer value rejects with exit 1", () => {

--- a/tests/cli/no-wall-clock-kill.test.ts
+++ b/tests/cli/no-wall-clock-kill.test.ts
@@ -1,0 +1,284 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// Behavior fence for samo.team #415 + #424: CLI must NOT kill a dev LLM
+// run on the wall clock.
+//
+// Rule 10 / memory `feedback_no_dev_timeout`:
+//   "No setTimeout, no --timeout flag, no AppArmor RuntimeMaxSec=, no
+//    Caddy read_timeout, no EventSource client-side reconnect threshold,
+//    nothing kills a dev LLM run on the wall clock. Allowed stop signals:
+//    inactivity heartbeat + user-cancel."
+//
+// History:
+//   - samospec #81 added a 10-min session wall-clock cap to `samospec new`
+//     emitting exit 4 with `session-wall-clock` in stderr.
+//   - samospec #91 mirrored the same cap into `samospec iterate`.
+//   - samo.team consumed the CLI as a subprocess and translated exit 4
+//     into an `exit-timeout` SSE event, which the UI rendered as
+//     "Run ended / timed out / exit code 4" — alarming the user even
+//     when the underlying LLM was still making progress.
+//   - samo.team #415 removed the BACKEND supervisor; #424 reworded the
+//     frontend copy. This fence ensures the CLI itself never produces
+//     the wall-clock kill in the first place.
+//
+// What this fence asserts:
+//   1. With a hanging adapter and an explicit `maxSessionWallClockMs`,
+//      `runNew` does NOT exit 4 with `session-wall-clock` within a
+//      window longer than the cap. The CLI keeps running; the only
+//      legitimate stop is parent SIGTERM or inactivity-heartbeat
+//      handling (neither of which exit 4 with a wall-clock reason).
+//   2. Same for `runIterate`.
+//
+// Implementation note: because the adapters hang forever, we race the
+// CLI promise against a real-time deadline and assert the CLI did NOT
+// resolve within the wall-clock-cap window. If the kill were still in
+// place, the CLI would resolve with exit 4 + session-wall-clock well
+// before the deadline.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import type {
+  Adapter,
+  AskInput,
+  AskOutput,
+  AuthStatus,
+  CritiqueInput,
+  CritiqueOutput,
+  DetectResult,
+  EffortLevel,
+  ModelInfo,
+  ReviseInput,
+  ReviseOutput,
+} from "../../src/adapter/types.ts";
+import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
+import { runInit } from "../../src/cli/init.ts";
+import { runIterate, type IterateResolvers } from "../../src/cli/iterate.ts";
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import { writeState } from "../../src/state/store.ts";
+import type { State } from "../../src/state/types.ts";
+
+// ---------- helpers ----------
+
+function makeHangingAdapter(): Adapter {
+  const auth: AuthStatus = { authenticated: true, subscription_auth: false };
+  return {
+    vendor: "fake-hang",
+    detect: (): Promise<DetectResult> =>
+      Promise.resolve({ installed: true, version: "0", path: "/fake" }),
+    auth_status: (): Promise<AuthStatus> => Promise.resolve(auth),
+    supports_structured_output: () => true,
+    supports_effort: (_level: EffortLevel) => true,
+    models: (): Promise<readonly ModelInfo[]> =>
+      Promise.resolve([{ id: "fake", family: "fake" }]),
+    ask: (_input: AskInput): Promise<AskOutput> =>
+      new Promise(() => {
+        /* hangs */
+      }),
+    critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
+      new Promise(() => {
+        /* hangs */
+      }),
+    revise: (_input: ReviseInput): Promise<ReviseOutput> =>
+      new Promise(() => {
+        /* hangs */
+      }),
+  };
+}
+
+function acceptResolvers(): ChoiceResolvers {
+  return {
+    persona: () => Promise.resolve({ kind: "accept" }),
+    question: (_q) => Promise.resolve({ choice: "decide for me" }),
+  };
+}
+
+const ITERATE_RESOLVERS: IterateResolvers = {
+  onManualEdit: () => Promise.resolve("incorporate"),
+  onDegraded: () => Promise.resolve("accept"),
+  onReviewerExhausted: () => Promise.resolve("abort"),
+};
+
+/** Race a promise against a real-time deadline. */
+async function raceDeadline<T>(
+  p: Promise<T>,
+  deadlineMs: number,
+): Promise<{ resolved: true; value: T } | { resolved: false }> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolve({ resolved: false });
+    }, deadlineMs);
+    p.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve({ resolved: true, value });
+      },
+      () => {
+        // If the CLI throws unexpectedly, the test should still progress;
+        // treat as "did not resolve normally" so the fence still asserts
+        // the absence of a clean exit-4 wall-clock kill.
+        clearTimeout(timer);
+        resolve({ resolved: false });
+      },
+    );
+  });
+}
+
+// ---------- new ----------
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "samospec-no-wc-kill-"));
+  runInit({ cwd: tmp });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("CLI wall-clock kill removed (samo.team #415 + #424)", () => {
+  test("runNew does NOT exit 4 with session-wall-clock when cap is exceeded", async () => {
+    const adapter = makeHangingAdapter();
+    const capMs = 1_000;
+
+    const runPromise = runNew(
+      {
+        cwd: tmp,
+        slug: "no-kill-new",
+        idea: "fence test",
+        explain: false,
+        resolvers: acceptResolvers(),
+        now: "2026-04-19T10:00:00Z",
+        // Cap value that the OLD code would have honored. The NEW code
+        // must IGNORE it — adapter hangs, CLI keeps running, no exit 4.
+        maxSessionWallClockMs: capMs,
+      },
+      adapter,
+    );
+
+    // Race against a deadline well past the cap. The OLD kill mechanism
+    // would have produced exit 4 + session-wall-clock within ~capMs;
+    // post-fix the CLI must still be running (unresolved) at this point.
+    const outcome = await raceDeadline(runPromise, capMs * 3 + 500);
+    expect(outcome.resolved).toBe(false);
+  }, 8_000);
+
+  test("runIterate does NOT exit 4 with session-wall-clock when cap is exceeded", async () => {
+    // Seed the spec so iterate gets past its state-missing precondition.
+    const slug = "no-kill-iter";
+    spawnSync("git", ["init", "-q"], { cwd: tmp });
+    spawnSync("git", ["config", "user.email", "test@example.com"], {
+      cwd: tmp,
+    });
+    spawnSync("git", ["config", "user.name", "Test"], { cwd: tmp });
+    spawnSync("git", ["config", "commit.gpgsign", "false"], { cwd: tmp });
+    spawnSync("git", ["checkout", "-q", "-b", `samospec/${slug}`], {
+      cwd: tmp,
+    });
+    writeFileSync(path.join(tmp, "README.md"), "seed\n", "utf8");
+    spawnSync("git", ["add", "README.md"], { cwd: tmp });
+    spawnSync("git", ["commit", "-q", "-m", "seed"], { cwd: tmp });
+
+    const slugDir = path.join(tmp, ".samo", "spec", slug);
+    mkdirSync(slugDir, { recursive: true });
+    writeFileSync(
+      path.join(slugDir, "SPEC.md"),
+      "# SPEC\n\ncontent v0.1\n",
+      "utf8",
+    );
+    writeFileSync(path.join(slugDir, "TLDR.md"), "# TLDR\n\n- old\n", "utf8");
+    writeFileSync(
+      path.join(slugDir, "decisions.md"),
+      "# decisions\n\n- No review-loop decisions yet.\n",
+      "utf8",
+    );
+    writeFileSync(
+      path.join(slugDir, "changelog.md"),
+      "# changelog\n\n## v0.1 — seed\n\n- initial\n",
+      "utf8",
+    );
+    writeFileSync(
+      path.join(slugDir, "interview.json"),
+      JSON.stringify({
+        slug,
+        persona: 'Veteran "no-kill-iter" expert',
+        generated_at: "2026-04-19T12:00:00Z",
+        questions: [],
+        answers: [],
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      path.join(slugDir, "context.json"),
+      JSON.stringify({
+        phase: "draft",
+        files: [],
+        risk_flags: [],
+        budget: { phase: "draft", tokens_used: 0, tokens_budget: 0 },
+      }),
+      "utf8",
+    );
+    const state: State = {
+      slug,
+      phase: "review_loop",
+      round_index: 0,
+      version: "0.1.0",
+      persona: { skill: "no-kill-iter", accepted: true },
+      push_consent: null,
+      calibration: null,
+      remote_stale: false,
+      coupled_fallback: false,
+      head_sha: null,
+      round_state: "committed",
+      exit: null,
+      created_at: "2026-04-19T12:00:00Z",
+      updated_at: "2026-04-19T12:00:00Z",
+    };
+    writeState(path.join(slugDir, "state.json"), state);
+    spawnSync("git", ["add", "."], { cwd: tmp });
+    spawnSync("git", ["commit", "-q", "-m", "seed spec"], { cwd: tmp });
+
+    const lead = createFakeAdapter({
+      revise: {
+        spec: "# SPEC\n\nrevised\n",
+        ready: true,
+        rationale: "[]",
+        usage: null,
+        effort_used: "max",
+      },
+    });
+    const reviewerA: Adapter = {
+      ...createFakeAdapter({}),
+      critique: () =>
+        new Promise(() => {
+          /* hangs */
+        }),
+    };
+    const reviewerB: Adapter = {
+      ...createFakeAdapter({}),
+      critique: () =>
+        new Promise(() => {
+          /* hangs */
+        }),
+    };
+
+    const capMs = 1_000;
+    const runPromise = runIterate({
+      cwd: tmp,
+      slug,
+      now: "2026-04-19T12:00:00Z",
+      resolvers: ITERATE_RESOLVERS,
+      adapters: { lead, reviewerA, reviewerB },
+      maxRounds: 1,
+      maxSessionWallClockMs: capMs,
+      sessionStartedAtMs: 0,
+      nowMs: 0,
+      maxWallClockMs: 60 * 60 * 1000,
+    });
+
+    const outcome = await raceDeadline(runPromise, capMs * 3 + 500);
+    expect(outcome.resolved).toBe(false);
+  }, 10_000);
+});

--- a/tests/cli/session-wallclock.test.ts
+++ b/tests/cli/session-wallclock.test.ts
@@ -1,16 +1,24 @@
 // Copyright 2026 Nikolay Samokhvalov.
 
-// RED test for #81: session wall-clock cap.
+// Historically (#81) this file asserted that `runNew` killed a hanging
+// adapter on the session wall-clock cap, returning exit 4 with a
+// `session-wall-clock` reason in stderr. That kill was removed per
+// Rule 10 ("nothing kills a dev LLM run on the wall clock") and
+// samo.team #415 + #424. The tests below have been rewritten to fence
+// the NEW behavior:
 //
-// SPEC §7 default: 10 minutes session wall-clock cap, configurable via
-// `.samo/config.json` `budget.max_session_wall_clock_minutes`.
+//   1. With an explicit `maxSessionWallClockMs` set and a hanging
+//      adapter, `runNew` does NOT exit 4 + session-wall-clock within
+//      a window longer than the cap. The flag is a deprecated no-op.
+//   2. Same when the cap is read from `.samo/config.json`
+//      `budget.max_session_wall_clock_minutes`.
+//   3. A session that would normally complete still completes (the
+//      removal didn't break the happy path).
 //
-// Tests:
-// 1. A session that exceeds the wall-clock cap terminates with reason
-//    `session-wall-clock` and exit code 4.
-// 2. The cap is read from config.json `budget.max_session_wall_clock_minutes`
-//    when present.
-// 3. A session that completes within the cap succeeds normally.
+// The primary behavior fence lives in
+// `tests/cli/no-wall-clock-kill.test.ts`; this file preserves the
+// historical entry points so that anyone landing here from #81 / git
+// blame sees why the assertion shape inverted.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
@@ -66,6 +74,28 @@ function acceptResolvers(): ChoiceResolvers {
   };
 }
 
+/** Race a promise against a real-time deadline. */
+async function raceDeadline<T>(
+  p: Promise<T>,
+  deadlineMs: number,
+): Promise<{ resolved: true; value: T } | { resolved: false }> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolve({ resolved: false });
+    }, deadlineMs);
+    p.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve({ resolved: true, value });
+      },
+      () => {
+        clearTimeout(timer);
+        resolve({ resolved: false });
+      },
+    );
+  });
+}
+
 let tmp: string;
 beforeEach(() => {
   tmp = mkdtempSync(path.join(tmpdir(), "samospec-wallclock-"));
@@ -75,12 +105,12 @@ afterEach(() => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
-describe("session wall-clock cap (#81)", () => {
-  test("exceeding wall-clock cap terminates with exit 4 + session-wall-clock reason", async () => {
+describe("session wall-clock cap is a deprecated no-op (#81 / samo.team #415, #424)", () => {
+  test("hanging adapter is NOT preempted by maxSessionWallClockMs", async () => {
     const adapter = makeHangingAdapter();
-    const startMs = Date.now();
+    const capMs = 2_000;
 
-    const result = await runNew(
+    const runPromise = runNew(
       {
         cwd: tmp,
         slug: "wc-test",
@@ -88,19 +118,17 @@ describe("session wall-clock cap (#81)", () => {
         explain: false,
         resolvers: acceptResolvers(),
         now: "2026-04-19T10:00:00Z",
-        // 3-second session wall-clock cap.
-        maxSessionWallClockMs: 3_000,
+        maxSessionWallClockMs: capMs,
       },
       adapter,
     );
-    const elapsedMs = Date.now() - startMs;
 
-    expect(elapsedMs).toBeLessThan(8_000);
-    expect(result.exitCode).toBe(4);
-    expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
+    // The CLI must still be running past the (now-ignored) cap.
+    const outcome = await raceDeadline(runPromise, capMs * 2 + 500);
+    expect(outcome.resolved).toBe(false);
   }, 10_000);
 
-  test("wall-clock cap is read from config.json budget.max_session_wall_clock_minutes", async () => {
+  test("hanging adapter is NOT preempted by config.json budget.max_session_wall_clock_minutes", async () => {
     // Patch the config to set max_session_wall_clock_minutes = 0.05 (3s).
     const configPath = path.join(tmp, ".samo", "config.json");
     const raw = readFileSync(configPath, "utf8");
@@ -111,10 +139,8 @@ describe("session wall-clock cap (#81)", () => {
     writeFileSync(configPath, JSON.stringify(cfg, null, 2));
 
     const adapter = makeHangingAdapter();
-    const startMs = Date.now();
 
-    // Do NOT pass maxSessionWallClockMs — must read from config.
-    const result = await runNew(
+    const runPromise = runNew(
       {
         cwd: tmp,
         slug: "cfg-wc",
@@ -125,12 +151,11 @@ describe("session wall-clock cap (#81)", () => {
       },
       adapter,
     );
-    const elapsedMs = Date.now() - startMs;
 
-    expect(elapsedMs).toBeLessThan(10_000);
-    expect(result.exitCode).toBe(4);
-    expect(result.stderr.toLowerCase()).toContain("session-wall-clock");
-  }, 12_000);
+    // Configured cap is ~3s; the CLI must still be running past 6s.
+    const outcome = await raceDeadline(runPromise, 6_000);
+    expect(outcome.resolved).toBe(false);
+  }, 10_000);
 
   test("session that completes within wall-clock cap exits 0", async () => {
     // Fast-responding adapter that completes immediately.
@@ -184,7 +209,7 @@ describe("session wall-clock cap (#81)", () => {
         explain: false,
         resolvers: acceptResolvers(),
         now: "2026-04-19T10:00:00Z",
-        // 10-minute cap — should be more than enough.
+        // Generous cap value — ignored, but legal input.
         maxSessionWallClockMs: 600_000,
       },
       fastAdapter,

--- a/tests/loop/revise-timeout.test.ts
+++ b/tests/loop/revise-timeout.test.ts
@@ -378,7 +378,19 @@ describe("loop/round — session wall-clock clamps per-call revise (#92 REV)", (
   });
 });
 
-describe("iterate — threads remainingSessionMsFn into runRound (#92 REV)", () => {
+// NOTE (samo.team #415, #424): the
+// `iterate — threads remainingSessionMsFn into runRound` describe block
+// was removed alongside the wall-clock kill. That test asserted exit 4
+// + `lead-terminal:revise_timeout` proving the round-level clamp won
+// the race against the outer `withSessionDeadline` wrapper. Both
+// mechanisms (`withSessionDeadline` AND `remainingSessionMsFn`) are
+// gone now — there is no session cap to race against. The
+// `loop/round — session wall-clock clamps per-call revise` describe
+// above still exercises `remainingSessionMsFn` directly on `runRound`
+// as a unit; that function still exists as a defensive timeout knob
+// for callers who explicitly pass one.
+
+describe.skip("iterate — threads remainingSessionMsFn into runRound (#92 REV) [removed: wall-clock kill gone]", () => {
   test("session cap smaller than configured revise → round-level clamp fires first (revise_timeout, not wall_clock)", async () => {
     // This test distinguishes the round-level clamp from #91's outer
     // `withSessionDeadline` wrapper. Both race against roughly the same


### PR DESCRIPTION
## Motivation

The CLI had its own `setTimeout`-based wall-clock cap (#81 for `samospec new`, #91 for `samospec iterate`) that hard-killed the subprocess after N minutes and exited with code **4** and a `session-wall-clock` reason in stderr.

samo.team consumed the CLI as a subprocess and translated that exit into an `exit-timeout` SSE event, which the UI rendered as an alarming **"Run ended / timed out / exit code 4"** banner even while the underlying LLM was still making progress.

samo.team#415 removed the backend supervisor that owned the same behavior on its side. samo.team#424 reworded the frontend copy ("Still working / Retry"). **This PR closes the remaining half**: the CLI itself no longer emits the wall-clock kill in the first place.

Per Rule 10 (`feedback_no_dev_timeout` memory): _"nothing kills a dev LLM run on the wall clock. Allowed stop signals: inactivity heartbeat + user-cancel."_ The SIGTERM path from a parent process (user cancel) is unchanged. The progress-reporter inactivity heartbeat is unchanged.

## Behavior change

### Before
- `samospec new` and `samospec iterate` each ran an internal `setTimeout` that called `reject(new SessionWallClockError(...))` after `maxSessionWallClockMs` (default 10 min, configurable via `budget.max_session_wall_clock_minutes`).
- On trip: write `lead_terminal` state, emit `samospec: session-wall-clock exceeded ...` to stderr, return `exitCode: 4`.

### After
- The wall-clock deadline is removed. Adapter calls run to completion or until the parent sends SIGTERM. No internal kill timer remains.
- `--max-session-wall-clock-ms <ms>` CLI flag is still **parsed and validated** for backward compat — the value is silently ignored. USAGE strings document this as a deprecated no-op.
- `RunNewInput.maxSessionWallClockMs` and `IterateInput.maxSessionWallClockMs` remain on the input types (ignored) so external callers like samo.team's backend keep type-checking without code changes.
- SPEC §11 "one more round fits" gate (`shouldStartNextRound` / `maxWallClockMs`) is **untouched** — that's a between-round budget boundary check, not a mid-call wall-clock kill.

## Behavior fence

New test: [`tests/cli/no-wall-clock-kill.test.ts`](../blob/fix/cli-no-wall-clock-kill/tests/cli/no-wall-clock-kill.test.ts)

With a hanging adapter and `maxSessionWallClockMs = 1000`, both `runNew` and `runIterate` must still be in-flight 3+ seconds later (proof the kill is gone). Pre-fix this test would resolve in ~1s with `exit 4 + session-wall-clock`.

```ts
const outcome = await raceDeadline(runPromise, capMs * 3 + 500);
expect(outcome.resolved).toBe(false);
```

## Existing tests

The 4 test files that asserted the kill mechanism have been **inverted** to fence the new behavior:

- `tests/cli/session-wallclock.test.ts` — was "exit 4 within cap", now "still running past cap"
- `tests/cli/new-hang-recovery.test.ts` — same flip
- `tests/cli/iterate-wall-clock.test.ts` — parser tests unchanged; runtime test inverted
- `tests/cli/new-max-session-wall-clock-ms-flag.test.ts` — USAGE + parser-validation tests unchanged; e2e tests inverted to assert "no session-wall-clock exceeded in stderr; spawnSync timeout kills it instead"
- `tests/loop/revise-timeout.test.ts` — one describe block (`iterate — threads remainingSessionMsFn into runRound`) skipped: it tested a race between two mechanisms (`withSessionDeadline` + `remainingSessionMsFn` clamp) that are both now gone. The unit-level `loop/round — session wall-clock clamps per-call revise` test is preserved (the `remainingSessionMsFn` parameter on `runRound` remains as a defensive knob for callers who explicitly pass one).

## Test results

```
 1657 pass
 1 skip
 0 fail
 9815 expect() calls
Ran 1658 tests across 171 files. [142.90s]
```

`bun run typecheck` and `bun run lint` both clean.

## Downstream: bringing this into samo.team prod

samo.team consumes samospec via npm/registry-pinned-version. To bring this fix into prod after merge:

1. Tag a new samospec release (per `CLAUDE.md` release-checklist: `bun run scripts/bump-version.ts <version>` + tag).
2. In the samo.team repo, bump the samospec dependency pin to the new version.
3. Deploy samo.team. The frontend already has the calm copy from #424; the CLI exit-4 path simply will no longer fire on long sessions.

Closes samo.team#415 (CLI half).
Closes samo.team#424 (CLI half — root-cause fix; the samo.team frontend copy rewording remains as defense in depth).