### PR TITLE
fix(structuredAsk): eliminate ask()-wrapper schema conflict (persona + interview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samospec",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Git-native CLI that turns a rough idea into a reviewed, versioned specification document.",
   "type": "module",
   "bin": {

--- a/src/adapter/claude.ts
+++ b/src/adapter/claude.ts
@@ -54,12 +54,16 @@ import {
   type ModelInfo,
   type ReviseInput,
   type ReviseOutput,
+  type StructuredAskInput,
+  type StructuredAskOutput,
   AskInputSchema,
   AskOutputSchema,
   CritiqueInputSchema,
   CritiqueOutputSchema,
   ReviseInputSchema,
   ReviseOutputSchema,
+  StructuredAskInputSchema,
+  StructuredAskOutputSchema,
 } from "./types.ts";
 
 // ---------- constants ----------
@@ -354,6 +358,32 @@ export class ClaudeAdapter implements Adapter {
     });
     const parsed = parseAskJson(raw, input.opts.effort);
     return AskOutputSchema.parse(parsed);
+  }
+
+  async structuredAsk(input: StructuredAskInput): Promise<StructuredAskOutput> {
+    StructuredAskInputSchema.parse(input);
+    const prompt = buildStructuredAskPrompt(input);
+    const raw = await this.runWithRetries({
+      prompt,
+      timeoutMs: input.opts.timeout,
+      effort: input.opts.effort,
+      structured: true,
+    });
+    // Return the raw JSON string; caller parses it against their own schema.
+    // We still normalize usage + effort_used for consistent bookkeeping.
+    const parsed = preParseJson<Record<string, unknown>>(raw);
+    if (!parsed.ok) {
+      throw new ClaudeAdapterError({
+        kind: "terminal",
+        reason: "schema_violation",
+        detail: `structuredAsk: response is not valid JSON: ${parsed.error.message}`,
+      });
+    }
+    return StructuredAskOutputSchema.parse({
+      rawJson: raw,
+      usage: null,
+      effort_used: input.opts.effort,
+    });
   }
 
   async critique(input: CritiqueInput): Promise<CritiqueOutput> {
@@ -726,6 +756,24 @@ export function buildAskPrompt(input: AskInput): string {
     ctx +
     `\n\nQuestion:\n${input.prompt}\n`
   );
+}
+
+/**
+ * Prompt builder for structuredAsk(). Unlike buildAskPrompt(), this does
+ * NOT prepend the outer { "answer": string } schema directive. The caller's
+ * prompt is expected to already contain the full "Respond ONLY with ..."
+ * instruction for its own domain JSON shape (e.g. { "persona", "rationale" }
+ * for persona, { "questions": [...] } for interview).
+ *
+ * Passing a domain prompt through this builder keeps the model's instruction
+ * set unambiguous — exactly ONE schema directive, from the caller.
+ */
+export function buildStructuredAskPrompt(input: StructuredAskInput): string {
+  const ctx = input.context === "" ? "" : `\n\nContext:\n${input.context}\n`;
+  const autonomyBlock = renderAutonomyPolicySnapshotPromptBlock(
+    input.autonomy_policy,
+  );
+  return autonomyBlock + ctx + input.prompt;
 }
 
 export function buildCritiquePrompt(input: CritiqueInput): string {

--- a/src/adapter/codex.ts
+++ b/src/adapter/codex.ts
@@ -81,12 +81,16 @@ import {
   type ModelInfo,
   type ReviseInput,
   type ReviseOutput,
+  type StructuredAskInput,
+  type StructuredAskOutput,
   AskInputSchema,
   AskOutputSchema,
   CritiqueInputSchema,
   CritiqueOutputSchema,
   ReviseInputSchema,
   ReviseOutputSchema,
+  StructuredAskInputSchema,
+  StructuredAskOutputSchema,
 } from "./types.ts";
 
 // ---------- constants ----------
@@ -343,6 +347,31 @@ export class CodexAdapter implements Adapter {
     const parsed = parseStructuredJson(raw, input.opts.effort);
     const base = AskOutputSchema.parse(parsed);
     return accountDefault ? { ...base, account_default: true } : base;
+  }
+
+  async structuredAsk(input: StructuredAskInput): Promise<StructuredAskOutput> {
+    StructuredAskInputSchema.parse(input);
+    const prompt = buildStructuredAskPrompt(input);
+    const { raw } = await this.runWithRetries({
+      prompt,
+      timeoutMs: input.opts.timeout,
+      effort: input.opts.effort,
+      structured: true,
+    });
+    // Validate the raw output is parseable JSON before returning.
+    const parsed = preParseJson<Record<string, unknown>>(raw);
+    if (!parsed.ok) {
+      throw new CodexAdapterError({
+        kind: "terminal",
+        reason: "schema_violation",
+        detail: `structuredAsk: response is not valid JSON: ${parsed.error.message}`,
+      });
+    }
+    return StructuredAskOutputSchema.parse({
+      rawJson: raw,
+      usage: null,
+      effort_used: input.opts.effort,
+    });
   }
 
   async critique(input: CritiqueInput): Promise<CritiqueOutput> {
@@ -672,6 +701,19 @@ function buildAskPrompt(input: AskInput): string {
     ctx +
     `\n\nQuestion:\n${input.prompt}\n`
   );
+}
+
+/**
+ * Like buildAskPrompt but does NOT inject the outer { "answer": string }
+ * wrapper. Used by structuredAsk() when the caller's prompt already carries
+ * the full schema directive for a domain-specific JSON shape.
+ */
+function buildStructuredAskPrompt(input: StructuredAskInput): string {
+  const ctx = input.context === "" ? "" : `\n\nContext:\n${input.context}\n`;
+  const autonomyBlock = renderAutonomyPolicySnapshotPromptBlock(
+    input.autonomy_policy,
+  );
+  return autonomyBlock + ctx + input.prompt;
 }
 
 /**

--- a/src/adapter/contract-test.ts
+++ b/src/adapter/contract-test.ts
@@ -25,6 +25,7 @@ import {
   type CritiqueInput,
   type EffortLevel,
   type ReviseInput,
+  type StructuredAskInput,
   AskOutputSchema,
   AuthStatusSchema,
   CritiqueOutputSchema,
@@ -32,6 +33,7 @@ import {
   EffortLevelSchema,
   ModelInfoSchema,
   ReviseOutputSchema,
+  StructuredAskOutputSchema,
 } from "./types.ts";
 
 export interface AdapterContractInput {
@@ -54,6 +56,12 @@ const SAMPLE_OPTS = Object.freeze({
 
 const SAMPLE_ASK: AskInput = {
   prompt: "ping",
+  context: "",
+  opts: SAMPLE_OPTS,
+};
+const SAMPLE_STRUCTURED_ASK: StructuredAskInput = {
+  prompt:
+    'Respond ONLY with a JSON object: { "result": "pong" }. Do not wrap in code fences.',
   context: "",
   opts: SAMPLE_OPTS,
 };
@@ -99,6 +107,10 @@ export async function runAdapterContract(
   // Work
   const ask = await adapter.ask(SAMPLE_ASK);
   AskOutputSchema.parse(ask);
+
+  const structuredAsk = await adapter.structuredAsk(SAMPLE_STRUCTURED_ASK);
+  StructuredAskOutputSchema.parse(structuredAsk);
+  expect(typeof structuredAsk.rawJson).toBe("string");
 
   const critique = await adapter.critique(SAMPLE_CRITIQUE);
   CritiqueOutputSchema.parse(critique);

--- a/src/adapter/fake-adapter.ts
+++ b/src/adapter/fake-adapter.ts
@@ -18,6 +18,8 @@ import {
   type ModelInfo,
   type ReviseInput,
   type ReviseOutput,
+  type StructuredAskInput,
+  type StructuredAskOutput,
   AskInputSchema,
   AskOutputSchema,
   AuthStatusSchema,
@@ -26,6 +28,8 @@ import {
   DetectResultSchema,
   ReviseInputSchema,
   ReviseOutputSchema,
+  StructuredAskInputSchema,
+  StructuredAskOutputSchema,
 } from "./types.ts";
 
 export interface FakeAdapterProgram {
@@ -35,6 +39,7 @@ export interface FakeAdapterProgram {
   readonly supports_effort: ReadonlySet<EffortLevel>;
   readonly models: readonly ModelInfo[];
   readonly ask: AskOutput;
+  readonly structuredAsk: StructuredAskOutput;
   readonly critique: CritiqueOutput;
   readonly revise: ReviseOutput;
 }
@@ -57,6 +62,12 @@ const DEFAULT_MODELS: readonly ModelInfo[] = [
 
 const DEFAULT_ASK: AskOutput = {
   answer: "fake answer",
+  usage: null,
+  effort_used: "max",
+};
+
+const DEFAULT_STRUCTURED_ASK: StructuredAskOutput = {
+  rawJson: "{}",
   usage: null,
   effort_used: "max",
 };
@@ -96,6 +107,7 @@ const DEFAULT_PROGRAM: FakeAdapterProgram = {
   ]),
   models: DEFAULT_MODELS,
   ask: DEFAULT_ASK,
+  structuredAsk: DEFAULT_STRUCTURED_ASK,
   critique: DEFAULT_CRITIQUE,
   revise: DEFAULT_REVISE,
 };
@@ -121,6 +133,12 @@ export function createFakeAdapter(
       AskInputSchema.parse(input);
       return Promise.resolve(AskOutputSchema.parse(program.ask));
     },
+    structuredAsk: (input: StructuredAskInput) => {
+      StructuredAskInputSchema.parse(input);
+      return Promise.resolve(
+        StructuredAskOutputSchema.parse(program.structuredAsk),
+      );
+    },
     critique: (input: CritiqueInput) => {
       CritiqueInputSchema.parse(input);
       return Promise.resolve(CritiqueOutputSchema.parse(program.critique));
@@ -130,4 +148,30 @@ export function createFakeAdapter(
       return Promise.resolve(ReviseOutputSchema.parse(program.revise));
     },
   };
+}
+
+/**
+ * Returns a stub `structuredAsk` method that never resolves (simulates a
+ * hanging adapter). Used in tests that need an Adapter with a non-resolving
+ * structuredAsk without going through createFakeAdapter.
+ */
+export function hangingStructuredAsk(): (
+  input: StructuredAskInput,
+) => Promise<StructuredAskOutput> {
+  return (_input: StructuredAskInput) =>
+    new Promise(() => {
+      /* hangs forever */
+    });
+}
+
+/**
+ * Returns a stub `structuredAsk` method that immediately rejects with the
+ * given error message. Useful for testing adapters that shouldn't be called
+ * for persona/interview.
+ */
+export function rejectingStructuredAsk(
+  msg = "structuredAsk not expected in this test",
+): (input: StructuredAskInput) => Promise<StructuredAskOutput> {
+  return (_input: StructuredAskInput) =>
+    Promise.reject(new Error(msg));
 }

--- a/src/adapter/fake-adapter.ts
+++ b/src/adapter/fake-adapter.ts
@@ -172,6 +172,5 @@ export function hangingStructuredAsk(): (
 export function rejectingStructuredAsk(
   msg = "structuredAsk not expected in this test",
 ): (input: StructuredAskInput) => Promise<StructuredAskOutput> {
-  return (_input: StructuredAskInput) =>
-    Promise.reject(new Error(msg));
+  return (_input: StructuredAskInput) => Promise.reject(new Error(msg));
 }

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -112,6 +112,37 @@ export const AskOutputSchema = z.object({
 });
 export type AskOutput = z.infer<typeof AskOutputSchema>;
 
+// ---------- structuredAsk — caller owns the schema directive ----------
+
+/**
+ * Input for structuredAsk(). Identical to AskInput but the prompt
+ * ALREADY contains the full "Respond ONLY with ..." schema instruction.
+ * The adapter must NOT inject an additional outer { "answer": string }
+ * wrapper — that would produce two contradictory schema directives and
+ * cause the model to emit one shape while the caller parses another.
+ */
+export const StructuredAskInputSchema = z.object({
+  prompt: z.string().min(1),
+  context: z.string(),
+  opts: WorkOptsSchema,
+  autonomy_policy: autonomyPolicySnapshotSchema.optional(),
+});
+export type StructuredAskInput = z.infer<typeof StructuredAskInputSchema>;
+
+/**
+ * Output for structuredAsk(). Returns the model's raw JSON string exactly
+ * as emitted (after code-fence stripping). The caller is responsible for
+ * parsing it against their own domain schema (e.g. personaAskSchema,
+ * LeadResponseSchema). No { "answer" } envelope is applied.
+ */
+export const StructuredAskOutputSchema = z.object({
+  rawJson: z.string(),
+  usage: UsageSchema,
+  effort_used: EffortLevelSchema,
+  account_default: z.boolean().optional(),
+});
+export type StructuredAskOutput = z.infer<typeof StructuredAskOutputSchema>;
+
 // SPEC §7 review taxonomy.
 export const FindingCategorySchema = z.enum([
   "ambiguity",
@@ -268,6 +299,13 @@ export interface Adapter {
 
   // Work
   ask(input: AskInput): Promise<AskOutput>;
+  /**
+   * Like ask() but does NOT inject the outer { "answer": string } wrapper.
+   * Use this when the caller's prompt already carries a full "Respond ONLY
+   * with ..." schema directive (e.g. persona, interview). Returns the raw
+   * JSON string; the caller parses it against their own domain schema.
+   */
+  structuredAsk(input: StructuredAskInput): Promise<StructuredAskOutput>;
   critique(input: CritiqueInput): Promise<CritiqueOutput>;
   revise(input: ReviseInput): Promise<ReviseOutput>;
 }

--- a/src/cli/interview.ts
+++ b/src/cli/interview.ts
@@ -34,7 +34,11 @@ import { z } from "zod";
 
 import { UNIFIED_DEFAULT_EFFORT } from "../adapter/effort.ts";
 import { preParseJson } from "../adapter/json-parse.ts";
-import type { Adapter, AskInput, EffortLevel } from "../adapter/types.ts";
+import type {
+  Adapter,
+  EffortLevel,
+  StructuredAskInput,
+} from "../adapter/types.ts";
 import { PERSONA_FORM_RE } from "./persona.ts";
 
 // ---------- constants ----------
@@ -337,21 +341,25 @@ export async function runInterview(
   let currentPrompt = prompt;
   let lastDuplicates: string[] = [];
   for (let attempt = 0; attempt <= MAX_DEDUPE_RETRIES; attempt += 1) {
-    const askInput: AskInput = {
+    // Use structuredAsk so the adapter does NOT inject an outer
+    // { "answer": string } wrapper. buildInterviewPrompt already carries a
+    // "Respond ONLY with { questions: [...] }" directive; a second wrapper
+    // from buildAskPrompt creates a schema conflict causing parse failures.
+    const askInput: StructuredAskInput = {
       prompt: currentPrompt,
       context: "",
       opts: { effort, timeout: timeoutMs },
     };
     let askOut;
     try {
-      askOut = await adapter.ask(askInput);
+      askOut = await adapter.structuredAsk(askInput);
     } catch (err) {
       throw new InterviewTerminalError(
         err instanceof Error ? err.message : String(err),
       );
     }
 
-    const parsed = preParseJson(askOut.answer);
+    const parsed = preParseJson(askOut.rawJson);
     if (!parsed.ok) {
       throw new InterviewTerminalError(
         `lead response was not valid JSON: ${parsed.error.message}`,

--- a/src/cli/persona.ts
+++ b/src/cli/persona.ts
@@ -21,7 +21,11 @@ import { z } from "zod";
 
 import { UNIFIED_DEFAULT_EFFORT } from "../adapter/effort.ts";
 import { preParseJson } from "../adapter/json-parse.ts";
-import type { Adapter, AskInput, EffortLevel } from "../adapter/types.ts";
+import type {
+  Adapter,
+  EffortLevel,
+  StructuredAskInput,
+} from "../adapter/types.ts";
 
 // SPEC §5 Phase 2 canonical form. Matches:
 //   Veteran "<non-empty skill>" expert
@@ -191,24 +195,27 @@ async function askForPersona(
   prompt: string,
   effort: EffortLevel,
   timeoutMs: number,
-  idea?: string,
 ): Promise<string> {
-  const askInput: AskInput = {
+  // Use structuredAsk so the adapter does NOT inject an outer
+  // { "answer": string } wrapper. buildPersonaPrompt already carries a
+  // "Respond ONLY with { persona, rationale }" directive; adding a second
+  // "Respond ONLY with { answer }" directive from buildAskPrompt creates a
+  // schema conflict that causes non-deterministic parse failures.
+  const askInput: StructuredAskInput = {
     prompt,
     context: "",
     opts: { effort, timeout: timeoutMs },
-    ...(typeof idea === "string" && idea.length > 0 ? { idea } : {}),
   };
   let output;
   try {
-    output = await adapter.ask(askInput);
+    output = await adapter.structuredAsk(askInput);
   } catch (err) {
     throw new PersonaTerminalError(
       "adapter_error",
       err instanceof Error ? err.message : String(err),
     );
   }
-  return output.answer;
+  return output.rawJson;
 }
 
 /**
@@ -238,13 +245,7 @@ export async function proposePersona(
   });
 
   // First attempt.
-  const rawFirst = await askForPersona(
-    adapter,
-    prompt,
-    effort,
-    timeoutMs,
-    input.idea,
-  );
+  const rawFirst = await askForPersona(adapter, prompt, effort, timeoutMs);
   let validated = parsePersonaAnswer(rawFirst);
 
   // One repair retry if the first attempt failed the schema.
@@ -255,7 +256,6 @@ export async function proposePersona(
       repairPrompt,
       effort,
       timeoutMs,
-      input.idea,
     );
     validated = parsePersonaAnswer(rawSecond);
   }

--- a/tests/adapter/structured-ask-schema-conflict.test.ts
+++ b/tests/adapter/structured-ask-schema-conflict.test.ts
@@ -38,11 +38,11 @@ function countOccurrences(haystack: string, re: RegExp): number {
 // A domain prompt that has its own "Respond ONLY with" directive (like
 // persona.ts:155-158 and interview.ts:239-242 do).
 const DOMAIN_PROMPT_WITH_SCHEMA =
-  'You are the samospec lead. Given a rough idea, propose a single expert persona.\n\n' +
-  'Respond ONLY with a JSON object:\n' +
+  "You are the samospec lead. Given a rough idea, propose a single expert persona.\n\n" +
+  "Respond ONLY with a JSON object:\n" +
   '  { "persona": "Veteran \\"<skill>\\" expert", "rationale": "..." }\n' +
-  'Do not wrap in code fences.\n\n' +
-  'Idea:\nA recipe sharing app\n';
+  "Do not wrap in code fences.\n\n" +
+  "Idea:\nA recipe sharing app\n";
 
 function makeAskInputWithDomainPrompt(): AskInput {
   return {
@@ -125,7 +125,11 @@ describe("Adapter interface — structuredAsk method", () => {
 
   test("structuredAsk returns a StructuredAskOutput with a rawJson string field", async () => {
     const adapter = createFakeAdapter({
-      structuredAsk: { rawJson: '{"persona":"Veteran \\"Test\\" expert","rationale":"test"}', usage: null, effort_used: "max" },
+      structuredAsk: {
+        rawJson: '{"persona":"Veteran \\"Test\\" expert","rationale":"test"}',
+        usage: null,
+        effort_used: "max",
+      },
     });
     const result = await adapter.structuredAsk(makeStructuredAskInput());
     expect(typeof result.rawJson).toBe("string");
@@ -133,7 +137,8 @@ describe("Adapter interface — structuredAsk method", () => {
   });
 
   test("structuredAsk rawJson is parseable JSON", async () => {
-    const domainJson = '{"questions":[{"id":"q1","text":"What is the target user?","options":["A","B"]}]}';
+    const domainJson =
+      '{"questions":[{"id":"q1","text":"What is the target user?","options":["A","B"]}]}';
     const adapter = createFakeAdapter({
       structuredAsk: { rawJson: domainJson, usage: null, effort_used: "max" },
     });
@@ -151,7 +156,8 @@ describe("persona call site — uses structuredAsk, no { answer } wrapper collis
     // in the RED test phase when the interface doesn't exist yet.
     const { proposePersona } = await import("../../src/cli/persona.ts");
 
-    const personaJson = '{"persona":"Veteran \\"Recipe Developer\\" expert","rationale":"Core skill for recipe app"}';
+    const personaJson =
+      '{"persona":"Veteran \\"Recipe Developer\\" expert","rationale":"Core skill for recipe app"}';
     const adapter = createFakeAdapter({
       structuredAsk: { rawJson: personaJson, usage: null, effort_used: "max" },
     });

--- a/tests/adapter/structured-ask-schema-conflict.test.ts
+++ b/tests/adapter/structured-ask-schema-conflict.test.ts
@@ -1,0 +1,173 @@
+// Copyright 2026 Nikolay Samokhvalov.
+
+// RED test for the ask()-wrapper schema conflict.
+//
+// Bug: buildAskPrompt() always prepends "Respond ONLY with { "answer": string
+// ... }" before the caller's prompt. When persona.ts / interview.ts call
+// adapter.ask() with a domain prompt that already contains its own
+// "Respond ONLY with { "persona", "rationale" }" (or "questions") directive,
+// the model sees TWO contradictory schema instructions. It picks one shape
+// (e.g. { "persona", "rationale" }) but AskOutputSchema.parse() requires
+// { "answer": string } → ZodError → PersonaTerminalError / exit 4.
+//
+// Fix: introduce adapter.structuredAsk() whose prompt builder does NOT inject
+// the outer { answer } wrapper. The caller's prompt already carries the full
+// schema instruction. Persona + interview call sites switch to structuredAsk;
+// the result is the raw domain JSON string (parsed by the caller's own schema).
+//
+// These tests are assertable without any LLM call — they validate the
+// PROMPT TEXT produced by the builders (pure functions).
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildAskPrompt,
+  buildStructuredAskPrompt,
+} from "../../src/adapter/claude.ts";
+import type { AskInput } from "../../src/adapter/types.ts";
+import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
+import type { Adapter, StructuredAskInput, StructuredAskOutput } from "../../src/adapter/types.ts";
+
+// The exact phrase both prompt builders inject.
+const RESPOND_ONLY_PATTERN = /Respond ONLY with/gi;
+
+function countOccurrences(haystack: string, re: RegExp): number {
+  const global = new RegExp(re.source, "gi");
+  return (haystack.match(global) ?? []).length;
+}
+
+// A domain prompt that has its own "Respond ONLY with" directive (like
+// persona.ts:155-158 and interview.ts:239-242 do).
+const DOMAIN_PROMPT_WITH_SCHEMA =
+  'You are the samospec lead. Given a rough idea, propose a single expert persona.\n\n' +
+  'Respond ONLY with a JSON object:\n' +
+  '  { "persona": "Veteran \\"<skill>\\" expert", "rationale": "..." }\n' +
+  'Do not wrap in code fences.\n\n' +
+  'Idea:\nA recipe sharing app\n';
+
+function makeAskInputWithDomainPrompt(): AskInput {
+  return {
+    prompt: DOMAIN_PROMPT_WITH_SCHEMA,
+    context: "",
+    opts: { effort: "max", timeout: 120_000 },
+  };
+}
+
+function makeStructuredAskInput(): StructuredAskInput {
+  return {
+    prompt: DOMAIN_PROMPT_WITH_SCHEMA,
+    context: "",
+    opts: { effort: "max", timeout: 120_000 },
+  };
+}
+
+// ---------- 1. Demonstrate the conflict in buildAskPrompt ----------
+
+describe("buildAskPrompt — schema conflict (BEFORE fix)", () => {
+  test("buildAskPrompt wraps the caller prompt with its own Respond-ONLY directive", () => {
+    const prompt = buildAskPrompt(makeAskInputWithDomainPrompt());
+    // The outer wrapper always adds one "Respond ONLY with"
+    const count = countOccurrences(prompt, RESPOND_ONLY_PATTERN);
+    // The resulting prompt has at least 2: one from buildAskPrompt wrapper,
+    // one from the domain prompt inside.
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  test("buildAskPrompt outer wrapper requires { answer: string } schema", () => {
+    const prompt = buildAskPrompt(makeAskInputWithDomainPrompt());
+    expect(prompt).toContain('"answer"');
+    expect(prompt).toContain('"usage"');
+  });
+
+  test("buildAskPrompt outer wrapper conflicts with domain { persona, rationale } schema", () => {
+    const prompt = buildAskPrompt(makeAskInputWithDomainPrompt());
+    // Both schemas are present in the combined prompt — a clear contradiction.
+    expect(prompt).toContain('"answer"');
+    expect(prompt).toContain('"persona"');
+    // Model sees two contradictory "Respond ONLY with" — non-deterministic failure.
+  });
+});
+
+// ---------- 2. buildStructuredAskPrompt — NO outer {answer} wrapper ----------
+
+describe("buildStructuredAskPrompt — no outer wrapper (AFTER fix)", () => {
+  test("buildStructuredAskPrompt is exported from claude.ts", () => {
+    expect(typeof buildStructuredAskPrompt).toBe("function");
+  });
+
+  test("buildStructuredAskPrompt does NOT inject the outer { answer } wrapper", () => {
+    const prompt = buildStructuredAskPrompt(makeStructuredAskInput());
+    // The outer { answer } directive must NOT be present.
+    expect(prompt).not.toContain('"answer"');
+  });
+
+  test("buildStructuredAskPrompt contains exactly ONE Respond-ONLY directive", () => {
+    const prompt = buildStructuredAskPrompt(makeStructuredAskInput());
+    const count = countOccurrences(prompt, RESPOND_ONLY_PATTERN);
+    expect(count).toBe(1);
+  });
+
+  test("buildStructuredAskPrompt preserves the caller-supplied domain prompt verbatim", () => {
+    const prompt = buildStructuredAskPrompt(makeStructuredAskInput());
+    // The domain schema instruction must survive intact.
+    expect(prompt).toContain('"persona"');
+    expect(prompt).toContain('"rationale"');
+    expect(prompt).toContain("Idea:\nA recipe sharing app");
+  });
+});
+
+// ---------- 3. Adapter interface has structuredAsk ----------
+
+describe("Adapter interface — structuredAsk method", () => {
+  test("createFakeAdapter returns an adapter with a structuredAsk method", () => {
+    const adapter = createFakeAdapter();
+    expect(typeof adapter.structuredAsk).toBe("function");
+  });
+
+  test("structuredAsk returns a StructuredAskOutput with a rawJson string field", async () => {
+    const adapter = createFakeAdapter({
+      structuredAsk: { rawJson: '{"persona":"Veteran \\"Test\\" expert","rationale":"test"}', usage: null, effort_used: "max" },
+    });
+    const result = await adapter.structuredAsk(makeStructuredAskInput());
+    expect(typeof result.rawJson).toBe("string");
+    expect(result.rawJson).toContain("persona");
+  });
+
+  test("structuredAsk rawJson is parseable JSON", async () => {
+    const domainJson = '{"questions":[{"id":"q1","text":"What is the target user?","options":["A","B"]}]}';
+    const adapter = createFakeAdapter({
+      structuredAsk: { rawJson: domainJson, usage: null, effort_used: "max" },
+    });
+    const result = await adapter.structuredAsk(makeStructuredAskInput());
+    const parsed = JSON.parse(result.rawJson);
+    expect(Array.isArray(parsed.questions)).toBe(true);
+  });
+});
+
+// ---------- 4. Persona call site uses structuredAsk (no double-wrap) ----------
+
+describe("persona call site — uses structuredAsk, no { answer } wrapper collision", () => {
+  test("proposePersona succeeds when structuredAsk returns raw { persona, rationale } JSON", async () => {
+    // Import proposePersona dynamically to avoid top-level import errors
+    // in the RED test phase when the interface doesn't exist yet.
+    const { proposePersona } = await import("../../src/cli/persona.ts");
+
+    const personaJson = '{"persona":"Veteran \\"Recipe Developer\\" expert","rationale":"Core skill for recipe app"}';
+    const adapter = createFakeAdapter({
+      structuredAsk: { rawJson: personaJson, usage: null, effort_used: "max" },
+    });
+
+    const result = await proposePersona(
+      {
+        idea: "A recipe sharing app",
+        explain: false,
+        subscriptionAuth: false,
+        choice: { kind: "accept" },
+      },
+      adapter,
+    );
+
+    expect(result.persona).toBe('Veteran "Recipe Developer" expert');
+    expect(result.skill).toBe("Recipe Developer");
+  });
+});

--- a/tests/adapter/structured-ask-schema-conflict.test.ts
+++ b/tests/adapter/structured-ask-schema-conflict.test.ts
@@ -24,9 +24,8 @@ import {
   buildAskPrompt,
   buildStructuredAskPrompt,
 } from "../../src/adapter/claude.ts";
-import type { AskInput } from "../../src/adapter/types.ts";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
-import type { Adapter, StructuredAskInput, StructuredAskOutput } from "../../src/adapter/types.ts";
+import type { AskInput, StructuredAskInput } from "../../src/adapter/types.ts";
 
 // The exact phrase both prompt builders inject.
 const RESPOND_ONLY_PATTERN = /Respond ONLY with/gi;

--- a/tests/cli/architecture-integration.test.ts
+++ b/tests/cli/architecture-integration.test.ts
@@ -13,10 +13,10 @@ import path from "node:path";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { runIterate } from "../../src/cli/iterate.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
@@ -33,8 +33,8 @@ import {
 import { writeState } from "../../src/state/store.ts";
 import { createTempRepo, type TempRepo } from "../git/helpers/tempRepo.ts";
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 function personaJson(): string {
@@ -65,10 +65,12 @@ function makeLeadAdapter(): Adapter {
   let askCall = 0;
   return {
     ...base,
-    ask: (_input: AskInput): Promise<AskOutput> => {
-      const a = answers[askCall] ?? answers[answers.length - 1] ?? "";
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
+      const a = answers[askCall] ?? answers[answers.length - 1] ?? "{}";
       askCall += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
     revise: (_input: ReviseInput): Promise<ReviseOutput> =>
       Promise.resolve({
@@ -316,10 +318,12 @@ function makeResumeAdapter(): Adapter {
   let askCall = 0;
   return {
     ...base,
-    ask: (_input: AskInput): Promise<AskOutput> => {
-      const a = answers[askCall] ?? answers[answers.length - 1] ?? "";
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
+      const a = answers[askCall] ?? answers[answers.length - 1] ?? "{}";
       askCall += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
     revise: (_input: ReviseInput): Promise<ReviseOutput> =>
       Promise.resolve({

--- a/tests/cli/doctor-effort-support.test.ts
+++ b/tests/cli/doctor-effort-support.test.ts
@@ -21,6 +21,7 @@ function fakeAdapter(vendor: string, detect: DetectResult): Adapter {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: vendor }]),
     ask: () => Promise.reject(new Error("unused")),
+    structuredAsk: () => Promise.reject(new Error("unused")),
     critique: () => Promise.reject(new Error("unused")),
     revise: () => Promise.reject(new Error("unused")),
   };

--- a/tests/cli/interview.test.ts
+++ b/tests/cli/interview.test.ts
@@ -11,9 +11,9 @@ import path from "node:path";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   EffortLevel,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import {
   INTERVIEW_MAX_QUESTIONS,
@@ -25,27 +25,30 @@ import {
   writeInterview,
 } from "../../src/cli/interview.ts";
 
-function askOutputWithAnswer(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOutputWithRawJson(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 interface ScriptedAskAdapter extends Adapter {
-  readonly asks: readonly AskInput[];
+  readonly asks: readonly StructuredAskInput[];
 }
 
 function makeScriptedAskAdapter(
-  answers: readonly string[],
+  rawJsonAnswers: readonly string[],
 ): ScriptedAskAdapter {
   const base = createFakeAdapter();
-  const asks: AskInput[] = [];
+  const asks: StructuredAskInput[] = [];
   let call = 0;
   const scripted: Adapter = {
     ...base,
-    ask: (input: AskInput): Promise<AskOutput> => {
+    structuredAsk: (input: StructuredAskInput): Promise<StructuredAskOutput> => {
       asks.push(input);
-      const answer = answers[call] ?? answers[answers.length - 1] ?? "";
+      const rawJson =
+        rawJsonAnswers[call] ??
+        rawJsonAnswers[rawJsonAnswers.length - 1] ??
+        "{}";
       call += 1;
-      return Promise.resolve(askOutputWithAnswer(answer));
+      return Promise.resolve(structuredAskOutputWithRawJson(rawJson));
     },
   };
   const result = Object.assign(scripted, { asks }) as ScriptedAskAdapter;

--- a/tests/cli/interview.test.ts
+++ b/tests/cli/interview.test.ts
@@ -41,7 +41,9 @@ function makeScriptedAskAdapter(
   let call = 0;
   const scripted: Adapter = {
     ...base,
-    structuredAsk: (input: StructuredAskInput): Promise<StructuredAskOutput> => {
+    structuredAsk: (
+      input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
       asks.push(input);
       const rawJson =
         rawJsonAnswers[call] ??

--- a/tests/cli/iterate-progress-wrap.test.ts
+++ b/tests/cli/iterate-progress-wrap.test.ts
@@ -33,6 +33,8 @@ import type {
   ModelInfo,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { wrapAdaptersForProgress } from "../../src/cli/iterate.ts";
 import type { ProgressReporter } from "../../src/cli/iterate-progress.ts";
@@ -71,6 +73,12 @@ class FakeClassAdapter implements Adapter {
       usage: null,
       effort_used: "max",
     });
+  }
+
+  structuredAsk(
+    _input: StructuredAskInput,
+  ): Promise<StructuredAskOutput> {
+    return Promise.reject(new Error("structuredAsk not expected"));
   }
 
   critique(_input: CritiqueInput): Promise<CritiqueOutput> {

--- a/tests/cli/iterate-progress-wrap.test.ts
+++ b/tests/cli/iterate-progress-wrap.test.ts
@@ -75,9 +75,7 @@ class FakeClassAdapter implements Adapter {
     });
   }
 
-  structuredAsk(
-    _input: StructuredAskInput,
-  ): Promise<StructuredAskOutput> {
+  structuredAsk(_input: StructuredAskInput): Promise<StructuredAskOutput> {
     return Promise.reject(new Error("structuredAsk not expected"));
   }
 

--- a/tests/cli/iterate-progress.test.ts
+++ b/tests/cli/iterate-progress.test.ts
@@ -270,7 +270,7 @@ function slowAdapter(
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: `${vendor}-max`, family: vendor }]),
     ask: () => Promise.reject(new Error("unused")),
-      structuredAsk: () => Promise.reject(new Error("unused")),
+    structuredAsk: () => Promise.reject(new Error("unused")),
     critique: async (_input: CritiqueInput) => {
       const startedAt = clock.now();
       await waitUntil(startedAt);

--- a/tests/cli/iterate-progress.test.ts
+++ b/tests/cli/iterate-progress.test.ts
@@ -270,6 +270,7 @@ function slowAdapter(
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: `${vendor}-max`, family: vendor }]),
     ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
     critique: async (_input: CritiqueInput) => {
       const startedAt = clock.now();
       await waitUntil(startedAt);

--- a/tests/cli/iterate.regression.test.ts
+++ b/tests/cli/iterate.regression.test.ts
@@ -531,6 +531,7 @@ describe("iterate regression — lead_terminal exit-4 messages are specific per 
         supports_effort: () => true,
         models: () => Promise.resolve([{ id: "x", family: "fake" }]),
         ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
         critique: () => Promise.reject(new Error("unused")),
         revise: () => Promise.reject(new Error(sub.errorMessage)),
       };
@@ -594,6 +595,7 @@ describe("iterate regression — lead_terminal exit-4 messages are specific per 
           supports_effort: () => true,
           models: () => Promise.resolve([{ id: "x", family: "fake" }]),
           ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
           critique: () => Promise.reject(new Error("unused")),
           revise: () => Promise.reject(new Error(errMsg)),
         };

--- a/tests/cli/iterate.regression.test.ts
+++ b/tests/cli/iterate.regression.test.ts
@@ -531,7 +531,7 @@ describe("iterate regression — lead_terminal exit-4 messages are specific per 
         supports_effort: () => true,
         models: () => Promise.resolve([{ id: "x", family: "fake" }]),
         ask: () => Promise.reject(new Error("unused")),
-      structuredAsk: () => Promise.reject(new Error("unused")),
+        structuredAsk: () => Promise.reject(new Error("unused")),
         critique: () => Promise.reject(new Error("unused")),
         revise: () => Promise.reject(new Error(sub.errorMessage)),
       };
@@ -595,7 +595,7 @@ describe("iterate regression — lead_terminal exit-4 messages are specific per 
           supports_effort: () => true,
           models: () => Promise.resolve([{ id: "x", family: "fake" }]),
           ask: () => Promise.reject(new Error("unused")),
-      structuredAsk: () => Promise.reject(new Error("unused")),
+          structuredAsk: () => Promise.reject(new Error("unused")),
           critique: () => Promise.reject(new Error("unused")),
           revise: () => Promise.reject(new Error(errMsg)),
         };

--- a/tests/cli/iterate.test.ts
+++ b/tests/cli/iterate.test.ts
@@ -321,6 +321,7 @@ describe("cli/iterate — partial reviewer failure", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => Promise.reject(new Error("unused")),
       revise: (input) => {
         if (input.spec.includes("samospec:lead-directive")) {
@@ -383,6 +384,7 @@ describe("cli/iterate — both seats fail then retry succeeds", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => {
         if (label === "a") {
           aCalls += 1;
@@ -485,6 +487,7 @@ describe("cli/iterate — reviewers exhausted", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => Promise.reject(new Error("persistent fail")),
       revise: () => Promise.reject(new Error("unused")),
     };
@@ -523,6 +526,7 @@ describe("cli/iterate — lead_terminal", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => Promise.reject(new Error("unused")),
       revise: () => Promise.reject(new Error("model refused")),
     };

--- a/tests/cli/new-accept-persona.test.ts
+++ b/tests/cli/new-accept-persona.test.ts
@@ -14,17 +14,17 @@ import path from "node:path";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { runInit } from "../../src/cli/init.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { buildNonInteractiveResolvers } from "../../src/cli/non-interactive.ts";
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 function personaJson(skill: string): string {
@@ -49,10 +49,12 @@ function makeLeadAdapter(answers: readonly string[]): Adapter {
   let call = 0;
   return {
     ...base,
-    ask: (_input: AskInput): Promise<AskOutput> => {
-      const a = answers[call] ?? answers[answers.length - 1] ?? "";
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
+      const a = answers[call] ?? answers[answers.length - 1] ?? "{}";
       call += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
     revise: (_input: ReviseInput): Promise<ReviseOutput> =>
       Promise.resolve({

--- a/tests/cli/new-auto-commit-94.test.ts
+++ b/tests/cli/new-auto-commit-94.test.ts
@@ -27,10 +27,10 @@ import { spawnSync } from "node:child_process";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { runInit } from "../../src/cli/init.ts";
@@ -39,8 +39,8 @@ import { createTempRepo, type TempRepo } from "../git/helpers/tempRepo.ts";
 
 // ---------- fixture builders ----------
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 function personaJson(skill: string): string {
@@ -86,11 +86,15 @@ function makeAdapter(args: MakeAdapterArgs): {
   let askCall = 0;
   const adapter: Adapter = {
     ...base,
-    ask: (_input: AskInput): Promise<AskOutput> => {
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
       const a =
-        args.answers[askCall] ?? args.answers[args.answers.length - 1] ?? "";
+        args.answers[askCall] ??
+        args.answers[args.answers.length - 1] ??
+        "{}";
       askCall += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
     revise: (_input: ReviseInput): Promise<ReviseOutput> =>
       Promise.resolve(reviseOut()),

--- a/tests/cli/new-auto-commit-94.test.ts
+++ b/tests/cli/new-auto-commit-94.test.ts
@@ -90,9 +90,7 @@ function makeAdapter(args: MakeAdapterArgs): {
       _input: StructuredAskInput,
     ): Promise<StructuredAskOutput> => {
       const a =
-        args.answers[askCall] ??
-        args.answers[args.answers.length - 1] ??
-        "{}";
+        args.answers[askCall] ?? args.answers[args.answers.length - 1] ?? "{}";
       askCall += 1;
       return Promise.resolve(structuredAskOut(a));
     },

--- a/tests/cli/new-hang-recovery.test.ts
+++ b/tests/cli/new-hang-recovery.test.ts
@@ -28,6 +28,8 @@ import type {
   ModelInfo,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { runInit } from "../../src/cli/init.ts";
@@ -44,6 +46,12 @@ function makeHangingAdapter(): Adapter {
     models: (): Promise<readonly ModelInfo[]> =>
       Promise.resolve([{ id: "fake", family: "fake" }]),
     ask: (_input: AskInput): Promise<AskOutput> =>
+      new Promise(() => {
+        /* never resolves */
+      }),
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> =>
       new Promise(() => {
         /* never resolves */
       }),

--- a/tests/cli/new-hang-recovery.test.ts
+++ b/tests/cli/new-hang-recovery.test.ts
@@ -49,9 +49,7 @@ function makeHangingAdapter(): Adapter {
       new Promise(() => {
         /* never resolves */
       }),
-    structuredAsk: (
-      _input: StructuredAskInput,
-    ): Promise<StructuredAskOutput> =>
+    structuredAsk: (_input: StructuredAskInput): Promise<StructuredAskOutput> =>
       new Promise(() => {
         /* never resolves */
       }),

--- a/tests/cli/new-idea-file.test.ts
+++ b/tests/cli/new-idea-file.test.ts
@@ -18,10 +18,10 @@ import path from "node:path";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { loadIdeaFile } from "../../src/cli/non-interactive.ts";
 import { runInit } from "../../src/cli/init.ts";
@@ -155,8 +155,8 @@ describe("samospec new --idea-file — parse-time path validation", () => {
 // none asserted the happy path at the CLI level. We drive runCli against a
 // scripted fake adapter inside a throwaway repo via the test-only deps seam.
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 function personaJson(skill: string): string {
@@ -192,10 +192,12 @@ function makeIdeaFileAdapter(): {
   ];
   const adapter: Adapter = {
     ...base,
-    ask: (_input: AskInput): Promise<AskOutput> => {
-      const a = answers[askCall] ?? answers[answers.length - 1] ?? "";
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
+      const a = answers[askCall] ?? answers[answers.length - 1] ?? "{}";
       askCall += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
     revise: (input: ReviseInput): Promise<ReviseOutput> => {
       revises.push(input);

--- a/tests/cli/new-interview-protocol-jsonl.test.ts
+++ b/tests/cli/new-interview-protocol-jsonl.test.ts
@@ -39,10 +39,10 @@ import path from "node:path";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { runInit } from "../../src/cli/init.ts";
 import { runNew } from "../../src/cli/new.ts";
@@ -337,8 +337,8 @@ afterEach(() => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 function personaJson(skill: string): string {
@@ -359,10 +359,12 @@ function makeLeadAdapter(answers: readonly string[]): Adapter {
   let call = 0;
   return {
     ...base,
-    ask: (_input: AskInput): Promise<AskOutput> => {
-      const a = answers[call] ?? answers[answers.length - 1] ?? "";
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
+      const a = answers[call] ?? answers[answers.length - 1] ?? "{}";
       call += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
     revise: (_input: ReviseInput): Promise<ReviseOutput> =>
       Promise.resolve({
@@ -626,16 +628,15 @@ describe("samospec new --interview-protocol jsonl — spawnSync E2E (M4)", () =>
       // works even across re-invocations in the same PID.
       const counterPath = path.join(fakeBin, ".claude-count");
       writeFileSync(counterPath, "0");
-      // The adapter wraps every call's structured JSON inside
-      // {"answer": "...", "usage": null, "effort_used": "max"} for ask,
-      // and {"spec": "...", "ready": ..., "rationale": "...", "usage": null,
-      // "effort_used": "max"} for revise. `answer` is a JSON-string that
-      // the caller (persona / interview) re-parses.
-      const personaJsonStr = JSON.stringify({
+      // structuredAsk (persona + interview) receives the raw domain JSON
+      // directly from the model. revise() receives the spec JSON object.
+      // NOTE: since the persona and interview calls now use structuredAsk,
+      // the Claude stub must return the raw domain JSON (no {answer} wrapper).
+      const personaPayload = JSON.stringify({
         persona: 'Veteran "CLI engineer" expert',
         rationale: "pragmatic",
       });
-      const questionsJsonStr = JSON.stringify({
+      const questionsPayload = JSON.stringify({
         questions: [
           { id: "q1", text: "framework?", options: ["React", "Vue"] },
           { id: "q2", text: "db?", options: ["pg", "sqlite"] },
@@ -643,16 +644,6 @@ describe("samospec new --interview-protocol jsonl — spawnSync E2E (M4)", () =>
           { id: "q4", text: "lang?", options: ["ts", "rust"] },
           { id: "q5", text: "auth?", options: ["oauth", "magic-link"] },
         ],
-      });
-      const askPersonaPayload = JSON.stringify({
-        answer: personaJsonStr,
-        usage: null,
-        effort_used: "max",
-      });
-      const askInterviewPayload = JSON.stringify({
-        answer: questionsJsonStr,
-        usage: null,
-        effort_used: "max",
       });
       const revisePayload = JSON.stringify({
         spec: "# spec\n\n## Goal\nx\n\n## Scope\n- x\n\n## Non-goals\n- n\n",
@@ -667,9 +658,9 @@ describe("samospec new --interview-protocol jsonl — spawnSync E2E (M4)", () =>
         `N=$(cat "${counterPath}" 2>/dev/null || echo 0)\n` +
         `echo $((N+1)) > "${counterPath}"\n` +
         "case $N in\n" +
-        `  0) cat <<'PAYLOAD_EOF_0'\n${askPersonaPayload}\nPAYLOAD_EOF_0\n` +
+        `  0) cat <<'PAYLOAD_EOF_0'\n${personaPayload}\nPAYLOAD_EOF_0\n` +
         "    ;;\n" +
-        `  1) cat <<'PAYLOAD_EOF_1'\n${askInterviewPayload}\nPAYLOAD_EOF_1\n` +
+        `  1) cat <<'PAYLOAD_EOF_1'\n${questionsPayload}\nPAYLOAD_EOF_1\n` +
         "    ;;\n" +
         `  *) cat <<'PAYLOAD_EOF_R'\n${revisePayload}\nPAYLOAD_EOF_R\n` +
         "    ;;\n" +

--- a/tests/cli/new-verbose.test.ts
+++ b/tests/cli/new-verbose.test.ts
@@ -17,14 +17,18 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
-import type { Adapter, AskInput, AskOutput } from "../../src/adapter/types.ts";
+import type {
+  Adapter,
+  StructuredAskInput,
+  StructuredAskOutput,
+} from "../../src/adapter/types.ts";
 import { runInit } from "../../src/cli/init.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 
 const NOW = "2026-04-21T12:00:00Z";
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 const personaJson = (skill: string): string =>
@@ -49,10 +53,12 @@ function makeLeadAdapter(answers: readonly string[]): Adapter {
   let call = 0;
   return {
     ...base,
-    ask: (_input: AskInput): Promise<AskOutput> => {
-      const a = answers[call] ?? answers[answers.length - 1] ?? "";
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
+      const a = answers[call] ?? answers[answers.length - 1] ?? "{}";
       call += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
   };
 }

--- a/tests/cli/new-yes-flag.test.ts
+++ b/tests/cli/new-yes-flag.test.ts
@@ -29,17 +29,17 @@ import path from "node:path";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { runInit } from "../../src/cli/init.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { buildNonInteractiveResolvers } from "../../src/cli/non-interactive.ts";
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 function personaJson(skill: string): string {
@@ -64,10 +64,12 @@ function makeLeadAdapter(answers: readonly string[]): Adapter {
   let call = 0;
   return {
     ...base,
-    ask: (_input: AskInput): Promise<AskOutput> => {
-      const a = answers[call] ?? answers[answers.length - 1] ?? "";
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
+      const a = answers[call] ?? answers[answers.length - 1] ?? "{}";
       call += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
     revise: (_input: ReviseInput): Promise<ReviseOutput> =>
       Promise.resolve({

--- a/tests/cli/new.e2e.test.ts
+++ b/tests/cli/new.e2e.test.ts
@@ -26,11 +26,11 @@ import { spawnSync } from "node:child_process";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   AuthStatus,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { readInterview } from "../../src/cli/interview.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
@@ -42,8 +42,8 @@ import { createTempRepo, type TempRepo } from "../git/helpers/tempRepo.ts";
 
 // ---------- fixture builders ----------
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 function personaJson(skill: string): string {
@@ -91,23 +91,25 @@ interface MakeAdapterArgs {
 
 function makeAdapter(args: MakeAdapterArgs): {
   adapter: Adapter;
-  asks: AskInput[];
+  asks: StructuredAskInput[];
   revises: ReviseInput[];
 } {
   const base = createFakeAdapter(
     args.auth !== undefined ? { auth: args.auth } : {},
   );
-  const asks: AskInput[] = [];
+  const asks: StructuredAskInput[] = [];
   const revises: ReviseInput[] = [];
   let askCall = 0;
   const adapter: Adapter = {
     ...base,
-    ask: (input: AskInput): Promise<AskOutput> => {
+    structuredAsk: (input: StructuredAskInput): Promise<StructuredAskOutput> => {
       asks.push(input);
       const a =
-        args.answers[askCall] ?? args.answers[args.answers.length - 1] ?? "";
+        args.answers[askCall] ??
+        args.answers[args.answers.length - 1] ??
+        "{}";
       askCall += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
     revise: (input: ReviseInput): Promise<ReviseOutput> => {
       revises.push(input);

--- a/tests/cli/new.e2e.test.ts
+++ b/tests/cli/new.e2e.test.ts
@@ -102,12 +102,12 @@ function makeAdapter(args: MakeAdapterArgs): {
   let askCall = 0;
   const adapter: Adapter = {
     ...base,
-    structuredAsk: (input: StructuredAskInput): Promise<StructuredAskOutput> => {
+    structuredAsk: (
+      input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
       asks.push(input);
       const a =
-        args.answers[askCall] ??
-        args.answers[args.answers.length - 1] ??
-        "{}";
+        args.answers[askCall] ?? args.answers[args.answers.length - 1] ?? "{}";
       askCall += 1;
       return Promise.resolve(structuredAskOut(a));
     },

--- a/tests/cli/new.test.ts
+++ b/tests/cli/new.test.ts
@@ -50,7 +50,9 @@ function makeLeadAdapter(
   let call = 0;
   const adapter: Adapter = {
     ...base,
-    structuredAsk: (input: StructuredAskInput): Promise<StructuredAskOutput> => {
+    structuredAsk: (
+      input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
       asks.push(input);
       const a = answers[call] ?? answers[answers.length - 1] ?? "{}";
       call += 1;

--- a/tests/cli/new.test.ts
+++ b/tests/cli/new.test.ts
@@ -26,35 +26,35 @@ import { spawnSync } from "node:child_process";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   AuthStatus,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { readInterview } from "../../src/cli/interview.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { readState } from "../../src/state/store.ts";
 import { runInit } from "../../src/cli/init.ts";
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 function makeLeadAdapter(
   answers: readonly string[],
   authOverride?: AuthStatus,
-): { adapter: Adapter; asks: AskInput[] } {
+): { adapter: Adapter; asks: StructuredAskInput[] } {
   const base = createFakeAdapter(
     authOverride !== undefined ? { auth: authOverride } : {},
   );
-  const asks: AskInput[] = [];
+  const asks: StructuredAskInput[] = [];
   let call = 0;
   const adapter: Adapter = {
     ...base,
-    ask: (input: AskInput): Promise<AskOutput> => {
+    structuredAsk: (input: StructuredAskInput): Promise<StructuredAskOutput> => {
       asks.push(input);
-      const a = answers[call] ?? answers[answers.length - 1] ?? "";
+      const a = answers[call] ?? answers[answers.length - 1] ?? "{}";
       call += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
   };
   return { adapter, asks };

--- a/tests/cli/no-wall-clock-kill.test.ts
+++ b/tests/cli/no-wall-clock-kill.test.ts
@@ -53,6 +53,8 @@ import type {
   ModelInfo,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { runInit } from "../../src/cli/init.ts";
@@ -75,6 +77,12 @@ function makeHangingAdapter(): Adapter {
     models: (): Promise<readonly ModelInfo[]> =>
       Promise.resolve([{ id: "fake", family: "fake" }]),
     ask: (_input: AskInput): Promise<AskOutput> =>
+      new Promise(() => {
+        /* hangs */
+      }),
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> =>
       new Promise(() => {
         /* hangs */
       }),

--- a/tests/cli/no-wall-clock-kill.test.ts
+++ b/tests/cli/no-wall-clock-kill.test.ts
@@ -80,9 +80,7 @@ function makeHangingAdapter(): Adapter {
       new Promise(() => {
         /* hangs */
       }),
-    structuredAsk: (
-      _input: StructuredAskInput,
-    ): Promise<StructuredAskOutput> =>
+    structuredAsk: (_input: StructuredAskInput): Promise<StructuredAskOutput> =>
       new Promise(() => {
         /* hangs */
       }),

--- a/tests/cli/persona.test.ts
+++ b/tests/cli/persona.test.ts
@@ -8,10 +8,10 @@ import { describe, expect, test } from "bun:test";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   AuthStatus,
   EffortLevel,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import {
   PERSONA_FORM_RE,
@@ -20,35 +20,38 @@ import {
   formatPersonaString,
 } from "../../src/cli/persona.ts";
 
-function askOutputWithAnswer(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOutputWithRawJson(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
-interface ScriptedAskAdapter extends Adapter {
-  readonly asks: readonly AskInput[];
+interface ScriptedStructuredAskAdapter extends Adapter {
+  readonly structuredAsks: readonly StructuredAskInput[];
 }
 
-function makeScriptedAskAdapter(
-  answers: readonly string[],
+function makeScriptedStructuredAskAdapter(
+  rawJsonAnswers: readonly string[],
   overrides: Partial<{
     auth: AuthStatus;
   }> = {},
-): ScriptedAskAdapter {
+): ScriptedStructuredAskAdapter {
   const base = createFakeAdapter(
     overrides.auth !== undefined ? { auth: overrides.auth } : {},
   );
-  const asks: AskInput[] = [];
+  const structuredAsks: StructuredAskInput[] = [];
   let call = 0;
   const scripted: Adapter = {
     ...base,
-    ask: (input: AskInput): Promise<AskOutput> => {
-      asks.push(input);
-      const answer = answers[call] ?? answers[answers.length - 1] ?? "";
+    structuredAsk: (input: StructuredAskInput): Promise<StructuredAskOutput> => {
+      structuredAsks.push(input);
+      const rawJson =
+        rawJsonAnswers[call] ?? rawJsonAnswers[rawJsonAnswers.length - 1] ?? "{}";
       call += 1;
-      return Promise.resolve(askOutputWithAnswer(answer));
+      return Promise.resolve(structuredAskOutputWithRawJson(rawJson));
     },
   };
-  const result = Object.assign(scripted, { asks }) as ScriptedAskAdapter;
+  const result = Object.assign(scripted, {
+    structuredAsks,
+  }) as ScriptedStructuredAskAdapter;
   return result;
 }
 
@@ -102,7 +105,7 @@ describe("persona form regex (SPEC §5 Phase 2)", () => {
 
 describe("proposePersona — happy path", () => {
   test("returns { persona, rationale } when lead returns canonical form + rationale", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale:
@@ -125,9 +128,9 @@ describe("proposePersona — happy path", () => {
     expect(result.skill).toBe("CLI software engineer");
   });
 
-  test("ask() is invoked with a system prompt mentioning the persona form", async () => {
+  test("structuredAsk() is invoked with a system prompt mentioning the persona form", async () => {
     const idea = "some idea";
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "platform engineer" expert',
         rationale: "ok",
@@ -143,11 +146,12 @@ describe("proposePersona — happy path", () => {
       adapter,
     );
 
-    expect(adapter.asks.length).toBeGreaterThan(0);
-    const first = adapter.asks[0];
+    expect(adapter.structuredAsks.length).toBeGreaterThan(0);
+    const first = adapter.structuredAsks[0];
     expect(first.prompt).toContain("Veteran");
     expect(first.prompt).toContain("expert");
-    expect(first.idea).toBe(idea);
+    // The idea text is baked into the domain prompt (not a separate field).
+    expect(first.prompt).toContain(idea);
     // Unified default: high (was "max" before the unified-effort knob).
     expect(first.opts.effort).toBe("high");
   });
@@ -157,7 +161,7 @@ describe("proposePersona — happy path", () => {
 
 describe("proposePersona — confirm / edit / replace", () => {
   test("kind: edit overrides the skill and keeps the rationale", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "reasoning",
@@ -180,7 +184,7 @@ describe("proposePersona — confirm / edit / replace", () => {
   });
 
   test("kind: replace overrides the entire persona string", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "reasoning",
@@ -206,7 +210,7 @@ describe("proposePersona — confirm / edit / replace", () => {
   });
 
   test("kind: replace rejects an ill-formed persona (throws)", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "reasoning",
@@ -236,7 +240,7 @@ describe("proposePersona — confirm / edit / replace", () => {
 describe("proposePersona — schema repair + lead_terminal", () => {
   test("first response malformed, second response valid: accepts second", async () => {
     const idea = "idea";
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       // Malformed: missing quotes around skill.
       JSON.stringify({
         persona: "Veteran CLI software engineer expert",
@@ -258,14 +262,15 @@ describe("proposePersona — schema repair + lead_terminal", () => {
       adapter,
     );
     expect(result.persona).toBe('Veteran "CLI software engineer" expert');
-    // Exactly one repair attempt was made (so 2 total ask calls).
-    expect(adapter.asks.length).toBe(2);
-    expect(adapter.asks[0].idea).toBe(idea);
-    expect(adapter.asks[1].idea).toBe(idea);
+    // Exactly one repair attempt was made (so 2 total structuredAsk calls).
+    expect(adapter.structuredAsks.length).toBe(2);
+    // The idea is baked into the prompt, not a separate field.
+    expect(adapter.structuredAsks[0].prompt).toContain(idea);
+    expect(adapter.structuredAsks[1].prompt).toContain(idea);
   });
 
   test("two malformed responses in a row => throws PersonaTerminalError", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({ persona: "nope", rationale: "bad" }),
       JSON.stringify({ persona: "still bad", rationale: "worse" }),
     ]);
@@ -288,7 +293,7 @@ describe("proposePersona — schema repair + lead_terminal", () => {
   });
 
   test("non-JSON response => throws PersonaTerminalError", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       "this is not JSON at all",
       "still not JSON",
     ]);
@@ -315,7 +320,7 @@ describe("proposePersona — schema repair + lead_terminal", () => {
 
 describe("proposePersona — subscription-auth UX copy (SPEC §11)", () => {
   test("subscriptionAuth=true surfaces the explicit message via onNotice callback", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "r",
@@ -337,7 +342,7 @@ describe("proposePersona — subscription-auth UX copy (SPEC §11)", () => {
   });
 
   test("subscriptionAuth=false suppresses the message", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "r",
@@ -362,7 +367,7 @@ describe("proposePersona — subscription-auth UX copy (SPEC §11)", () => {
 
 describe("proposePersona — --explain flag (SPEC §4 secondary ICP)", () => {
   test("explain=true adds a plain-English preamble to the prompt", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "r",
@@ -377,14 +382,14 @@ describe("proposePersona — --explain flag (SPEC §4 secondary ICP)", () => {
       },
       adapter,
     );
-    const first = adapter.asks[0];
+    const first = adapter.structuredAsks[0];
     expect(first.prompt.toLowerCase()).toMatch(
       /plain english|plain-english|non-technical|everyday/,
     );
   });
 
   test("explain=false does NOT include the plain-English preamble", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "r",
@@ -399,7 +404,7 @@ describe("proposePersona — --explain flag (SPEC §4 secondary ICP)", () => {
       },
       adapter,
     );
-    const first = adapter.asks[0];
+    const first = adapter.structuredAsks[0];
     expect(first.prompt.toLowerCase()).not.toMatch(
       /plain english preamble|non-technical/,
     );
@@ -410,7 +415,7 @@ describe("proposePersona — --explain flag (SPEC §4 secondary ICP)", () => {
 
 describe("proposePersona — job-title shape guidance (#367)", () => {
   test("prompt asks for a 2-4 word job-title-shaped role", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "Recipe Developer" expert',
         rationale: "r",
@@ -425,7 +430,7 @@ describe("proposePersona — job-title shape guidance (#367)", () => {
       },
       adapter,
     );
-    const prompt = adapter.asks[0].prompt;
+    const prompt = adapter.structuredAsks[0].prompt;
     // Must mention the 2-4 word constraint.
     expect(prompt).toMatch(/2[–—-]4\s+words/i);
     // Must instruct Title Case.
@@ -435,7 +440,7 @@ describe("proposePersona — job-title shape guidance (#367)", () => {
   });
 
   test("prompt names person-noun endings (Developer, Designer, etc.)", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "Recipe Developer" expert',
         rationale: "r",
@@ -450,7 +455,7 @@ describe("proposePersona — job-title shape guidance (#367)", () => {
       },
       adapter,
     );
-    const prompt = adapter.asks[0].prompt;
+    const prompt = adapter.structuredAsks[0].prompt;
     // At least three of these person-nouns should be enumerated as
     // accepted endings.
     const personNouns = [
@@ -470,7 +475,7 @@ describe("proposePersona — job-title shape guidance (#367)", () => {
   });
 
   test("prompt forbids descriptive task / domain phrases", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "Recipe Developer" expert',
         rationale: "r",
@@ -485,7 +490,7 @@ describe("proposePersona — job-title shape guidance (#367)", () => {
       },
       adapter,
     );
-    const prompt = adapter.asks[0].prompt;
+    const prompt = adapter.structuredAsks[0].prompt;
     const lower = prompt.toLowerCase();
     // Must call out the forbidden -ing / -ment / -ence task-shaped
     // suffixes by listing some of them verbatim.
@@ -501,7 +506,7 @@ describe("proposePersona — job-title shape guidance (#367)", () => {
   });
 
   test("prompt includes few-shot good/bad examples for shape", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "Recipe Developer" expert',
         rationale: "r",
@@ -516,7 +521,7 @@ describe("proposePersona — job-title shape guidance (#367)", () => {
       },
       adapter,
     );
-    const prompt = adapter.asks[0].prompt;
+    const prompt = adapter.structuredAsks[0].prompt;
     // Good examples: short job-title-shaped roles (canonically wrapped
     // in the Veteran "<skill>" expert form).
     expect(prompt).toContain('Veteran "Recipe Developer" expert');
@@ -534,7 +539,7 @@ describe("proposePersona — job-title shape guidance (#367)", () => {
 
 describe("proposePersona — lead effort policy", () => {
   test("defaults to effort=high (unified default, not max)", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "r",
@@ -547,11 +552,11 @@ describe("proposePersona — lead effort policy", () => {
       choice: { kind: "accept" as const },
     };
     await proposePersona(opts, adapter);
-    expect(adapter.asks[0].opts.effort).toBe("high");
+    expect(adapter.structuredAsks[0].opts.effort).toBe("high");
   });
 
   test("honors an explicit effort override", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "r",
@@ -565,22 +570,19 @@ describe("proposePersona — lead effort policy", () => {
       effort: "high" as EffortLevel,
     };
     await proposePersona(opts, adapter);
-    expect(adapter.asks[0].opts.effort).toBe("high");
+    expect(adapter.structuredAsks[0].opts.effort).toBe("high");
   });
 });
 
 // ---------- timeout policy (raised SPEC §7 default) ----------
 //
 // Regression guard for the timeouts robustness pass: persona's lead
-// `ask()` must default `opts.timeout` to 900_000 ms (15m) so a slow
-// max-effort lead is not preempted mid-flight. Before this guard the
-// suite asserted `opts.effort` but NEVER `opts.timeout`, so a revert of
-// the 900_000 default (e.g. back to 300_000) would have passed green.
-// See draft.test.ts (DRAFT_REVISE_TIMEOUT_MS) for the sibling pattern.
+// `structuredAsk()` must default `opts.timeout` to 900_000 ms (15m) so a
+// slow max-effort lead is not preempted mid-flight.
 
 describe("proposePersona — lead timeout policy (SPEC §7)", () => {
   test("defaults opts.timeout to 900_000 ms (15m) when no override is given", async () => {
-    const adapter = makeScriptedAskAdapter([
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "r",
@@ -595,11 +597,11 @@ describe("proposePersona — lead timeout policy (SPEC §7)", () => {
       },
       adapter,
     );
-    expect(adapter.asks[0].opts.timeout).toBe(900_000);
+    expect(adapter.structuredAsks[0].opts.timeout).toBe(900_000);
   });
 
-  test("a caller-supplied timeoutMs override reaches adapter.ask opts.timeout", async () => {
-    const adapter = makeScriptedAskAdapter([
+  test("a caller-supplied timeoutMs override reaches adapter.structuredAsk opts.timeout", async () => {
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "r",
@@ -615,14 +617,14 @@ describe("proposePersona — lead timeout policy (SPEC §7)", () => {
       },
       adapter,
     );
-    expect(adapter.asks[0].opts.timeout).toBe(123_456);
+    expect(adapter.structuredAsks[0].opts.timeout).toBe(123_456);
   });
 
   test("the 900_000 default and the override both apply on the repair retry too", async () => {
     // First answer is malformed -> triggers ONE repair retry. The
-    // timeout override must thread through to BOTH asks (the default
-    // would otherwise silently re-appear on the retry path).
-    const adapter = makeScriptedAskAdapter([
+    // timeout override must thread through to BOTH structuredAsks (the
+    // default would otherwise silently re-appear on the retry path).
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({ persona: "not canonical", rationale: "r1" }),
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
@@ -639,17 +641,15 @@ describe("proposePersona — lead timeout policy (SPEC §7)", () => {
       },
       adapter,
     );
-    expect(adapter.asks.length).toBe(2);
-    expect(adapter.asks[0].opts.timeout).toBe(777_000);
-    expect(adapter.asks[1].opts.timeout).toBe(777_000);
+    expect(adapter.structuredAsks.length).toBe(2);
+    expect(adapter.structuredAsks[0].opts.timeout).toBe(777_000);
+    expect(adapter.structuredAsks[1].opts.timeout).toBe(777_000);
   });
 
-  test("effort AND timeout are BOTH correct on the same ask (no regression from the timeout raise)", async () => {
+  test("effort AND timeout are BOTH correct on the same structuredAsk (no regression from the timeout raise)", async () => {
     // Combined assertion: bumping the timeout default must not regress
-    // effort threading, and vice versa. Here effort is set explicitly
-    // (`high`, which also happens to be the unified default); timeout
-    // defaults to 900_000.
-    const adapter = makeScriptedAskAdapter([
+    // effort threading, and vice versa.
+    const adapter = makeScriptedStructuredAskAdapter([
       JSON.stringify({
         persona: 'Veteran "CLI software engineer" expert',
         rationale: "r",
@@ -665,7 +665,7 @@ describe("proposePersona — lead timeout policy (SPEC §7)", () => {
       },
       adapter,
     );
-    expect(adapter.asks[0].opts.effort).toBe("high");
-    expect(adapter.asks[0].opts.timeout).toBe(900_000);
+    expect(adapter.structuredAsks[0].opts.effort).toBe("high");
+    expect(adapter.structuredAsks[0].opts.timeout).toBe(900_000);
   });
 });

--- a/tests/cli/persona.test.ts
+++ b/tests/cli/persona.test.ts
@@ -41,10 +41,14 @@ function makeScriptedStructuredAskAdapter(
   let call = 0;
   const scripted: Adapter = {
     ...base,
-    structuredAsk: (input: StructuredAskInput): Promise<StructuredAskOutput> => {
+    structuredAsk: (
+      input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
       structuredAsks.push(input);
       const rawJson =
-        rawJsonAnswers[call] ?? rawJsonAnswers[rawJsonAnswers.length - 1] ?? "{}";
+        rawJsonAnswers[call] ??
+        rawJsonAnswers[rawJsonAnswers.length - 1] ??
+        "{}";
       call += 1;
       return Promise.resolve(structuredAskOutputWithRawJson(rawJson));
     },

--- a/tests/cli/resume.idempotency.test.ts
+++ b/tests/cli/resume.idempotency.test.ts
@@ -20,10 +20,10 @@ import path from "node:path";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { runInit } from "../../src/cli/init.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
@@ -33,8 +33,8 @@ import { createTempRepo, type TempRepo } from "../git/helpers/tempRepo.ts";
 
 // ---------- fixtures ----------
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 function personaJson(skill: string): string {
@@ -79,12 +79,14 @@ function makeAdapter(args: MakeArgs): Adapter {
   let askCall = 0;
   return {
     ...base,
-    ask: (input: AskInput): Promise<AskOutput> => {
+    structuredAsk: (input: StructuredAskInput): Promise<StructuredAskOutput> => {
       void input;
       const a =
-        args.answers[askCall] ?? args.answers[args.answers.length - 1] ?? "";
+        args.answers[askCall] ??
+        args.answers[args.answers.length - 1] ??
+        "{}";
       askCall += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
     revise: (input: ReviseInput): Promise<ReviseOutput> => {
       void input;

--- a/tests/cli/resume.idempotency.test.ts
+++ b/tests/cli/resume.idempotency.test.ts
@@ -79,12 +79,12 @@ function makeAdapter(args: MakeArgs): Adapter {
   let askCall = 0;
   return {
     ...base,
-    structuredAsk: (input: StructuredAskInput): Promise<StructuredAskOutput> => {
+    structuredAsk: (
+      input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
       void input;
       const a =
-        args.answers[askCall] ??
-        args.answers[args.answers.length - 1] ??
-        "{}";
+        args.answers[askCall] ?? args.answers[args.answers.length - 1] ?? "{}";
       askCall += 1;
       return Promise.resolve(structuredAskOut(a));
     },

--- a/tests/cli/resume.test.ts
+++ b/tests/cli/resume.test.ts
@@ -20,11 +20,11 @@ import path from "node:path";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   CritiqueOutput,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { runInit } from "../../src/cli/init.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
@@ -35,8 +35,8 @@ import { newState, readState, writeState } from "../../src/state/store.ts";
 import type { State } from "../../src/state/types.ts";
 import { readInterview, writeInterview } from "../../src/cli/interview.ts";
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 function reviseOut(overrides: Partial<ReviseOutput> = {}): ReviseOutput {
@@ -55,18 +55,20 @@ function reviseOut(overrides: Partial<ReviseOutput> = {}): ReviseOutput {
 
 function makeLeadAdapter(answers: readonly string[]): {
   adapter: Adapter;
-  asks: AskInput[];
+  asks: StructuredAskInput[];
 } {
   const base = createFakeAdapter();
-  const asks: AskInput[] = [];
+  const asks: StructuredAskInput[] = [];
   let call = 0;
   const adapter: Adapter = {
     ...base,
-    ask: (input: AskInput): Promise<AskOutput> => {
+    structuredAsk: (
+      input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
       asks.push(input);
-      const a = answers[call] ?? answers[answers.length - 1] ?? "";
+      const a = answers[call] ?? answers[answers.length - 1] ?? "{}";
       call += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
   };
   return { adapter, asks };

--- a/tests/cli/session-wallclock.test.ts
+++ b/tests/cli/session-wallclock.test.ts
@@ -37,6 +37,8 @@ import type {
   ModelInfo,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { runInit } from "../../src/cli/init.ts";
@@ -53,6 +55,10 @@ function makeHangingAdapter(): Adapter {
     models: (): Promise<readonly ModelInfo[]> =>
       Promise.resolve([{ id: "fake", family: "fake" }]),
     ask: (_input: AskInput): Promise<AskOutput> =>
+      new Promise(() => {
+        /* hangs */
+      }),
+    structuredAsk: (_input: StructuredAskInput): Promise<StructuredAskOutput> =>
       new Promise(() => {
         /* hangs */
       }),
@@ -177,10 +183,14 @@ describe("session wall-clock cap is a deprecated no-op (#81 / samo.team #415, #4
       supports_effort: (_level: EffortLevel) => true,
       models: (): Promise<readonly ModelInfo[]> =>
         Promise.resolve([{ id: "fake", family: "fake" }]),
-      ask: (_input: AskInput): Promise<AskOutput> => {
+      ask: (_input: AskInput): Promise<AskOutput> =>
+        Promise.resolve({ answer: "", usage: null, effort_used: "max" }),
+      structuredAsk: (
+        _input: StructuredAskInput,
+      ): Promise<StructuredAskOutput> => {
         const c = callCount++;
-        const answer = c === 0 ? personaJson : questionsJson;
-        return Promise.resolve({ answer, usage: null, effort_used: "max" });
+        const rawJson = c === 0 ? personaJson : questionsJson;
+        return Promise.resolve({ rawJson, usage: null, effort_used: "max" });
       },
       critique: (_input: CritiqueInput): Promise<CritiqueOutput> =>
         Promise.resolve({

--- a/tests/cli/skip-flag.test.ts
+++ b/tests/cli/skip-flag.test.ts
@@ -30,18 +30,18 @@ import { runNew, type ChoiceResolvers } from "../../src/cli/new.ts";
 import { createFakeAdapter } from "../../src/adapter/fake-adapter.ts";
 import type {
   Adapter,
-  AskInput,
-  AskOutput,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 import { runInit } from "../../src/cli/init.ts";
 import { createTempRepo, type TempRepo } from "../git/helpers/tempRepo.ts";
 
 // ---------- fixture builders (shared with new.e2e.test.ts pattern) ----------
 
-function askOut(answer: string): AskOutput {
-  return { answer, usage: null, effort_used: "max" };
+function structuredAskOut(rawJson: string): StructuredAskOutput {
+  return { rawJson, usage: null, effort_used: "max" };
 }
 
 function personaJson(skill: string): string {
@@ -86,10 +86,12 @@ function makeAdapter(answers: readonly string[]): {
   let askCall = 0;
   const adapter: Adapter = {
     ...base,
-    ask: (_input: AskInput): Promise<AskOutput> => {
-      const a = answers[askCall] ?? answers[answers.length - 1] ?? "";
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> => {
+      const a = answers[askCall] ?? answers[answers.length - 1] ?? "{}";
       askCall += 1;
-      return Promise.resolve(askOut(a));
+      return Promise.resolve(structuredAskOut(a));
     },
     revise: (input: ReviseInput): Promise<ReviseOutput> => {
       revises.push(input);

--- a/tests/fixtures/claude-fixtures/contract-trio.json
+++ b/tests/fixtures/claude-fixtures/contract-trio.json
@@ -13,12 +13,21 @@
       "script": [
         {
           "type": "stdout",
-          "text": "{\"findings\":[{\"category\":\"ambiguity\",\"text\":\"x\",\"severity\":\"minor\"}],\"summary\":\"s\",\"suggested_next_version\":\"0.1.1\",\"usage\":null,\"effort_used\":\"max\"}"
+          "text": "{\"result\":\"pong\",\"usage\":null,\"effort_used\":\"max\"}"
         },
         { "type": "exit", "code": 0 }
       ]
     },
     "2": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"findings\":[{\"category\":\"ambiguity\",\"text\":\"x\",\"severity\":\"minor\"}],\"summary\":\"s\",\"suggested_next_version\":\"0.1.1\",\"usage\":null,\"effort_used\":\"max\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    },
+    "3": {
       "script": [
         {
           "type": "stdout",

--- a/tests/fixtures/codex-fixtures/contract-trio.json
+++ b/tests/fixtures/codex-fixtures/contract-trio.json
@@ -13,12 +13,21 @@
       "script": [
         {
           "type": "stdout",
-          "text": "{\"findings\":[{\"category\":\"missing-risk\",\"text\":\"x\",\"severity\":\"major\"}],\"summary\":\"s\",\"suggested_next_version\":\"0.1.1\",\"usage\":null,\"effort_used\":\"max\"}"
+          "text": "{\"result\":\"pong\",\"usage\":null,\"effort_used\":\"max\"}"
         },
         { "type": "exit", "code": 0 }
       ]
     },
     "2": {
+      "script": [
+        {
+          "type": "stdout",
+          "text": "{\"findings\":[{\"category\":\"missing-risk\",\"text\":\"x\",\"severity\":\"major\"}],\"summary\":\"s\",\"suggested_next_version\":\"0.1.1\",\"usage\":null,\"effort_used\":\"max\"}"
+        },
+        { "type": "exit", "code": 0 }
+      ]
+    },
+    "3": {
       "script": [
         {
           "type": "stdout",

--- a/tests/loop/e2e.test.ts
+++ b/tests/loop/e2e.test.ts
@@ -162,6 +162,7 @@ describe("loop/e2e — 3-round fake-adapter loop to ready=true", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => Promise.reject(new Error("unused")),
       revise: () => {
         roundCounter += 1;
@@ -277,6 +278,7 @@ describe("loop/e2e — manual-edit mid-session", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => Promise.reject(new Error("unused")),
       revise: (input) => {
         roundCounter += 1;

--- a/tests/loop/push-round-boundary.test.ts
+++ b/tests/loop/push-round-boundary.test.ts
@@ -179,6 +179,7 @@ function makeLead(readyOnRound: number): Adapter {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
     critique: () => Promise.reject(new Error("unused")),
     revise: () => {
       roundCounter += 1;

--- a/tests/loop/push-round-boundary.test.ts
+++ b/tests/loop/push-round-boundary.test.ts
@@ -179,7 +179,7 @@ function makeLead(readyOnRound: number): Adapter {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
-      structuredAsk: () => Promise.reject(new Error("unused")),
+    structuredAsk: () => Promise.reject(new Error("unused")),
     critique: () => Promise.reject(new Error("unused")),
     revise: () => {
       roundCounter += 1;

--- a/tests/loop/reviewer-a-misclass.test.ts
+++ b/tests/loop/reviewer-a-misclass.test.ts
@@ -71,6 +71,7 @@ function makeFailingAdapter(errorMessage: string): Adapter {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
     critique: () => Promise.reject(new Error(errorMessage)),
     revise: () => Promise.reject(new Error("unused")),
   };

--- a/tests/loop/reviewer-a-misclass.test.ts
+++ b/tests/loop/reviewer-a-misclass.test.ts
@@ -71,7 +71,7 @@ function makeFailingAdapter(errorMessage: string): Adapter {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
-      structuredAsk: () => Promise.reject(new Error("unused")),
+    structuredAsk: () => Promise.reject(new Error("unused")),
     critique: () => Promise.reject(new Error(errorMessage)),
     revise: () => Promise.reject(new Error("unused")),
   };

--- a/tests/loop/revise-timeout.test.ts
+++ b/tests/loop/revise-timeout.test.ts
@@ -614,7 +614,8 @@ describe("loop/round — distinguishes reviewer-retry from revise-retry (#92 REV
         supports_effort: () => true,
         models: () => Promise.resolve([{ id: "fake", family: "fake" }]),
         ask: () => Promise.reject(new Error("ask not used")),
-      structuredAsk: () => Promise.reject(new Error("structuredAsk not used")),
+        structuredAsk: () =>
+          Promise.reject(new Error("structuredAsk not used")),
         critique: (): Promise<CritiqueOutput> => {
           n += 1;
           if (n === 1) return Promise.reject(new Error("first-fail"));
@@ -847,7 +848,8 @@ describe("iterate — changelog note differs by retry kind (#92 REV)", () => {
         supports_effort: () => true,
         models: () => Promise.resolve([{ id: "fake", family: "fake" }]),
         ask: () => Promise.reject(new Error("ask not used")),
-      structuredAsk: () => Promise.reject(new Error("structuredAsk not used")),
+        structuredAsk: () =>
+          Promise.reject(new Error("structuredAsk not used")),
         critique: (): Promise<CritiqueOutput> => {
           n += 1;
           if (n === 1) return Promise.reject(new Error("first-fail"));

--- a/tests/loop/revise-timeout.test.ts
+++ b/tests/loop/revise-timeout.test.ts
@@ -34,6 +34,8 @@ import type {
   DetectResult,
   EffortLevel,
   ModelInfo,
+  StructuredAskInput,
+  StructuredAskOutput,
   ReviseInput,
   ReviseOutput,
 } from "../../src/adapter/types.ts";
@@ -76,6 +78,8 @@ function passingReviewer(): Adapter {
       Promise.resolve([{ id: "fake", family: "fake" }]),
     ask: (_i: AskInput): Promise<AskOutput> =>
       Promise.reject(new Error("ask not used")),
+    structuredAsk: (_i: StructuredAskInput): Promise<StructuredAskOutput> =>
+      Promise.reject(new Error("structuredAsk not used")),
     critique: (_i: CritiqueInput): Promise<CritiqueOutput> =>
       Promise.resolve(SAMPLE_CRITIQUE),
     revise: (_i: ReviseInput): Promise<ReviseOutput> =>
@@ -102,6 +106,8 @@ function hangingLead(): Adapter & { reviseCalls: () => number } {
       Promise.resolve([{ id: "fake", family: "fake" }]),
     ask: (_i: AskInput): Promise<AskOutput> =>
       Promise.reject(new Error("ask not used")),
+    structuredAsk: (_i: StructuredAskInput): Promise<StructuredAskOutput> =>
+      Promise.reject(new Error("structuredAsk not used")),
     critique: (_i: CritiqueInput): Promise<CritiqueOutput> =>
       Promise.reject(new Error("critique not used on lead")),
     revise: (_i: ReviseInput): Promise<ReviseOutput> => {
@@ -137,6 +143,8 @@ function capturingReviewer(): Adapter & {
       Promise.resolve([{ id: "fake", family: "fake" }]),
     ask: (_i: AskInput): Promise<AskOutput> =>
       Promise.reject(new Error("ask not used")),
+    structuredAsk: (_i: StructuredAskInput): Promise<StructuredAskOutput> =>
+      Promise.reject(new Error("structuredAsk not used")),
     critique: (i: CritiqueInput): Promise<CritiqueOutput> => {
       seen.push(i.opts.timeout);
       return Promise.resolve(SAMPLE_CRITIQUE);
@@ -168,6 +176,8 @@ function capturingLead(): Adapter & {
       Promise.resolve([{ id: "fake", family: "fake" }]),
     ask: (_i: AskInput): Promise<AskOutput> =>
       Promise.reject(new Error("ask not used")),
+    structuredAsk: (_i: StructuredAskInput): Promise<StructuredAskOutput> =>
+      Promise.reject(new Error("structuredAsk not used")),
     critique: (_i: CritiqueInput): Promise<CritiqueOutput> =>
       Promise.reject(new Error("critique not used on lead")),
     revise: (i: ReviseInput): Promise<ReviseOutput> => {
@@ -289,6 +299,7 @@ describe("loop/round — lead revise per-call timeout (#92)", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "fake", family: "fake" }]),
       ask: () => Promise.reject(new Error("ask not used")),
+      structuredAsk: () => Promise.reject(new Error("structuredAsk not used")),
       critique: () => Promise.reject(new Error("critique not used on lead")),
       revise: (_i: ReviseInput): Promise<ReviseOutput> => {
         calls += 1;
@@ -580,6 +591,7 @@ describe("loop/round — distinguishes reviewer-retry from revise-retry (#92 REV
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "fake", family: "fake" }]),
       ask: () => Promise.reject(new Error("ask not used")),
+      structuredAsk: () => Promise.reject(new Error("structuredAsk not used")),
       critique: () => Promise.reject(new Error("critique not used on lead")),
       revise: (_i: ReviseInput): Promise<ReviseOutput> =>
         Promise.resolve({
@@ -602,6 +614,7 @@ describe("loop/round — distinguishes reviewer-retry from revise-retry (#92 REV
         supports_effort: () => true,
         models: () => Promise.resolve([{ id: "fake", family: "fake" }]),
         ask: () => Promise.reject(new Error("ask not used")),
+      structuredAsk: () => Promise.reject(new Error("structuredAsk not used")),
         critique: (): Promise<CritiqueOutput> => {
           n += 1;
           if (n === 1) return Promise.reject(new Error("first-fail"));
@@ -660,6 +673,7 @@ describe("loop/round — distinguishes reviewer-retry from revise-retry (#92 REV
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "fake", family: "fake" }]),
       ask: () => Promise.reject(new Error("ask not used")),
+      structuredAsk: () => Promise.reject(new Error("structuredAsk not used")),
       critique: () => Promise.reject(new Error("critique not used on lead")),
       revise: (_i: ReviseInput): Promise<ReviseOutput> => {
         calls += 1;
@@ -750,6 +764,7 @@ describe("iterate — changelog note differs by retry kind (#92 REV)", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "fake", family: "fake" }]),
       ask: () => Promise.reject(new Error("ask not used")),
+      structuredAsk: () => Promise.reject(new Error("structuredAsk not used")),
       critique: () => Promise.reject(new Error("critique not used on lead")),
       revise: (_i: ReviseInput): Promise<ReviseOutput> => {
         calls += 1;
@@ -810,6 +825,7 @@ describe("iterate — changelog note differs by retry kind (#92 REV)", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "fake", family: "fake" }]),
       ask: () => Promise.reject(new Error("ask not used")),
+      structuredAsk: () => Promise.reject(new Error("structuredAsk not used")),
       critique: () => Promise.reject(new Error("critique not used on lead")),
       revise: (_i: ReviseInput): Promise<ReviseOutput> =>
         Promise.resolve({
@@ -831,6 +847,7 @@ describe("iterate — changelog note differs by retry kind (#92 REV)", () => {
         supports_effort: () => true,
         models: () => Promise.resolve([{ id: "fake", family: "fake" }]),
         ask: () => Promise.reject(new Error("ask not used")),
+      structuredAsk: () => Promise.reject(new Error("structuredAsk not used")),
         critique: (): Promise<CritiqueOutput> => {
           n += 1;
           if (n === 1) return Promise.reject(new Error("first-fail"));

--- a/tests/loop/round-prior-context.test.ts
+++ b/tests/loop/round-prior-context.test.ts
@@ -92,7 +92,7 @@ function recordingReviewer(seat: "reviewer_a" | "reviewer_b"): {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
-      structuredAsk: () => Promise.reject(new Error("unused")),
+    structuredAsk: () => Promise.reject(new Error("unused")),
     critique: (input: CritiqueInput): Promise<CritiqueOutput> => {
       captured = input;
       return Promise.resolve(out);
@@ -112,7 +112,7 @@ function leadAdapter(): Adapter {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
-      structuredAsk: () => Promise.reject(new Error("unused")),
+    structuredAsk: () => Promise.reject(new Error("unused")),
     critique: () => Promise.reject(new Error("unused")),
     revise: (_input: ReviseInput): Promise<ReviseOutput> =>
       Promise.resolve(READY_REVISE),

--- a/tests/loop/round-prior-context.test.ts
+++ b/tests/loop/round-prior-context.test.ts
@@ -92,6 +92,7 @@ function recordingReviewer(seat: "reviewer_a" | "reviewer_b"): {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
     critique: (input: CritiqueInput): Promise<CritiqueOutput> => {
       captured = input;
       return Promise.resolve(out);
@@ -111,6 +112,7 @@ function leadAdapter(): Adapter {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
     critique: () => Promise.reject(new Error("unused")),
     revise: (_input: ReviseInput): Promise<ReviseOutput> =>
       Promise.resolve(READY_REVISE),

--- a/tests/loop/round-resume-critiques.test.ts
+++ b/tests/loop/round-resume-critiques.test.ts
@@ -92,6 +92,7 @@ function explodingReviewer(): Adapter {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
     critique: (_input: CritiqueInput) =>
       Promise.reject(new Error("reviewer must NOT be invoked on resume")),
     revise: () => Promise.reject(new Error("unused")),
@@ -111,6 +112,7 @@ function flakyLead(): { adapter: Adapter; reviseCalls: () => number } {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
     critique: () => Promise.reject(new Error("unused")),
     revise: (input: ReviseInput): Promise<ReviseOutput> => {
       calls += 1;

--- a/tests/loop/round-resume-critiques.test.ts
+++ b/tests/loop/round-resume-critiques.test.ts
@@ -92,7 +92,7 @@ function explodingReviewer(): Adapter {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
-      structuredAsk: () => Promise.reject(new Error("unused")),
+    structuredAsk: () => Promise.reject(new Error("unused")),
     critique: (_input: CritiqueInput) =>
       Promise.reject(new Error("reviewer must NOT be invoked on resume")),
     revise: () => Promise.reject(new Error("unused")),
@@ -112,7 +112,7 @@ function flakyLead(): { adapter: Adapter; reviseCalls: () => number } {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
-      structuredAsk: () => Promise.reject(new Error("unused")),
+    structuredAsk: () => Promise.reject(new Error("unused")),
     critique: () => Promise.reject(new Error("unused")),
     revise: (input: ReviseInput): Promise<ReviseOutput> => {
       calls += 1;

--- a/tests/loop/round-seat-errors.test.ts
+++ b/tests/loop/round-seat-errors.test.ts
@@ -60,7 +60,7 @@ function makeFailingAdapter(errorMessage: string): Adapter {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
-      structuredAsk: () => Promise.reject(new Error("unused")),
+    structuredAsk: () => Promise.reject(new Error("unused")),
     critique: () => Promise.reject(new Error(errorMessage)),
     revise: () => Promise.reject(new Error("unused")),
   };

--- a/tests/loop/round-seat-errors.test.ts
+++ b/tests/loop/round-seat-errors.test.ts
@@ -60,6 +60,7 @@ function makeFailingAdapter(errorMessage: string): Adapter {
     supports_effort: () => true,
     models: () => Promise.resolve([{ id: "x", family: "fake" }]),
     ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
     critique: () => Promise.reject(new Error(errorMessage)),
     revise: () => Promise.reject(new Error("unused")),
   };

--- a/tests/loop/round.test.ts
+++ b/tests/loop/round.test.ts
@@ -123,6 +123,7 @@ describe("loop/round — partial failure (SPEC §7)", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("not used")),
+      structuredAsk: () => Promise.reject(new Error("not used")),
       critique: () => Promise.reject(new Error("fail: reviewer b crash")),
       revise: () => Promise.reject(new Error("not used")),
     };
@@ -160,6 +161,7 @@ describe("loop/round — partial failure (SPEC §7)", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => {
         aCalls += 1;
         if (aCalls === 1) return Promise.reject(new Error("first-fail a"));
@@ -176,6 +178,7 @@ describe("loop/round — partial failure (SPEC §7)", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => {
         bCalls += 1;
         if (bCalls === 1) return Promise.reject(new Error("first-fail b"));
@@ -210,6 +213,7 @@ describe("loop/round — partial failure (SPEC §7)", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => Promise.reject(new Error("persistent-fail")),
       revise: () => Promise.reject(new Error("unused")),
     };
@@ -246,6 +250,7 @@ describe("loop/round — lead_terminal (SPEC §7)", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => Promise.reject(new Error("unused")),
       revise: () => Promise.reject(new Error("model refused to continue")),
     };
@@ -482,6 +487,7 @@ describe("loop/round — round.json records real started/completed timestamps (#
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => Promise.reject(new Error("persistent-fail")),
       revise: () => Promise.reject(new Error("unused")),
     };
@@ -520,6 +526,7 @@ describe("loop/round — decisions_history passthrough", () => {
       supports_effort: () => true,
       models: () => Promise.resolve([{ id: "x", family: "fake" }]),
       ask: () => Promise.reject(new Error("unused")),
+      structuredAsk: () => Promise.reject(new Error("unused")),
       critique: () => Promise.reject(new Error("unused")),
       revise: (input) => {
         seenHistory = input.decisions_history;

--- a/tests/render/brief-ai.test.ts
+++ b/tests/render/brief-ai.test.ts
@@ -81,9 +81,7 @@ function makeAdapter(
         effort_used: input.opts.effort,
       });
     },
-    structuredAsk: (
-      _input: StructuredAskInput,
-    ): Promise<StructuredAskOutput> =>
+    structuredAsk: (_input: StructuredAskInput): Promise<StructuredAskOutput> =>
       Promise.reject(new Error("structuredAsk not expected in brief-ai tests")),
     critique: (_i: CritiqueInput): Promise<CritiqueOutput> =>
       Promise.reject(new Error("not used")),

--- a/tests/render/brief-ai.test.ts
+++ b/tests/render/brief-ai.test.ts
@@ -30,6 +30,8 @@ import type {
   EffortLevel,
   ReviseInput,
   ReviseOutput,
+  StructuredAskInput,
+  StructuredAskOutput,
 } from "../../src/adapter/types.ts";
 
 let tmp: string;
@@ -79,6 +81,10 @@ function makeAdapter(
         effort_used: input.opts.effort,
       });
     },
+    structuredAsk: (
+      _input: StructuredAskInput,
+    ): Promise<StructuredAskOutput> =>
+      Promise.reject(new Error("structuredAsk not expected in brief-ai tests")),
     critique: (_i: CritiqueInput): Promise<CritiqueOutput> =>
       Promise.reject(new Error("not used")),
     revise: (_i: ReviseInput): Promise<ReviseOutput> =>


### PR DESCRIPTION
## Root cause

`buildAskPrompt()` always prepends **"Respond ONLY with { \"answer\": string, ... }"** before the caller's prompt. When `persona.ts` and `interview.ts` call `adapter.ask()` with a domain prompt that already carries its own schema directive:

- `buildPersonaPrompt()` says: **"Respond ONLY with { \"persona\", \"rationale\" }"**
- `buildInterviewPrompt()` says: **"Respond ONLY with { \"questions\": [...] }"**

The model sees **two contradictory schema instructions** in a single prompt. It picks the domain shape (e.g. `{persona, rationale}`) but `AskOutputSchema.parse()` requires `{answer: string}` → ZodError → `PersonaTerminalError` → exit 4. Non-deterministic; hits both persona and interview phases.

## Fix (minimum footprint)

Add `adapter.structuredAsk(input: StructuredAskInput): Promise<StructuredAskOutput>` whose prompt builder (`buildStructuredAskPrompt`) does **not** inject the outer `{answer}` wrapper. The caller's prompt already carries the full schema instruction.

- `StructuredAskOutput` has `rawJson: string` instead of `answer: string`; the caller parses against their own domain schema
- `persona.ts`: `askForPersona` switches `ask → structuredAsk`; returns `output.rawJson`
- `interview.ts`: `runInterview` switches `ask → structuredAsk`; reads `askOut.rawJson`
- `ClaudeAdapter` and `CodexAdapter` both implement `structuredAsk`
- `FakeAdapter` and contract tests updated; no regressions

## TDD

- **RED commit** `6c652d3`: failing test proving `buildAskPrompt` produces ≥2 "Respond ONLY with" directives when given a domain prompt, plus assertions for `buildStructuredAskPrompt` and `Adapter.structuredAsk` (both non-existent at commit time)
- **GREEN commit** `f54a82e`: full implementation; `bun test` → 1877 pass, 1 skip, 0 fail; `tsc --noEmit` → 0 errors

## Test plan

- [x] `bun test tests/adapter/structured-ask-schema-conflict.test.ts` — 11 pass
- [x] `bun test tests/cli/persona.test.ts` — 29 pass
- [x] `bun test tests/cli/interview.test.ts` — 37 pass
- [x] `bun test` (full suite) — 1877 pass, 1 skip, 0 fail
- [x] `bun run typecheck` — 0 TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)