### PR TITLE
docs: make samospec bot-operable from the repo alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,17 @@ No install step. Requires [Bun](https://bun.sh) ≥ 1.2.0; `bunx` fetches and ca
 
 ```bash
 bunx samospec doctor
-bunx samospec --version   # 0.8.0
+bunx samospec --version   # 0.9.1
 ```
 
 `npx` won't work — the CLI ships as TypeScript and depends on the Bun runtime (`Bun.spawn`, etc.). Use `bunx`.
 
 For brevity, the rest of this README writes `samospec` — read it as `bunx samospec`.
+
+> **Running samospec from a bot / agent / CI?** See
+> [`docs/bot-operations.md`](docs/bot-operations.md) — a self-contained
+> runbook with the credential checklist, the fully non-interactive command
+> surface, exit codes, stopping conditions, and the JSONL interview protocol.
 
 ---
 
@@ -85,9 +90,9 @@ At every step: `bunx samospec status <slug>` prints phase, current version, next
              └──────────────────────┘
 ```
 
-- **Lead** = `claude` CLI, pinned `claude-opus-4-7`, default effort `high`.
-- **Reviewer A** = `codex` CLI with a **security/ops** persona: missing risks, weak implementation, unnecessary scope.
-- **Reviewer B** = second `claude` session with a **QA / testability** persona: ambiguity, contradiction, weak-testing. Also checks the spec's mandatory baseline sections and verifies it stays faithful to your original idea.
+- **Lead** = `claude` CLI, pinned `claude-opus-4-8` (fallback chain `claude-opus-4-8 → claude-opus-4-7 → claude-sonnet-4-6`), default effort `high`.
+- **Reviewer A** = `codex` CLI with a **security/ops** persona: missing risks, weak implementation, unnecessary scope. Pinned `gpt-5.5` (fallback `gpt-5.5 → gpt-5.4 → gpt-5.3-codex → account-default`).
+- **Reviewer B** = second `claude` session with a **QA / testability** persona: ambiguity, contradiction, weak-testing. Same pin as the lead (`claude-opus-4-8`). Also checks the spec's mandatory baseline sections and verifies it stays faithful to your original idea.
 - Adapters share a coupled-fallback rule (lead and Reviewer B use the same vendor, so a Claude outage fails them together rather than running an uneven panel).
 
 Every generated `SPEC.md` gets nine mandatory sections by default (goal & why, user stories, architecture, implementation details, tests plan with red/green TDD, team of veteran experts, sprint plan, embedded changelog, version header). Pass `--skip` to opt out.
@@ -100,12 +105,19 @@ Every spec also ships a machine-readable `.samo/spec/<slug>/architecture.json` (
 
 The CLI shells out to the vendor CLIs you already use. OAuth-based sessions are the **primary** auth mode — API keys are an alternative:
 
-- **Claude Code** — `claude /login` once in a terminal; samospec inherits the session for `claude --print` calls. Or `export ANTHROPIC_API_KEY=sk-ant-...`. **Requires `claude` ≥ v2.1.0** (samospec passes `--effort` on every call; older CLIs reject the flag). `samospec doctor` WARNs if your `claude` predates it.
-- **Codex** — `codex auth` (ChatGPT subscription account works); samospec handles the pinned-model fallback when your account default differs. Or `export OPENAI_API_KEY=sk-...`.
+- **Claude Code** — `claude /login` once in a terminal; samospec inherits the session for `claude --print` calls. Or set the `ANTHROPIC_API_KEY` env var. **Requires `claude` ≥ v2.1.0** (samospec passes `--effort` on every call; older CLIs reject the flag). `samospec doctor` WARNs if your `claude` predates it.
+- **Codex** — `codex auth` (ChatGPT subscription account works); samospec handles the pinned-model fallback when your account default differs. Or set the `OPENAI_API_KEY` env var. Note: here Codex is a full reviewer LLM, so its `OPENAI_API_KEY` (when used) drives chat/reasoning calls — distinct from images-only OpenAI usage elsewhere in the Samo stack.
+
+A stale `ANTHROPIC_API_KEY` in the environment **preempts** the `claude /login` OAuth session and surfaces as an `Invalid API key` WARN in `doctor` — `unset` it to fall back to OAuth. Same shape for Codex.
 
 ```bash
-samospec doctor   # verifies CLI availability, auth, git, lockfile, config, entropy, push consent
+samospec doctor   # availability, effort-support, auth, git, lock, config,
+                  # global-config, entropy, push-consent, calibration, pr-capability
 ```
+
+> **Bots:** the full credential/setup checklist (every env-var name, the
+> `claude -p` OAuth-subprocess model, doctor exit codes) is in
+> [`docs/bot-operations.md`](docs/bot-operations.md).
 
 ---
 
@@ -133,18 +145,24 @@ samospec doctor   # verifies CLI availability, auth, git, lockfile, config, entr
 | `samospec publish <slug>`        | Promotes the spec to `blueprints/<slug>/SPEC.md`, commits, pushes, opens PR via `gh` / `glab`.                                               |
 | `samospec brief <slug>`          | Generates a summarized HTML brief — a derivative of the published spec, NOT the spec itself. Pages-friendly, single self-contained file.     |
 
-Useful flags:
+Useful flags (run `samospec` with no command for the full usage block, which is the authoritative source):
 
+- `samospec new --effort <max|high|medium|low|off>` — unified reasoning effort for ALL seats. Default `high`; `max` is deepest/slowest, `off` is minimal/fastest. Overrides per-seat config. Precedence: `--effort` flag > `adapters.<seat>.effort` in config > `high`. Same flag exists on `iterate`.
 - `samospec new --skip user-stories,sprint-plan,…` — opt out of baseline sections.
-- `samospec new --max-session-wall-clock-ms 1800000` — 30-min session cap.
+- `samospec new --verbose` — emit per-phase / per-file diagnostics on stderr (stdout stays concise).
+- `samospec new --max-session-wall-clock-ms <ms>` — **deprecated no-op.** The session wall-clock kill was removed; the flag is still accepted for script back-compat but the value is ignored. The only stop signals are the inactivity heartbeat and SIGTERM.
 - `samospec new --force` — archive any existing `<slug>` dir as `.archived-YYYY-MM-DDThhmmssZ/` before starting.
 - `samospec new --idea-file <path>` — read the idea from a file instead of `--idea "…"`. Preferred for long, structured ideas (AI agents, CI): no fragile shell-quoting. Surrounding whitespace is trimmed; internal markdown is preserved. Mutually exclusive with `--idea`.
 - `samospec new --yes` — fully non-interactive: auto-accept the lead's persona proposal and default every interview answer to `decide for me`. Pair with `--answers-file <path>` when you want to steer the five questions from JSON instead.
 - `samospec new --interview-protocol jsonl` — drive the interview over stdin/stdout with a line-delimited JSON event stream. The CLI emits one JSON object per line on stdout (`{"type":"persona-proposal","v":1,…}`, `{"type":"question","v":1,…}`, terminal `{"type":"complete","v":1}`); the consumer writes `{"type":"persona-answer","v":1,…}` and `{"type":"answer","v":1,…}` on stdin. Every event carries `v: 1` — the protocol version — so consumers can sniff breaking changes; events missing or mismatching `v` are rejected. Human notices route to stderr so stdout stays protocol-clean. Bypasses the `#114` non-TTY refusal (when both `--yes` and `--interview-protocol jsonl` are passed, the JSONL resolver wins; `--yes` auto-accept is ignored). Question count is bounded by the lead's output (0..5), not a fixed wire-level contract. See [`tests/cli/new-interview-protocol-jsonl.test.ts`](tests/cli/new-interview-protocol-jsonl.test.ts) for a live example (including the spawn-based end-to-end driver).
-- `samospec iterate --rounds 5` — cap rounds for this invocation.
+- `samospec iterate --rounds 5` — cap rounds for this invocation (a safety **cap**, not a target; the loop usually stops earlier on a convergence condition).
 - `samospec iterate --no-push` — stay local this run.
-- `samospec iterate --quiet` — suppress the per-round progress + heartbeat stream on stderr (final summary still prints on stdout).
-- `samospec iterate --on-dirty <incorporate|overwrite|abort>` — non-interactive answer for the uncommitted-edits prompt.
+- `samospec iterate --remote <name>` — git remote name (default: `origin`). Also on `publish`.
+- `samospec iterate --quiet` — suppress the per-round progress + heartbeat stream on stderr (final summary still prints on stdout). `--verbose` is a no-op alias (iterate is verbose by default).
+- `samospec iterate --on-dirty <incorporate|overwrite|abort>` — non-interactive answer for the uncommitted-edits prompt. Required when stdin is not a TTY and the slug dir has dirty edits.
+- `samospec iterate --push-consent <yes|no>` — non-interactive answer for the first-push consent prompt. Required (or `--no-push`, or `--yes`) when stdin is not a TTY and the remote has no persisted consent.
+- `samospec iterate --yes` — accept everything non-interactively; implies `--push-consent yes`.
+- `samospec publish --no-lint` — skip the publish-time lint pass.
 - `samospec brief <slug> --out docs/<slug>/index.html` — write the brief into your static-site host's expected location instead of the default `blueprints/<slug>/BRIEF.html`.
 - `samospec brief <slug> --no-nojekyll` — skip creating the repo-root `.nojekyll` marker (default: created idempotently for GitHub Pages compatibility).
 - `samospec brief <slug> --ai` — generate a **rich** HTML brief via the lead AI adapter with a cross-vendor verifier pass. Produces SVG architecture diagrams (synthesized from `architecture.json`), scope tables, decision matrices, mobile-responsive layout (per [Thariq's "unreasonable effectiveness of HTML"](https://x.com/trq212/status/2052809885763747935)). Cached in `.samo/cache/brief/` keyed by spec hash; re-runs return the cached HTML for free.

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -1,0 +1,314 @@
+# Bot / agent operations runbook
+
+Copyright 2026 Nikolay Samokhvalov.
+
+This is the self-contained guide for driving `samospec` from an **autonomous
+agent, bot, or CI job** — no human at the keyboard. Everything below is
+verified against the CLI in this repo. The authoritative usage block is always
+`bunx samospec` with no arguments; this doc explains the non-interactive paths
+that a human-oriented session never hits.
+
+> **No secrets in this doc.** Only environment-variable _names_ appear. Never
+> commit a token, key, or password to the repo or to a committed transcript.
+
+---
+
+## 1. What samospec is
+
+`samospec` is a git-native CLI that turns a rough idea into a reviewed,
+versioned `SPEC.md`. A **lead** model drafts; two **reviewers** (one Codex,
+one a second Claude session) critique with different personas; the lead
+revises; the loop repeats until an explicit stopping condition fires. Every
+round is a git commit on a `samospec/<slug>` branch, so the spec carries real
+`v0.1 → v0.2 → … → v1.0` history you can diff and blame. There is **no
+server and no daemon** — the bot invokes a CLI, which shells out to the
+vendor CLIs (`claude`, `codex`) as subprocesses.
+
+---
+
+## 2. Install & runtime
+
+- **Runtime:** [Bun](https://bun.sh) ≥ 1.2.0. `npx` does **not** work — the CLI
+  ships as TypeScript and uses `Bun.spawn`. Always use `bunx`/`bun`.
+- **No install step:** `bunx samospec <command>` fetches and caches the CLI on
+  first use. To run from a clone instead: `bun run src/main.ts <command>` (the
+  `package.json` `bin` points at `./src/main.ts`).
+- **Vendor CLIs on PATH:** `claude` (Claude Code, **≥ v2.1.0** — samospec
+  passes `--effort` on every call and older CLIs reject it) and `codex` (OpenAI
+  Codex CLI). `samospec doctor` reports any that are missing or too old.
+- **A git repo:** every command runs inside a git working tree. `samospec init`
+  scaffolds `.samo/` in the current repo.
+
+```bash
+bunx samospec --version   # prints the version, exits 0
+bunx samospec doctor      # environment preflight (see §3)
+```
+
+---
+
+## 3. Credential / setup checklist
+
+samospec never takes credentials as flags or arguments — it inherits them from
+the vendor CLIs' own auth state and from the environment. OAuth is the happy
+path; API keys are an alternative.
+
+| Seat              | Vendor CLI | OAuth setup (preferred)                  | API-key env var (alternative) |
+| ----------------- | ---------- | ---------------------------------------- | ----------------------------- |
+| Lead + Reviewer B | `claude`   | `claude /login` (run once interactively) | `ANTHROPIC_API_KEY`           |
+| Reviewer A        | `codex`    | `codex auth` (ChatGPT-account login)     | `OPENAI_API_KEY`              |
+
+Notes for a bot:
+
+- **Claude via OAuth subprocess (the Samo policy).** The recommended setup is
+  the `claude /login` OAuth session — samospec then drives Claude through
+  `claude --print` (`-p`) subprocess calls that inherit that session. No
+  `ANTHROPIC_API_KEY` is required in this mode, and samospec reports it as
+  `authenticated via OAuth`. This matches the Samo convention that Claude calls
+  go through the user's `claude` OAuth subprocess rather than a raw API key.
+- `ANTHROPIC_API_KEY` is accepted as an alternative, but a **stale/invalid**
+  one _preempts_ the OAuth session (the Claude CLI prefers the env var) and the
+  whole run fails with `Invalid API key`. If you intend OAuth, ensure
+  `ANTHROPIC_API_KEY` is **unset** in the bot's environment.
+- **Codex is a full reviewer LLM here.** Its `OPENAI_API_KEY` (when used) drives
+  chat/reasoning calls for Reviewer A — this is _not_ an images-only usage.
+  ChatGPT-account OAuth via `codex auth` works and is preferred; the adapter
+  auto-falls-back through the model chain if your account default differs.
+- **Git remote auth** (for `iterate --push` / `publish`): the bot's git client
+  must be able to push to the remote (HTTPS token or SSH key), and `gh` (or
+  `glab`) must be authenticated for `publish` to open a PR. samospec does not
+  manage these — they live in the standard git / `gh` config.
+- **Minimal-env spawn:** subprocesses see only `HOME`, `PATH`, `TMPDIR`,
+  `USER`, `LOGNAME`, plus the declared auth vars (`ANTHROPIC_API_KEY`,
+  `OPENAI_API_KEY`). Nothing else from the bot's environment bleeds through.
+
+Run the preflight and gate on it:
+
+```bash
+bunx samospec doctor
+# Exit 0 = OK/WARN (safe to proceed). Exit 1 = a critical check FAILED.
+```
+
+`doctor` runs these checks in order: **availability, effort-support, auth, git,
+lock, config, global-config, entropy, push-consent, calibration,
+pr-capability**. WARN-level findings (e.g. stale API key, old `claude`, a global
+`~/.claude/CLAUDE.md` that could steer the model) do not block; only FAIL does.
+
+---
+
+## 4. Command surface (copy-paste, non-interactive)
+
+The full create → refine → publish workflow, every command driven without a
+TTY. Replace `<slug>` with a filesystem-safe identifier (it is **not** semantic
+— the `--idea` text is the authoritative source of meaning).
+
+### 4.1 Scaffold
+
+```bash
+bunx samospec init --yes        # idempotent; creates .samo/config.json + .gitignore
+```
+
+### 4.2 Create the first draft (`new`)
+
+`new` runs a persona proposal + a ≤5-question interview, then drafts v0.1.
+**In a non-TTY context you MUST pass one of** `--yes`, `--accept-persona`, or
+`--answers-file <path>`, or `new` exits 1 with guidance (it refuses to
+readline-deadlock).
+
+```bash
+# Fully hands-off: accept the proposed persona, default every answer to
+# "decide for me". --idea-file avoids fragile shell quoting for long ideas.
+bunx samospec new linkrot \
+  --idea-file ./idea.md \
+  --yes \
+  --effort high
+
+# Steer the 5 interview answers from JSON instead of defaulting them:
+#   answers.json = { "answers": ["a", "b", "c", "d", "e"] }
+bunx samospec new linkrot --idea "Detect dead links in Markdown" \
+  --accept-persona --answers-file ./answers.json
+```
+
+Other `new` flags: `--skip <comma,list>` (omit baseline sections — valid names
+come from the usage block), `--force` (archive an existing `<slug>` dir first),
+`--verbose` (stderr diagnostics), `--max-session-wall-clock-ms <ms>`
+(**deprecated no-op**, accepted but ignored).
+
+`--idea` and `--idea-file` are **mutually exclusive**.
+
+#### JSONL interview protocol (for UI wrappers / tight control)
+
+For a bot that wants to _answer_ the interview programmatically rather than
+defaulting it, drive the interview over a line-delimited JSON event stream:
+
+```bash
+bunx samospec new linkrot --idea "…" --interview-protocol jsonl
+```
+
+- **stdout** emits exactly one JSON object per line, each carrying `"v":1`:
+  `{"type":"persona-proposal",…}`, `{"type":"question","id","text","options",…}`,
+  and a terminal `{"type":"complete","v":1}`.
+- **stdin** consumes `{"type":"persona-answer","kind":"accept"|"edit"|"replace",…}`
+  then one `{"type":"answer","id","choice","custom"?}` per question.
+- Human-facing notices go to **stderr**, so stdout stays protocol-clean.
+- This **bypasses** the non-TTY refusal (the protocol _is_ the non-TTY driver).
+  If both `--yes` and `--interview-protocol jsonl` are passed, JSONL wins.
+- Reference driver: `tests/cli/new-interview-protocol-jsonl.test.ts`.
+
+### 4.3 Refine (`iterate`)
+
+Runs review rounds (lead + both reviewers in parallel) until a stopping
+condition fires. Non-TTY runs must resolve two prompts up front:
+
+```bash
+# Local-only refinement, capped at 5 rounds, no prompts:
+bunx samospec iterate linkrot --rounds 5 --no-push --on-dirty incorporate
+
+# Push round commits, granting first-push consent non-interactively:
+bunx samospec iterate linkrot \
+  --push-consent yes \
+  --on-dirty incorporate \
+  --remote origin
+
+# "Accept everything" shorthand (implies --push-consent yes):
+bunx samospec iterate linkrot --yes --on-dirty incorporate
+```
+
+- `--rounds <N>` is a safety **cap**, not a target — the loop normally stops
+  earlier on a convergence condition (see §5).
+- `--on-dirty <incorporate|overwrite|abort>` answers the uncommitted-edits
+  prompt. **Required** in a non-TTY run when the slug dir has dirty edits.
+- `--push-consent <yes|no>` answers the first-push consent prompt. **Required**
+  (or `--no-push`, or `--yes`) in a non-TTY run on the first push to a remote
+  with no persisted consent — otherwise `iterate` exits 1 _before_ round 1 with
+  the exact flags to add.
+- `--quiet` suppresses the per-round progress/heartbeat on stderr (final
+  summary still prints to stdout). `--verbose` is a no-op alias.
+- Unknown flags are **rejected** (exit 1) so typos like `--rouns` are caught.
+
+### 4.4 Inspect / resume
+
+```bash
+bunx samospec status linkrot    # phase, version, round index, last-round summary, next action
+bunx samospec resume linkrot    # idempotent resume from a crash/kill at any round boundary
+```
+
+`resume` re-enters from the last committed round; it does **not** retry a
+`lead-terminal` failure automatically (edit `SPEC.md` first — see
+[troubleshooting.md](troubleshooting.md)).
+
+### 4.5 Publish
+
+```bash
+bunx samospec publish linkrot                 # promote → commit → push → open PR via gh/glab
+bunx samospec publish linkrot --no-lint       # skip the publish-time lint pass
+bunx samospec publish linkrot --remote upstream
+```
+
+Promotes the working draft to `<blueprints_dir>/<slug>/SPEC.md`, commits, pushes
+the `samospec/<slug>` branch, and opens a PR targeting `main`. Requires git
+push auth and an authenticated `gh`/`glab`.
+
+### 4.6 Brief (derived HTML summary)
+
+```bash
+bunx samospec brief linkrot                       # heuristic HTML → <blueprints_dir>/<slug>/BRIEF.html
+bunx samospec brief linkrot --out docs/linkrot/index.html
+bunx samospec brief linkrot --ai                  # rich AI-generated brief (lead adapter + verifier)
+bunx samospec brief linkrot --ai --no-cache       # force fresh AI generation
+bunx samospec brief linkrot --ai --no-verify      # skip the cross-vendor verifier pass
+```
+
+`--no-nojekyll` skips creating the repo-root `.nojekyll` marker (created
+idempotently by default for GitHub Pages). The brief is a **derivative summary**
+of the published spec, not the spec itself.
+
+---
+
+## 5. Stopping conditions, exit codes & gotchas
+
+### Exit codes (the bot should branch on these)
+
+| Exit | Meaning                                                                                                                |
+| ---- | ---------------------------------------------------------------------------------------------------------------------- |
+| `0`  | Success. For `iterate`: stopped on `ready`, `semantic-convergence`, or `max-rounds`.                                   |
+| `1`  | Usage / preflight error (missing slug, unknown flag, non-TTY without the required automation flag, missing `SPEC.md`). |
+| `2`  | Argument-value error (e.g. a bad `--effort` value) or a mid-run user/consent abort path.                               |
+| `3`  | Interrupted by SIGINT (`sigint`).                                                                                      |
+| `4`  | Terminal run-time stop: `lead-terminal`, `reviewers-exhausted`, `budget`, `wall-clock`, or `lead-ignoring-critiques`.  |
+
+For `iterate`, the stop reason is in the run summary and persisted to
+`state.json`. Reason → exit-code mapping is authoritative in
+`src/loop/stopping.ts` (`stopReasonExitCode`).
+
+### Convergence is defined, not vibes
+
+`iterate` ends on its own when any of these fire: **lead-ready**,
+**semantic-convergence**, **repeat-findings halt** (trigram-Jaccard), **budget
+cap**, **max-rounds cap**, **reviewers-exhausted**, or **SIGINT**. A bot does
+_not_ need to poll-and-kill; let the loop terminate.
+
+### Caps are caps, not targets
+
+`--rounds N` and the per-seat budget caps are **safety ceilings**. Designing a
+bot loop that always burns all N rounds is wrong — the natural termination
+signal (convergence) should end most runs early. Use a cap as a backstop only.
+
+### No wall-clock kill
+
+The session wall-clock kill was **removed**. `--max-session-wall-clock-ms` is a
+deprecated no-op (accepted, ignored). LLM calls run as long as they need; the
+only stop signals are the **inactivity heartbeat** and **SIGTERM/SIGINT**. Do
+not wrap samospec in an external "kill after N minutes" timeout expecting
+graceful behaviour — send SIGTERM and let it checkpoint.
+
+### Non-TTY refusals are the most common bot failure
+
+- `new` in a non-TTY without `--yes` / `--accept-persona` / `--answers-file`
+  → exit 1.
+- `iterate` with a dirty slug dir and no `--on-dirty` → exit 1.
+- `iterate` first push with no `--push-consent` / `--no-push` / `--yes`
+  → exit 1 _before_ round 1.
+
+All three print the exact flag to add. The effort prompt and all interactive
+readlines are auto-skipped under these automation flags / piped stdin.
+
+### Other failure recovery
+
+See [troubleshooting.md](troubleshooting.md) for: stale `ANTHROPIC_API_KEY`,
+Codex `model_unavailable` under ChatGPT auth, `lead-terminal` recovery, stale
+`.samo/.lock` removal, offline resume, and global-config contamination.
+
+---
+
+## 6. What runs where & where output lands
+
+- **Where it runs:** entirely on the machine invoking the CLI. samospec spawns
+  `claude` and `codex` as **local subprocesses** (minimal env). Those CLIs make
+  the network calls to their vendors. There is no samospec server.
+- **Defaults today** (overridable in `.samo/config.json` → `paths`):
+  - Working drafts: `.samo/spec/<slug>/`
+  - Published snapshots & briefs: `blueprints/<slug>/`
+- **Working draft contents** (`<spec_dir>/<slug>/`), read/written every round:
+  - `SPEC.md` (canonical during iteration), `TLDR.md`, `state.json` (phase +
+    round bookkeeping the bot can parse), `interview.json`, `context.json`,
+    `decisions.md`, `changelog.md`, `architecture.json` (Zod-validated machine
+    diagram), `reviews/rNN/` and `rounds/rNN/round.json` (per-round artifacts),
+    `transcripts/` (**gitignored**, redacted even when opted in).
+- **Published output** (`<blueprints_dir>/<slug>/`): `SPEC.md` (immutable
+  promoted copy) and, after `brief`, `BRIEF.html`.
+- **Runtime / config** (always under `.samo/`, never relocated): `config.json`
+  (committed), `.lock`, `cache/`, `transcripts/` (gitignored).
+- **Branch:** every spec's commits live on `samospec/<slug>`; `publish` opens a
+  PR from that branch into `main`. samospec never commits to a protected branch.
+
+### Programmatic state
+
+`state.json` and `rounds/rNN/round.json` are the bot's structured read-back:
+phase, current version, round index, stop reason, and (for Codex) whether the
+account-default tier resolved (`"account_default": true`). Parse these instead
+of scraping stdout.
+
+```bash
+# Example: did Codex fall back to the account-default model this round?
+cat .samo/spec/<slug>/rounds/r<N>/round.json | grep account_default
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,9 +27,9 @@ Install the OpenAI CLI: https://platform.openai.com/docs/guides/codex.
 FAIL  auth  claude: not authenticated
 ```
 
-Run `claude auth login` or `claude login` per the Claude Code documentation.
-For Codex, run `codex auth login` with a valid `OPENAI_API_KEY` in your
-environment.
+Run `claude /login` per the Claude Code documentation (OAuth is the happy
+path), or set a valid `ANTHROPIC_API_KEY` env var. For Codex, run `codex auth`
+(ChatGPT-account OAuth) or set a valid `OPENAI_API_KEY` env var.
 
 ## Stale ANTHROPIC_API_KEY preempting OAuth
 
@@ -61,15 +61,16 @@ samospec doctor
 
 ```
 samospec: terminal — model_unavailable: all fallbacks exhausted:
-  gpt-5.4 → gpt-5.3-codex → account-default (no --model flag);
+  gpt-5.5 → gpt-5.4 → gpt-5.3-codex → account-default (no --model flag);
   account is not authorized or no model is available
 ```
 
 Codex under ChatGPT-account auth (browser login via `codex auth`) does not
-support the pinned models `gpt-5.4` and `gpt-5.3-codex`. The
-adapter tries a three-tier fallback chain:
+support the pinned models `gpt-5.5` / `gpt-5.4` / `gpt-5.3-codex`. The
+adapter tries an ordered fallback chain:
 
-- `gpt-5.4` (default pin — flagship model, default effort high)
+- `gpt-5.5` (default pin — flagship model, default effort high)
+- `gpt-5.4` (explicit fallback)
 - `gpt-5.3-codex` (explicit fallback)
 - account-default: no `--model` flag, letting codex pick the account's
   supported model


### PR DESCRIPTION
## What

Makes the repo's docs sufficient for an **autonomous bot/agent (e.g. openclaw)** to operate samospec from the repo alone, and fixes stale facts in the existing docs. Every documented command/flag was verified against the actual CLI (`src/cli.ts` usage block + live runs), not invented.

## New: `docs/bot-operations.md`

A self-contained runbook covering the six requested areas:
1. **What it is** (1 para) — no server/daemon; CLI shells out to `claude`/`codex` subprocesses.
2. **Install/runtime** — Bun ≥ 1.2.0, `bunx`/`bun run src/main.ts`, vendor CLIs on PATH, git repo.
3. **Credential/setup checklist** — env-var *names* only. Documents the Samo policy: Claude via `claude /login` OAuth subprocess (`claude -p`), `ANTHROPIC_API_KEY` only as an alternative and a stale one *preempts* OAuth. Codex is a full reviewer LLM here (`codex auth` / `OPENAI_API_KEY`). Git/`gh` push auth for publish.
4. **Command surface** — copy-paste non-interactive examples for the full `init → new → iterate → status/resume → publish → brief` workflow, the JSONL interview protocol, and the `--yes`/`--accept-persona`/`--answers-file`/`--on-dirty`/`--push-consent` automation flags.
5. **Gotchas/troubleshooting** — exit-code table (0/1/2/3/4), the eight stopping conditions, **caps-not-defaults** for `--rounds`/budget, **no wall-clock kill** (deprecated `--max-session-wall-clock-ms` no-op), and the three common non-TTY refusals.
6. **What-runs-where + output locations** — local subprocesses; working drafts in `.samo/spec/<slug>/`, published snapshots in `blueprints/<slug>/`, `samospec/<slug>` branch; programmatic read-back via `state.json` / `rounds/rNN/round.json`.

## Fixes to existing docs (verified against CLI)

- `README.md`: version `0.8.0 → 0.9.1`; lead pin `claude-opus-4-7 → claude-opus-4-8` (+ fallback chains); document `--max-session-wall-clock-ms` as the deprecated no-op it now is; add real-but-undocumented flags (`iterate --remote/--push-consent/--yes`, `publish --no-lint/--remote`, `new --effort/--verbose`); corrected doctor-check list; bot-doc cross-links.
- `docs/troubleshooting.md`: `claude auth login`/`claude login → claude /login`; codex default pin `gpt-5.4 → gpt-5.5` with the corrected fallback chain.

## Verified against the live CLI

Ran each documented path: `--version` (0.9.0/0.9.1), `init --yes`, `new` non-TTY refusal (exit 1), `new --effort bogus` (exit 2, `max|high|medium|low|off`), `iterate --rouns` typo rejected (exit 1), `--max-session-wall-clock-ms` accepted-but-ignored, `publish`/`brief` missing-slug (exit 1). All matched the documented behavior.

No secrets: env-var names only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)