### PR TITLE
fix(publish): re-promote an iterated spec when the draft is newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`publish` can now re-promote an iterated spec.** Previously the first
+  `samospec publish <slug>` set `published_at` and every later `publish`
+  hard-failed — even though the error told the user to "republish", a
+  command that never existed. `blueprints/<slug>/SPEC.md` (and `brief`,
+  which reads it) stayed frozen on the first published version. `publish`
+  now re-promotes the committed working draft whenever it is newer than
+  the published snapshot, matching the documented iterate → publish loop.
+  It still refuses (exit 1) when the draft has not advanced, with an
+  actionable message pointing at `iterate`.
+
 ## [0.9.0] - 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ bunx samospec iterate linkrot                            # lead drafts → 2 rev
 bunx samospec publish linkrot                            # promote, commit, push, open PR via gh
 ```
 
+The loop is repeatable: run `iterate` again to advance the version, then
+`publish` again to re-promote the newer draft (`blueprints/<slug>/SPEC.md`
+and any regenerated `brief` follow the latest published version). `publish`
+only refuses when there is nothing new to promote — i.e. the working draft
+has not advanced past the published snapshot.
+
 At every step: `bunx samospec status <slug>` prints phase, current version, next-step hint, and last-round summary.
 
 ---

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -13,7 +13,9 @@
  *   1. Preconditions (exit 1 on miss):
  *      - `.samo/spec/<slug>/state.json` exists.
  *      - `state.round_state === "committed"`.
- *      - `state.published_at` is absent (republish error message).
+ *      - If `state.published_at` is set, the committed working draft must
+ *        be NEWER than the published snapshot (the iterate→publish loop);
+ *        otherwise exit 1 with "nothing new to publish".
  *   2. Safety invariant: refuse if current branch is protected (exit 2).
  *   3. Copy SPEC.md → `blueprints/<slug>/SPEC.md`.
  *   4. Advance state: set `published_at`, `published_version`,
@@ -56,7 +58,11 @@ import {
   type PrCapabilityProbe,
 } from "../git/push-consent.ts";
 import { pushBranch, type PushBranchResult } from "../git/push.ts";
-import { formatVersionLabel } from "../loop/version.ts";
+import {
+  compareSemver,
+  formatVersionLabel,
+  parsePublishedLabel,
+} from "../loop/version.ts";
 import { writeState } from "../state/store.ts";
 import { stateSchema, type State } from "../state/types.ts";
 import { specPaths } from "./new.ts";
@@ -134,12 +140,23 @@ export async function runPublish(input: PublishInput): Promise<PublishResult> {
   // Republish check (must come BEFORE the committed-state check so the
   // message is actionable: we don't want to confuse users who already
   // advanced past `committed` via publish).
+  //
+  // Auto-allow re-promotion when the committed working draft is NEWER
+  // than the published snapshot — that is exactly the README's
+  // "iterate → publish → iterate → publish" loop. Only refuse when there
+  // is nothing new to promote (the draft is at or below the published
+  // version), so the message stops promising a "republish" that the user
+  // can't reach.
   if (state.published_at !== undefined) {
-    error(
-      `samospec: '${input.slug}' is already published at ${state.published_at}. ` +
-        `Use \`samospec iterate ${input.slug}\` to run more rounds, then republish.`,
-    );
-    return finish(1, outLines, errLines);
+    if (!draftIsNewerThanPublished(state)) {
+      error(
+        `samospec: '${input.slug}' is already published at ${state.published_at} ` +
+          `(${state.published_version ?? "unknown"}) and the working draft has ` +
+          `not advanced. Run \`samospec iterate ${input.slug}\` to produce a ` +
+          `newer version, then publish again.`,
+      );
+      return finish(1, outLines, errLines);
+    }
   }
 
   if (state.round_state !== "committed") {
@@ -359,6 +376,25 @@ function finish(
 
 function stripLeadingV(label: string): string {
   return label.startsWith("v") ? label.slice(1) : label;
+}
+
+/**
+ * Decide whether a re-publish should proceed: true when the committed
+ * working draft's `state.version` (a full `X.Y.Z` triple) is strictly
+ * newer than the recorded `published_version` label (`vX.Y[.Z]`).
+ *
+ * When `published_version` is absent or malformed we cannot prove the
+ * draft is newer, so we conservatively allow the republish — the user
+ * already passed the `published_at` gate and the alternative is leaving
+ * them permanently stuck on a corrupted snapshot. The common path
+ * (`published_version` present and parseable) is a precise numeric
+ * comparison.
+ */
+function draftIsNewerThanPublished(state: State): boolean {
+  if (state.published_version === undefined) return true;
+  const publishedTriple = parsePublishedLabel(state.published_version);
+  if (publishedTriple === null) return true;
+  return compareSemver(state.version, publishedTriple) > 0;
 }
 
 function safePushBranch(args: {

--- a/src/loop/version.ts
+++ b/src/loop/version.ts
@@ -37,6 +37,44 @@ export function formatVersionLabel(semver: string): string {
   return `v${major}.${minor}.${patch}`;
 }
 
+/**
+ * Parse a published label (`vX.Y` or `vX.Y.Z`, leading `v` optional) back
+ * into the full `X.Y.Z` SemVer triple — the inverse of
+ * {@link formatVersionLabel}. A short `vX.Y` expands to `X.Y.0`. Returns
+ * `null` when the label is malformed (so callers can decide whether a
+ * missing/garbled published_version should block a republish).
+ */
+export function parsePublishedLabel(label: string): string | null {
+  const stripped = label.startsWith("v") ? label.slice(1) : label;
+  const m = /^(\d+)\.(\d+)(?:\.(\d+))?$/.exec(stripped);
+  if (m === null) return null;
+  const major = m[1] ?? "0";
+  const minor = m[2] ?? "0";
+  const patch = m[3] ?? "0";
+  return `${major}.${minor}.${patch}`;
+}
+
+/**
+ * Compare two `X.Y.Z` SemVer triples numerically (NOT lexically, so
+ * `0.10.0 > 0.9.0`). Returns a negative number when `a < b`, `0` when
+ * equal, and a positive number when `a > b`. Throws on malformed input
+ * so a republish decision never silently treats a garbled version as
+ * "not newer".
+ */
+export function compareSemver(a: string, b: string): number {
+  const pa = SEMVER_RE.exec(a);
+  const pb = SEMVER_RE.exec(b);
+  if (pa === null || pb === null) {
+    throw new Error(`compareSemver: expected X.Y.Z, received '${a}' / '${b}'.`);
+  }
+  for (let i = 1; i <= 3; i += 1) {
+    const da = Number.parseInt(pa[i] ?? "0", 10);
+    const db = Number.parseInt(pb[i] ?? "0", 10);
+    if (da !== db) return da - db;
+  }
+  return 0;
+}
+
 export interface ChangelogEntryInput {
   readonly version: string;
   readonly now: string;

--- a/tests/cli/publish.test.ts
+++ b/tests/cli/publish.test.ts
@@ -589,7 +589,7 @@ describe("samospec publish — state advance (SPEC §7)", () => {
     expect(state["published_version"]).toBe("v0.2");
   });
 
-  test("second publish on the same slug exits 1 (republish error)", async () => {
+  test("second publish at the SAME version exits 1 (nothing new to publish)", async () => {
     seedCommittedSpec(tmp, "refunds");
     const remoteUrl = spawnSync("git", ["remote", "get-url", "origin"], {
       cwd: tmp,
@@ -608,6 +608,8 @@ describe("samospec publish — state advance (SPEC §7)", () => {
       env: { PATH },
     });
     expect(first.exitCode).toBe(0);
+    // No iterate happened — the working draft is still v0.2, same as the
+    // published snapshot — so a re-publish has nothing new to promote.
     const second = await runPublish({
       cwd: tmp,
       slug: "refunds",
@@ -618,5 +620,110 @@ describe("samospec publish — state advance (SPEC §7)", () => {
     expect(second.exitCode).toBe(1);
     expect(second.stderr).toMatch(/already published/i);
     expect(second.stderr).toMatch(/iterate/);
+  });
+});
+
+describe("samospec publish — republish when the draft is newer (issue: stuck on first version)", () => {
+  /**
+   * Advance the committed working draft to a newer version, mirroring
+   * what `samospec iterate` does between two publishes: rewrite SPEC.md,
+   * bump `state.version`, and commit so the working tree is clean.
+   */
+  function advanceDraftTo(
+    cwd: string,
+    slug: string,
+    version: string,
+    label: string,
+  ): void {
+    const slugDir = path.join(cwd, ".samo", "spec", slug);
+    writeFileSync(
+      path.join(slugDir, "SPEC.md"),
+      [
+        "# SPEC",
+        "",
+        "## Goal",
+        "",
+        `Deliver a refunds policy that is reviewable and actionable (${label}).`,
+        "",
+        "## Scope",
+        "",
+        "- refund window",
+        "- edge cases",
+        "- partial refunds",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const statePath = path.join(slugDir, "state.json");
+    const state = JSON.parse(readFileSync(statePath, "utf8")) as State;
+    writeState(statePath, {
+      ...state,
+      version,
+      round_index: state.round_index + 1,
+      round_state: "committed",
+      updated_at: "2026-04-19T13:04:00Z",
+    });
+    spawnSync("git", ["add", "-A"], { cwd });
+    spawnSync("git", ["commit", "-q", "-m", `spec(${slug}): refine ${label}`], {
+      cwd,
+    });
+  }
+
+  test("re-promotes the working draft and updates published_at/version", async () => {
+    seedCommittedSpec(tmp, "refunds");
+    const remoteUrl = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
+    seedConfig(tmp, {
+      schema_version: 1,
+      git: { push_consent: { [remoteUrl]: true } },
+    });
+    const { PATH } = scriptShim({ gh: true });
+    const first = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:00:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    expect(first.exitCode).toBe(0);
+
+    // Simulate `iterate` bumping the working draft to v0.3.
+    advanceDraftTo(tmp, "refunds", "0.3.0", "v0.3");
+
+    const second = await runPublish({
+      cwd: tmp,
+      slug: "refunds",
+      now: "2026-04-19T13:10:00Z",
+      remote: "origin",
+      env: { PATH },
+    });
+    expect(second.exitCode).toBe(0);
+
+    // The promoted snapshot reflects the newer draft.
+    const promoted = readFileSync(
+      path.join(tmp, "blueprints", "refunds", "SPEC.md"),
+      "utf8",
+    );
+    expect(promoted).toContain("(v0.3)");
+    expect(promoted).toContain("partial refunds");
+
+    // state.json records the new publish.
+    const state = JSON.parse(
+      readFileSync(
+        path.join(tmp, ".samo", "spec", "refunds", "state.json"),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    expect(state["published_version"]).toBe("v0.3");
+    expect(state["published_at"]).toBe("2026-04-19T13:10:00Z");
+
+    // The publish commit landed for the new version.
+    const lastMsg = spawnSync("git", ["log", "-1", "--format=%s"], {
+      cwd: tmp,
+      encoding: "utf8",
+    }).stdout.trim();
+    expect(lastMsg).toBe("spec(refunds): publish v0.3");
   });
 });

--- a/tests/loop/version.test.ts
+++ b/tests/loop/version.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, test } from "bun:test";
 
 import {
   bumpMinor,
+  compareSemver,
   formatChangelogEntry,
   formatVersionLabel,
+  parsePublishedLabel,
 } from "../../src/loop/version.ts";
 
 describe("loop/version — version bump", () => {
@@ -62,5 +64,40 @@ describe("loop/version — formatChangelogEntry", () => {
       degradedResolution: "lead fell back to claude-sonnet-4-6",
     });
     expect(entry).toContain("lead fell back to claude-sonnet-4-6");
+  });
+});
+
+describe("loop/version — parsePublishedLabel", () => {
+  test("expands a short vX.Y label to the X.Y.0 triple", () => {
+    expect(parsePublishedLabel("v0.2")).toBe("0.2.0");
+    expect(parsePublishedLabel("v1.10")).toBe("1.10.0");
+  });
+  test("keeps an explicit patch in a vX.Y.Z label", () => {
+    expect(parsePublishedLabel("v0.2.3")).toBe("0.2.3");
+  });
+  test("tolerates a missing leading v", () => {
+    expect(parsePublishedLabel("0.4")).toBe("0.4.0");
+  });
+  test("returns null on a malformed label", () => {
+    expect(parsePublishedLabel("not-a-version")).toBeNull();
+    expect(parsePublishedLabel("v1")).toBeNull();
+  });
+});
+
+describe("loop/version — compareSemver", () => {
+  test("orders by major, then minor, then patch", () => {
+    expect(compareSemver("0.2.0", "0.1.0")).toBeGreaterThan(0);
+    expect(compareSemver("0.1.0", "0.2.0")).toBeLessThan(0);
+    expect(compareSemver("1.0.0", "0.9.0")).toBeGreaterThan(0);
+    expect(compareSemver("0.2.1", "0.2.0")).toBeGreaterThan(0);
+  });
+  test("returns 0 for equal versions", () => {
+    expect(compareSemver("0.2.0", "0.2.0")).toBe(0);
+  });
+  test("compares numerically, not lexically (v0.10 > v0.9)", () => {
+    expect(compareSemver("0.10.0", "0.9.0")).toBeGreaterThan(0);
+  });
+  test("throws on a malformed input", () => {
+    expect(() => compareSemver("0.2", "0.1.0")).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

After the first `samospec publish <slug>`, there was **no way to re-promote an iterated spec**. The first publish sets `state.published_at`, and the republish guard then hard-failed every later `publish` — even though the error told the user to *"then republish"*, a command/flag that never existed. So `blueprints/<slug>/SPEC.md` (and `brief`, which only reads that published snapshot) stayed frozen on the first published version, making the documented `iterate → publish → iterate → publish` loop impossible without manually copying files.

This implements the **"auto-allow republish when the draft is newer"** approach: `publish` now re-promotes the committed working draft whenever its version is newer than the published snapshot, and only refuses when there is genuinely nothing new to promote.

### Origin

This was flagged in a handoff note staged in [PgQue](https://github.com/NikolayS/PgQue) (`handoff/samospec-publish-republish-issue.md`) while dogfooding SamoSpec. Unlike the adapter work in #181, the note was an issue writeup with several candidate fixes rather than a ready patch — this PR implements one of them.

## Changes

- **`src/cli/publish.ts`** — replace the unconditional `published_at` block with a version check (`draftIsNewerThanPublished`): re-promote when `state.version` is strictly newer than the parsed `published_version`; otherwise exit 1 with an actionable message pointing at `iterate`. A malformed/absent `published_version` conservatively allows the republish so a user is never stuck on a corrupted snapshot.
- **`src/loop/version.ts`** — two new pure helpers:
  - `parsePublishedLabel("v0.2") → "0.2.0"` (inverse of `formatVersionLabel`; `null` on malformed).
  - `compareSemver(a, b)` — **numeric** triple compare (so `0.10.0 > 0.9.0`); throws on malformed input.
- **Tests (red→green):**
  - `tests/loop/version.test.ts` — parse + compare, incl. the lexical-vs-numeric `v0.10 > v0.9` case and malformed inputs.
  - `tests/cli/publish.test.ts` — new test: after publishing v0.2, advancing the committed draft to v0.3 re-promotes it (snapshot, `published_at`/`published_version`, and the `spec(<slug>): publish v0.3` commit all update). The existing second-publish test now asserts the **same-version** case still exits 1.
- **`README.md` / `CHANGELOG.md`** — document the repeatable loop / the fix.

## Why this approach

Chosen over a new `--force`/`--republish` flag because it makes the existing happy path (`iterate` then `publish` again) Just Work with no new surface, while still guarding the genuine no-op case. The brief-staleness symptom is fixed transitively: once a newer draft is promoted, `brief` reads the updated snapshot.

## Verification

- `bun test tests/loop/version.test.ts tests/cli/publish.test.ts` → **32 pass, 0 fail**.
- `tsc --noEmit`, `eslint`, `prettier --check` on changed files → clean.
- Broader `tests/{cli/publish,loop,publish}` run: only the 3 pre-existing `revise-timeout.test.ts` failures (an "ambiguous HEAD" test-harness issue present on clean `main`, confirmed by stashing this change) — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgqRfkeQicSAW2snfVrcrG)_