### PR TITLE
docs: polish user-facing text for clarity and consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,7 +759,7 @@ First public release. v1.0 feature set per `.samo/blueprints/SPEC.md`.
 
 ### Added
 
-- `samospec init` — initialise `.samo/` config directory in any git repo
+- `samospec init` — initialize `.samo/` config directory in any git repo
   (SPEC §5 Phase 1, §10).
 - `samospec new <slug> --idea "..."` — lead persona proposal, five-question
   strategic interview, v0.1 draft commit on `samospec/<slug>` branch

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![license](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Bun](https://img.shields.io/badge/Bun-%E2%89%A5_1.2-000?logo=bun)](https://bun.sh)
 
-> Turn a rough idea into a **reviewed, versioned spec** — with every round captured in git, not chat scrollback.
+> Turn a rough idea into a **reviewed, versioned spec** -- with every round captured in git, not chat scrollback.
 
-`samospec` is a git-native CLI that runs a small panel of top AI models against your idea: a **lead** drafts, two **reviewers** critique with different personas, the lead revises, and the loop repeats until convergence. The result is `SPEC.md` with real commit history — `v0.1 → v0.2 → … → v1.0` — that you can diff, blame, and publish.
+`samospec` is a git-native CLI that runs a small panel of top AI models against your idea: a **lead** drafts, two **reviewers** critique from different personas, the lead revises, and the loop repeats until convergence. The result is a `SPEC.md` with real commit history (`v0.1 → v0.2 → … → v1.0`) that you can diff, blame, and publish.
 
 ![SamoSpec demo](docs/demo.gif)
 
-**Live demo** — a real spec produced end-to-end over ChatGPT-account OAuth:
+**Live demo** -- a real spec produced end-to-end over ChatGPT-account OAuth:
 → https://github.com/NikolayS/todo-stream/tree/samospec/todo-stream
 (browse the `.samo/spec/todo-stream/` tree; 7 review rounds, both reviewers writing real critiques)
 
@@ -19,14 +19,14 @@
 
 ## Why
 
-Most "AI writes my spec" tools give you one shot from one model. You get a monologue in a chat window, lose the context the moment the tab closes, and have no record of what was considered and rejected.
+Most "AI writes my spec" tools give you one shot from one model. You get a monologue in a chat window, lose the context the moment the tab closes, and keep no record of what was considered and rejected.
 
 SamoSpec treats spec authoring like code review:
 
 - **Panel, not monologue.** One lead drafts; two reviewers with deliberately different personas critique in parallel. Disagreement is surfaced, not averaged away.
-- **Every round is a commit.** Each revision lives on a `samospec/<slug>` branch. `git log` tells the story. `decisions.md` records what was accepted, rejected, or deferred — and why.
-- **Convergence is defined, not vibes.** Eight explicit stopping conditions — lead-ready, semantic convergence, repeat-findings halt via trigram Jaccard, wall-clock cap, budget cap, max rounds, reviewers-exhausted, user SIGINT — mean the loop _ends_ on its own.
-- **Strongest model, deep reasoning by default.** Every seat runs the top of each vendor's ladder at effort `high` out of the box; `--effort max` dials it to the deepest review and lower levels trade depth for speed. The level is an explicit knob, never a silent downshift. The thesis is that great specs come from the strongest models running deep, not from the cheapest model running often.
+- **Every round is a commit.** Each revision lives on a `samospec/<slug>` branch. `git log` tells the story. `decisions.md` records what was accepted, rejected, or deferred -- and why.
+- **Convergence is defined, not vibes.** Eight explicit stopping conditions (lead-ready, semantic convergence, repeat-findings halt via trigram Jaccard, wall-clock cap, budget cap, max rounds, reviewers-exhausted, user SIGINT) mean the loop _ends_ on its own.
+- **Strongest model, deep reasoning by default.** Every seat runs the top of each vendor's ladder at effort `high` out of the box; `--effort max` dials it to the deepest review, and lower levels trade depth for speed. The level is an explicit knob, never a silent downshift. The thesis: great specs come from the strongest models running deep, not from the cheapest model running often.
 
 ---
 
@@ -39,12 +39,12 @@ bunx samospec doctor
 bunx samospec --version   # 0.9.1
 ```
 
-`npx` won't work — the CLI ships as TypeScript and depends on the Bun runtime (`Bun.spawn`, etc.). Use `bunx`.
+`npx` won't work -- the CLI ships as TypeScript and depends on the Bun runtime (`Bun.spawn`, etc.). Use `bunx`.
 
-For brevity, the rest of this README writes `samospec` — read it as `bunx samospec`.
+For brevity, the rest of this README writes `samospec` -- read it as `bunx samospec`.
 
 > **Running samospec from a bot / agent / CI?** See
-> [`docs/bot-operations.md`](docs/bot-operations.md) — a self-contained
+> [`docs/bot-operations.md`](docs/bot-operations.md) -- a self-contained
 > runbook with the credential checklist, the fully non-interactive command
 > surface, exit codes, stopping conditions, and the JSONL interview protocol.
 
@@ -92,7 +92,7 @@ At every step: `bunx samospec status <slug>` prints phase, current version, next
 
 - **Lead** = `claude` CLI, pinned `claude-opus-4-8` (fallback chain `claude-opus-4-8 → claude-opus-4-7 → claude-sonnet-4-6`), default effort `high`.
 - **Reviewer A** = `codex` CLI with a **security/ops** persona: missing risks, weak implementation, unnecessary scope. Pinned `gpt-5.5` (fallback `gpt-5.5 → gpt-5.4 → gpt-5.3-codex → account-default`).
-- **Reviewer B** = second `claude` session with a **QA / testability** persona: ambiguity, contradiction, weak-testing. Same pin as the lead (`claude-opus-4-8`). Also checks the spec's mandatory baseline sections and verifies it stays faithful to your original idea.
+- **Reviewer B** = a second `claude` session with a **QA / testability** persona: ambiguity, contradiction, weak testing. Same pin as the lead (`claude-opus-4-8`). Also checks the spec's mandatory baseline sections and verifies it stays faithful to your original idea.
 - Adapters share a coupled-fallback rule (lead and Reviewer B use the same vendor, so a Claude outage fails them together rather than running an uneven panel).
 
 Every generated `SPEC.md` gets nine mandatory sections by default (goal & why, user stories, architecture, implementation details, tests plan with red/green TDD, team of veteran experts, sprint plan, embedded changelog, version header). Pass `--skip` to opt out.
@@ -101,14 +101,14 @@ Every spec also ships a machine-readable `.samo/spec/<slug>/architecture.json` (
 
 ---
 
-## Auth — OAuth is the happy path
+## Auth -- OAuth is the happy path
 
-The CLI shells out to the vendor CLIs you already use. OAuth-based sessions are the **primary** auth mode — API keys are an alternative:
+The CLI shells out to the vendor CLIs you already use. OAuth-based sessions are the **primary** auth mode; API keys are an alternative:
 
-- **Claude Code** — `claude /login` once in a terminal; samospec inherits the session for `claude --print` calls. Or set the `ANTHROPIC_API_KEY` env var. **Requires `claude` ≥ v2.1.0** (samospec passes `--effort` on every call; older CLIs reject the flag). `samospec doctor` WARNs if your `claude` predates it.
-- **Codex** — `codex auth` (ChatGPT subscription account works); samospec handles the pinned-model fallback when your account default differs. Or set the `OPENAI_API_KEY` env var. Note: here Codex is a full reviewer LLM, so its `OPENAI_API_KEY` (when used) drives chat/reasoning calls — distinct from images-only OpenAI usage elsewhere in the Samo stack.
+- **Claude Code** -- `claude /login` once in a terminal; samospec inherits the session for `claude --print` calls. Or set the `ANTHROPIC_API_KEY` env var. **Requires `claude` ≥ v2.1.0** (samospec passes `--effort` on every call; older CLIs reject the flag). `samospec doctor` WARNs if your `claude` predates it.
+- **Codex** -- `codex auth` (ChatGPT subscription account works); samospec handles the pinned-model fallback when your account default differs. Or set the `OPENAI_API_KEY` env var. Note: here Codex is a full reviewer LLM, so its `OPENAI_API_KEY` (when used) drives chat/reasoning calls -- distinct from images-only OpenAI usage elsewhere in the Samo stack.
 
-A stale `ANTHROPIC_API_KEY` in the environment **preempts** the `claude /login` OAuth session and surfaces as an `Invalid API key` WARN in `doctor` — `unset` it to fall back to OAuth. Same shape for Codex.
+A stale `ANTHROPIC_API_KEY` in the environment **preempts** the `claude /login` OAuth session and surfaces as an `Invalid API key` WARN in `doctor` -- `unset` it to fall back to OAuth. The same applies to Codex.
 
 ```bash
 samospec doctor   # availability, effort-support, auth, git, lock, config,
@@ -128,7 +128,7 @@ samospec doctor   # availability, effort-support, auth, git, lock, config,
 - **Prompt-injection envelope.** Untrusted content (repo files, review bodies) is wrapped in a content-unique `<repo_content_<sha8> trusted="false">…</repo_content_<sha8>>` frame with a recency-bias suffix reminder, so a hostile README can't hijack the lead.
 - **Hard-coded no-read list** for credential files (`.env*`, `~/.aws/credentials`, `~/.ssh/id_*`, …) cannot be overridden.
 - **Transcripts not committed by default.** When opted in, they pass a gitleaks/truffleHog-derived redaction pass first.
-- **Minimal-env spawn.** Subprocesses see only `HOME`, `PATH`, `TMPDIR`, `USER`, `LOGNAME` plus caller-declared auth vars — no ambient environment bleed.
+- **Minimal-env spawn.** Subprocesses see only `HOME`, `PATH`, `TMPDIR`, `USER`, `LOGNAME` plus caller-declared auth vars -- no ambient environment bleed.
 
 ---
 
@@ -143,31 +143,31 @@ samospec doctor   # availability, effort-support, auth, git, lock, config,
 | `samospec resume <slug>`         | Idempotent resume from any crash/kill. Works at every round state boundary.                                                                  |
 | `samospec status <slug>`         | Phase, version, round index, last-round summary, next-step hint.                                                                             |
 | `samospec publish <slug>`        | Promotes the spec to `blueprints/<slug>/SPEC.md`, commits, pushes, opens PR via `gh` / `glab`.                                               |
-| `samospec brief <slug>`          | Generates a summarized HTML brief — a derivative of the published spec, NOT the spec itself. Pages-friendly, single self-contained file.     |
+| `samospec brief <slug>`          | Generates a summarized HTML brief -- a derivative of the published spec, NOT the spec itself. Pages-friendly, single self-contained file.     |
 
 Useful flags (run `samospec` with no command for the full usage block, which is the authoritative source):
 
-- `samospec new --effort <max|high|medium|low|off>` — unified reasoning effort for ALL seats. Default `high`; `max` is deepest/slowest, `off` is minimal/fastest. Overrides per-seat config. Precedence: `--effort` flag > `adapters.<seat>.effort` in config > `high`. Same flag exists on `iterate`.
-- `samospec new --skip user-stories,sprint-plan,…` — opt out of baseline sections.
-- `samospec new --verbose` — emit per-phase / per-file diagnostics on stderr (stdout stays concise).
-- `samospec new --max-session-wall-clock-ms <ms>` — **deprecated no-op.** The session wall-clock kill was removed; the flag is still accepted for script back-compat but the value is ignored. The only stop signals are the inactivity heartbeat and SIGTERM.
-- `samospec new --force` — archive any existing `<slug>` dir as `.archived-YYYY-MM-DDThhmmssZ/` before starting.
-- `samospec new --idea-file <path>` — read the idea from a file instead of `--idea "…"`. Preferred for long, structured ideas (AI agents, CI): no fragile shell-quoting. Surrounding whitespace is trimmed; internal markdown is preserved. Mutually exclusive with `--idea`.
-- `samospec new --yes` — fully non-interactive: auto-accept the lead's persona proposal and default every interview answer to `decide for me`. Pair with `--answers-file <path>` when you want to steer the five questions from JSON instead.
-- `samospec new --interview-protocol jsonl` — drive the interview over stdin/stdout with a line-delimited JSON event stream. The CLI emits one JSON object per line on stdout (`{"type":"persona-proposal","v":1,…}`, `{"type":"question","v":1,…}`, terminal `{"type":"complete","v":1}`); the consumer writes `{"type":"persona-answer","v":1,…}` and `{"type":"answer","v":1,…}` on stdin. Every event carries `v: 1` — the protocol version — so consumers can sniff breaking changes; events missing or mismatching `v` are rejected. Human notices route to stderr so stdout stays protocol-clean. Bypasses the `#114` non-TTY refusal (when both `--yes` and `--interview-protocol jsonl` are passed, the JSONL resolver wins; `--yes` auto-accept is ignored). Question count is bounded by the lead's output (0..5), not a fixed wire-level contract. See [`tests/cli/new-interview-protocol-jsonl.test.ts`](tests/cli/new-interview-protocol-jsonl.test.ts) for a live example (including the spawn-based end-to-end driver).
-- `samospec iterate --rounds 5` — cap rounds for this invocation (a safety **cap**, not a target; the loop usually stops earlier on a convergence condition).
-- `samospec iterate --no-push` — stay local this run.
-- `samospec iterate --remote <name>` — git remote name (default: `origin`). Also on `publish`.
-- `samospec iterate --quiet` — suppress the per-round progress + heartbeat stream on stderr (final summary still prints on stdout). `--verbose` is a no-op alias (iterate is verbose by default).
-- `samospec iterate --on-dirty <incorporate|overwrite|abort>` — non-interactive answer for the uncommitted-edits prompt. Required when stdin is not a TTY and the slug dir has dirty edits.
-- `samospec iterate --push-consent <yes|no>` — non-interactive answer for the first-push consent prompt. Required (or `--no-push`, or `--yes`) when stdin is not a TTY and the remote has no persisted consent.
-- `samospec iterate --yes` — accept everything non-interactively; implies `--push-consent yes`.
-- `samospec publish --no-lint` — skip the publish-time lint pass.
-- `samospec brief <slug> --out docs/<slug>/index.html` — write the brief into your static-site host's expected location instead of the default `blueprints/<slug>/BRIEF.html`.
-- `samospec brief <slug> --no-nojekyll` — skip creating the repo-root `.nojekyll` marker (default: created idempotently for GitHub Pages compatibility).
-- `samospec brief <slug> --ai` — generate a **rich** HTML brief via the lead AI adapter with a cross-vendor verifier pass. Produces SVG architecture diagrams (synthesized from `architecture.json`), scope tables, decision matrices, mobile-responsive layout (per [Thariq's "unreasonable effectiveness of HTML"](https://x.com/trq212/status/2052809885763747935)). Cached in `.samo/cache/brief/` keyed by spec hash; re-runs return the cached HTML for free.
-- `samospec brief <slug> --ai --no-cache` — force a fresh AI generation even when a cache hit exists.
-- `samospec brief <slug> --ai --no-verify` — skip the verifier pass. Faster but the brief may contain claims that don't trace back to `SPEC.md`.
+- `samospec new --effort <max|high|medium|low|off>` -- unified reasoning effort for ALL seats. Default `high`; `max` is deepest/slowest, `off` is minimal/fastest. Overrides per-seat config. Precedence: `--effort` flag > `adapters.<seat>.effort` in config > `high`. Same flag exists on `iterate`.
+- `samospec new --skip user-stories,sprint-plan,…` -- opt out of baseline sections.
+- `samospec new --verbose` -- emit per-phase / per-file diagnostics on stderr (stdout stays concise).
+- `samospec new --max-session-wall-clock-ms <ms>` -- **deprecated no-op.** The session wall-clock kill was removed; the flag is still accepted for script back-compat, but the value is ignored. The only stop signals are the inactivity heartbeat and SIGTERM.
+- `samospec new --force` -- archive any existing `<slug>` dir as `.archived-YYYY-MM-DDThhmmssZ/` before starting.
+- `samospec new --idea-file <path>` -- read the idea from a file instead of `--idea "…"`. Preferred for long, structured ideas (AI agents, CI): no fragile shell quoting. Surrounding whitespace is trimmed; internal markdown is preserved. Mutually exclusive with `--idea`.
+- `samospec new --yes` -- fully non-interactive: auto-accept the lead's persona proposal and default every interview answer to `decide for me`. Pair with `--answers-file <path>` when you want to steer the five questions from JSON instead.
+- `samospec new --interview-protocol jsonl` -- drive the interview over stdin/stdout with a line-delimited JSON event stream. The CLI emits one JSON object per line on stdout (`{"type":"persona-proposal","v":1,…}`, `{"type":"question","v":1,…}`, terminal `{"type":"complete","v":1}`); the consumer writes `{"type":"persona-answer","v":1,…}` and `{"type":"answer","v":1,…}` on stdin. Every event carries `v: 1` (the protocol version) so consumers can sniff breaking changes; events missing or mismatching `v` are rejected. Human notices route to stderr so stdout stays protocol-clean. Bypasses the `#114` non-TTY refusal (when both `--yes` and `--interview-protocol jsonl` are passed, the JSONL resolver wins; `--yes` auto-accept is ignored). Question count is bounded by the lead's output (0..5), not a fixed wire-level contract. See [`tests/cli/new-interview-protocol-jsonl.test.ts`](tests/cli/new-interview-protocol-jsonl.test.ts) for a live example (including the spawn-based end-to-end driver).
+- `samospec iterate --rounds 5` -- cap rounds for this invocation (a safety **cap**, not a target; the loop usually stops earlier on a convergence condition).
+- `samospec iterate --no-push` -- stay local this run.
+- `samospec iterate --remote <name>` -- git remote name (default: `origin`). Also on `publish`.
+- `samospec iterate --quiet` -- suppress the per-round progress + heartbeat stream on stderr (final summary still prints on stdout). `--verbose` is a no-op alias (iterate is verbose by default).
+- `samospec iterate --on-dirty <incorporate|overwrite|abort>` -- non-interactive answer for the uncommitted-edits prompt. Required when stdin is not a TTY and the slug dir has dirty edits.
+- `samospec iterate --push-consent <yes|no>` -- non-interactive answer for the first-push consent prompt. Required (or `--no-push`, or `--yes`) when stdin is not a TTY and the remote has no persisted consent.
+- `samospec iterate --yes` -- accept everything non-interactively; implies `--push-consent yes`.
+- `samospec publish --no-lint` -- skip the publish-time lint pass.
+- `samospec brief <slug> --out docs/<slug>/index.html` -- write the brief into your static-site host's expected location instead of the default `blueprints/<slug>/BRIEF.html`.
+- `samospec brief <slug> --no-nojekyll` -- skip creating the repo-root `.nojekyll` marker (default: created idempotently for GitHub Pages compatibility).
+- `samospec brief <slug> --ai` -- generate a **rich** HTML brief via the lead AI adapter with a cross-vendor verifier pass. Produces SVG architecture diagrams (synthesized from `architecture.json`), scope tables, decision matrices, mobile-responsive layout (per [Thariq's "unreasonable effectiveness of HTML"](https://x.com/trq212/status/2052809885763747935)). Cached in `.samo/cache/brief/` keyed by spec hash; re-runs return the cached HTML for free.
+- `samospec brief <slug> --ai --no-cache` -- force a fresh AI generation even when a cache hit exists.
+- `samospec brief <slug> --ai --no-verify` -- skip the verifier pass. Faster but the brief may contain claims that don't trace back to `SPEC.md`.
 
 ---
 
@@ -180,15 +180,15 @@ samospec follows the shared Samo repository layout:
 
 samospec keeps two kinds of artifacts in your repo:
 
-- **Working drafts** — read/written every round. Target default: `samo/spec/<slug>/`.
+- **Working drafts** -- read/written every round. Target default: `samo/spec/<slug>/`.
   - `SPEC.md` (canonical during iteration), `TLDR.md`, `state.json`, `interview.json`, `context.json`, `decisions.md`, `changelog.md`, `architecture.json`, `reviews/r01/`, `transcripts/` (gitignored).
-- **Published snapshots** — promoted by `samospec publish`. Target default: `samo/blueprints/<slug>/`.
+- **Published snapshots** -- promoted by `samospec publish`. Target default: `samo/blueprints/<slug>/`.
   - `SPEC.md` (immutable promoted copy), and after `samospec brief <slug>`, `BRIEF.html` (summarized derivative).
 
 Hidden runtime / config:
 
-- `.samo/config.json` — per-repo config (push consent, calibration, lint allowlist, paths overrides). Committed.
-- `.samo/.lock`, `.samo/cache/`, `.samo/transcripts/` — runtime, gitignored.
+- `.samo/config.json` -- per-repo config (push consent, calibration, lint allowlist, paths overrides). Committed.
+- `.samo/.lock`, `.samo/cache/`, `.samo/transcripts/` -- runtime, gitignored.
 
 ### Configuring paths
 
@@ -204,19 +204,19 @@ Both root-level paths are configurable via `.samo/config.json` so you can host b
 }
 ```
 
-- `paths.spec_dir` — where working drafts live. Current default: `.samo/spec`; target default: `samo/spec`.
-- `paths.blueprints_dir` — where published snapshots and briefs live. Current default: `blueprints`; target default: `samo/blueprints`.
+- `paths.spec_dir` -- where working drafts live. Current default: `.samo/spec`; target default: `samo/spec`.
+- `paths.blueprints_dir` -- where published snapshots and briefs live. Current default: `blueprints`; target default: `samo/blueprints`.
 
-Both must be **repo-relative** (absolute paths and `..`-escapes are rejected). Paths under `.samo/` work but GitHub Pages defaults to Jekyll, which excludes dotfile-prefixed paths — `samospec brief` writes a `.nojekyll` marker at the repo root for that reason.
+Both must be **repo-relative** (absolute paths and `..`-escapes are rejected). Paths under `.samo/` work, but GitHub Pages defaults to Jekyll, which excludes dotfile-prefixed paths -- that is why `samospec brief` writes a `.nojekyll` marker at the repo root.
 
-> **Heads-up:** the next minor release flips the defaults to `samo/spec` and `samo/blueprints` (visible, Pages-friendly out of the box). Set the keys above to keep the legacy layout when that lands. `.samo/config.json` itself stays put — the `.samo/` directory remains the home for runtime/config files.
+> **Heads-up:** the next minor release flips the defaults to `samo/spec` and `samo/blueprints` (visible, Pages-friendly out of the box). Set the keys above to keep the legacy layout when that lands. `.samo/config.json` itself stays put -- the `.samo/` directory remains the home for runtime/config files.
 
 ---
 
 ## Stack
 
 - **Language:** TypeScript on Bun
-- **Distribution:** npm (Homebrew / apt / standalone binaries — v1.1+)
+- **Distribution:** npm (Homebrew / apt / standalone binaries -- v1.1+)
 - **Subprocess:** `Bun.spawn` (minimal env; AbortController-backed stream reader so SIGKILL actually unblocks)
 - **Schema validation:** Zod for every structured-output contract
 - **Tests:** Bun's built-in runner; `fast-check` for property-based tests on the phase + round state machines
@@ -225,11 +225,11 @@ Both must be **repo-relative** (absolute paths and `..`-escapes are rejected). P
 
 ## Not in this release (deferred)
 
-- Homebrew, apt, or standalone compiled binaries — planned for v1.1+.
-- Gemini and OpenCode adapters — planned for v1.1+. Claude + Codex only today.
-- `samospec compare`, `samospec diff`, `samospec export pdf|html` — v1.5+.
-- Non-software persona packs (marketing, ops playbooks, research specs) — v1.5+.
-- `samospec experts set` — edit `.samo/config.json` manually until v1.1.
+- Homebrew, apt, or standalone compiled binaries -- planned for v1.1+.
+- Gemini and OpenCode adapters -- planned for v1.1+. Claude + Codex only today.
+- `samospec compare`, `samospec diff`, `samospec export pdf|html` -- v1.5+.
+- Non-software persona packs (marketing, ops playbooks, research specs) -- v1.5+.
+- `samospec experts set` -- edit `.samo/config.json` manually until v1.1.
 
 See [`.samo/blueprints/SPEC.md`](.samo/blueprints/SPEC.md) for the full product spec (architecture, state machines, adapter contract, publish lint, dogfood scorecard, threat model, implementation plan).
 
@@ -238,7 +238,7 @@ See [`.samo/blueprints/SPEC.md`](.samo/blueprints/SPEC.md) for the full product 
 ## Contributing
 
 - PRs welcome; target `main` from a feature branch.
-- Red-green TDD for new code — failing test → minimum green → refactor. Property-based tests for anything touching the phase machine, round state machine, or adapter contract.
+- Red-green TDD for new code -- failing test → minimum green → refactor. Property-based tests for anything touching the phase machine, round state machine, or adapter contract.
 - Conventional Commits, 50-char subjects, present tense. Never amend, never force-push without confirmation.
 - See [`CLAUDE.md`](CLAUDE.md) for full engineering standards.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ samospec doctor   # availability, effort-support, auth, git, lock, config,
 | `samospec resume <slug>`         | Idempotent resume from any crash/kill. Works at every round state boundary.                                                                  |
 | `samospec status <slug>`         | Phase, version, round index, last-round summary, next-step hint.                                                                             |
 | `samospec publish <slug>`        | Promotes the spec to `blueprints/<slug>/SPEC.md`, commits, pushes, opens PR via `gh` / `glab`.                                               |
-| `samospec brief <slug>`          | Generates a summarized HTML brief -- a derivative of the published spec, NOT the spec itself. Pages-friendly, single self-contained file.     |
+| `samospec brief <slug>`          | Generates a summarized HTML brief -- a derivative of the published spec, NOT the spec itself. Pages-friendly, single self-contained file.    |
 
 Useful flags (run `samospec` with no command for the full usage block, which is the authoritative source):
 

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -72,7 +72,7 @@ Notes for a bot:
 - **Codex is a full reviewer LLM here.** Its `OPENAI_API_KEY` (when used) drives
   chat/reasoning calls for Reviewer A — this is _not_ an images-only usage.
   ChatGPT-account OAuth via `codex auth` works and is preferred; the adapter
-  auto-falls-back through the model chain if your account default differs.
+  automatically falls back through the model chain if your account default differs.
 - **Git remote auth** (for `iterate --push` / `publish`): the bot's git client
   must be able to push to the remote (HTTPS token or SSH key), and `gh` (or
   `glab`) must be authenticated for `publish` to open a PR. samospec does not
@@ -259,7 +259,7 @@ The session wall-clock kill was **removed**. `--max-session-wall-clock-ms` is a
 deprecated no-op (accepted, ignored). LLM calls run as long as they need; the
 only stop signals are the **inactivity heartbeat** and **SIGTERM/SIGINT**. Do
 not wrap samospec in an external "kill after N minutes" timeout expecting
-graceful behaviour — send SIGTERM and let it checkpoint.
+graceful behavior — send SIGTERM and let it checkpoint.
 
 ### Non-TTY refusals are the most common bot failure
 

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="A captured run of the SamoSpec spec-creation engine: init, persona selection, interview, draft commit, and the generated spec files."
+    />
     <title>SamoSpec demo</title>
     <style>
       body {

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -114,10 +114,10 @@
   <body>
     <main>
       <section class="wrap">
-        <h1>SamoSpec creates a spec</h1>
+        <h1>SamoSpec turns a rough idea into a spec</h1>
         <p class="sub">
-          A concise fixture run of the real spec-creation engine: init, persona,
-          interview, draft commit, and generated files.
+          A captured run of the real spec-creation engine: init, persona
+          selection, interview, draft commit, and the generated spec files.
         </p>
         <div class="chips">
           <span class="chip">persona accepted</span

--- a/docs/examples/basic-flow.md
+++ b/docs/examples/basic-flow.md
@@ -5,7 +5,7 @@ Copyright 2026 Nikolay Samokhvalov.
 This walkthrough shows the full `samospec` lifecycle for a new feature spec.
 Output shown is representative; real AI output varies.
 
-## 1. Initialise
+## 1. Initialize
 
 ```bash
 cd /path/to/your-repo
@@ -15,7 +15,7 @@ samospec init
 Output:
 
 ```
-samospec: initialised .samo/ in /path/to/your-repo.
+samospec: initialized .samo/ in /path/to/your-repo.
 Run `samospec doctor` to verify the environment.
 ```
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -43,7 +43,7 @@ SPEC §18 lists the non-goals. The two most important:
   user's own wording. Applying `redact()` there could quietly corrupt
   rationale text, so this is opt-out rather than opt-in. Users who want
   stricter hygiene should run an external scanner on the committed
-  artefacts before pushing (see below).
+  artifacts before pushing (see below).
 
 Neither set of files is covered in v1. The roadmap in SPEC §18 tracks
 the open question for post-v1.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -386,7 +386,7 @@ const USAGE =
   "      Override the output path. Repo-relative or absolute.\n" +
   "      Default: <blueprints_dir>/<slug>/BRIEF.html. Use this to write\n" +
   "      directly into your static-site host's expected location\n" +
-  "      (e.g. docs/<slug>/index.html for GitHub Pages /docs source,\n" +
+  "      (e.g., docs/<slug>/index.html for GitHub Pages /docs source,\n" +
   "      public/<slug>/index.html for GitLab Pages).\n" +
   "  --no-nojekyll\n" +
   "      Skip creating the repo-root `.nojekyll` marker file. By\n" +


### PR DESCRIPTION
Copy review across the README, docs, and other user-facing text. Grammar, spelling, punctuation, and phrasing were brought to careful American-English technical-writing style while preserving 100% of the technical meaning. No code, commands, or technical values were touched.

## What changed

- **README.md**: normalized prose em dashes to the contract separator ` -- ` (list leads, blockquotes, table cells) or restructured for clarity (the eight stopping conditions and the `v0.1 -> ... -> v1.0` chain now sit in parentheses); tightened the opening paragraph so it reads well as a search/LLM snippet and is self-contained ("critique from different personas", "The result is a `SPEC.md` ... that you can diff, blame, and publish"); fixed non-native phrasing ("have no record" -> "keep no record", "Same shape for Codex" -> "The same applies to Codex", "weak-testing" -> "weak testing", "second claude session" -> "a second claude session", "no fragile shell-quoting" -> "no fragile shell quoting", "The thesis is that" -> "The thesis:"); added a missing comma in the back-compat sentence and clarified the `.nojekyll` causality; replaced an auth-mode dash with a semicolon.
- **docs/demo.html**: strengthened the H1 from "SamoSpec creates a spec" to "SamoSpec turns a rough idea into a spec" (states the value proposition, better search snippet); rewrote the subtitle to be self-contained and clearer ("A captured run of the real spec-creation engine: init, persona selection, interview, draft commit, and the generated spec files"). Only human-readable text nodes changed; the two quoted terminal `pre` blocks, chip labels, tags, classes, and styles were left untouched.
- **docs/bot-operations.md**: British "behaviour" -> "behavior"; awkward compound "auto-falls-back" -> "automatically falls back".
- **docs/security.md**: British "artefacts" -> "artifacts" (aligns with "artifacts" used elsewhere).
- **docs/examples/basic-flow.md**: heading "Initialise" -> "Initialize"; reconciled the quoted CLI output "initialised .samo/" -> "initialized .samo/" to match what the CLI actually emits (verified in `src/cli/init.ts`).
- **CHANGELOG.md**: British "initialise" -> "initialize" in the `samospec init` description (version numbers, dates, issue/PR refs, and the existing dash left as-is).
- **src/cli.ts**: in the `--out` help text inside the USAGE string, "e.g." -> "e.g.," to match American style and the file's own dominant house style. Descriptive help text only; no flag/command identifiers, logic, or asserted strings changed.

## Not changed

No code, commands, SQL, config values, numbers, identifiers, flags, env vars, file paths, version strings (0.9.1), URLs, badge URLs, model pins, or quoted tool output were altered. Naming conventions (samospec lowercase, SamoSpec product name) were preserved, headings remain sentence case, and no emojis or new em/en dashes were introduced. The one quoted-output edit (basic-flow.md) was verified against the CLI source so the doc now matches real output. Pre-existing em dashes in bot-operations.md were preserved per the do-not-churn rule.

Relates to #186
