### PR TITLE
docs: sync SAMO-DEV-PRINCIPLES block into CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,13 @@
 # CLAUDE.md — SamoSpec
 
 <!-- SAMO-DEV-PRINCIPLES:START (synced block — update the canonical source then re-sync; do not edit in place) -->
+
 ## Development principles
 
 Accumulated, non-negotiable working principles for SAMO projects. Canonical source: Tanya301/SAMO-Platform-Onboarding > PRINCIPLES.md. Keep this block in sync.
 
 ### 1. Re-review after ANY post-review change — green CI is not "reviewed"
+
 Once a reviewer (samorev) approves an MR/PR, **any** later commit invalidates that approval — **including a commit that fixes the review's own findings**. Re-review the change (at minimum the new delta) **before** merge. Never merge a post-review commit on the strength of the prior PASS plus a green pipeline: a passing pipeline proves it builds and tests pass, not that it was reviewed.
 
 Order: review → fix-commit → **re-review the delta** → merge. (NOT: review → fix-commit → merge.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,16 @@
 # CLAUDE.md — SamoSpec
 
+<!-- SAMO-DEV-PRINCIPLES:START (synced block — update the canonical source then re-sync; do not edit in place) -->
+## Development principles
+
+Accumulated, non-negotiable working principles for SAMO projects. Canonical source: Tanya301/SAMO-Platform-Onboarding > PRINCIPLES.md. Keep this block in sync.
+
+### 1. Re-review after ANY post-review change — green CI is not "reviewed"
+Once a reviewer (samorev) approves an MR/PR, **any** later commit invalidates that approval — **including a commit that fixes the review's own findings**. Re-review the change (at minimum the new delta) **before** merge. Never merge a post-review commit on the strength of the prior PASS plus a green pipeline: a passing pipeline proves it builds and tests pass, not that it was reviewed.
+
+Order: review → fix-commit → **re-review the delta** → merge.  (NOT: review → fix-commit → merge.)
+<!-- SAMO-DEV-PRINCIPLES:END -->
+
 ## Project
 
 samospec — git-native CLI (`samospec`) that turns a rough idea into a reviewed, versioned specification document through a lead AI expert and a panel of reviewer experts, with every material step captured in git. Repo: NikolayS/samospec.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Accumulated, non-negotiable working principles for SAMO projects. Canonical sour
 Once a reviewer (samorev) approves an MR/PR, **any** later commit invalidates that approval — **including a commit that fixes the review's own findings**. Re-review the change (at minimum the new delta) **before** merge. Never merge a post-review commit on the strength of the prior PASS plus a green pipeline: a passing pipeline proves it builds and tests pass, not that it was reviewed.
 
 Order: review → fix-commit → **re-review the delta** → merge. (NOT: review → fix-commit → merge.)
+
 <!-- SAMO-DEV-PRINCIPLES:END -->
 
 ## Project

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Accumulated, non-negotiable working principles for SAMO projects. Canonical sour
 ### 1. Re-review after ANY post-review change — green CI is not "reviewed"
 Once a reviewer (samorev) approves an MR/PR, **any** later commit invalidates that approval — **including a commit that fixes the review's own findings**. Re-review the change (at minimum the new delta) **before** merge. Never merge a post-review commit on the strength of the prior PASS plus a green pipeline: a passing pipeline proves it builds and tests pass, not that it was reviewed.
 
-Order: review → fix-commit → **re-review the delta** → merge.  (NOT: review → fix-commit → merge.)
+Order: review → fix-commit → **re-review the delta** → merge. (NOT: review → fix-commit → merge.)
 <!-- SAMO-DEV-PRINCIPLES:END -->
 
 ## Project


### PR DESCRIPTION
## Summary

- CLAUDE.md existed but had no SAMO-DEV-PRINCIPLES block.
- Inserted the canonical dev-principles block after the first heading (`# CLAUDE.md — SamoSpec`), delimited by `<!-- SAMO-DEV-PRINCIPLES:START -->` / `<!-- SAMO-DEV-PRINCIPLES:END -->` markers so future syncs can replace it idempotently.
- Block content: principle #1 — re-review after ANY post-review change; green CI alone is not sufficient to merge after a fix commit.

## What changed

`CLAUDE.md` — 11 lines inserted near the top, no existing content removed.

## Test plan

- [ ] Review the inserted block matches the canonical source in Tanya301/SAMO-Platform-Onboarding > PRINCIPLES.md verbatim.
- [ ] Confirm markers are present and correct so the next sync run is idempotent.
- [ ] Do NOT merge without explicit owner review — that is literally the principle being added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)